### PR TITLE
add missing fragments

### DIFF
--- a/src/jormungandr/explorer/src/db/indexing.rs
+++ b/src/jormungandr/explorer/src/db/indexing.rs
@@ -170,6 +170,28 @@ impl ExplorerBlock {
                         offset_in_block: offset,
                         config_params: Some(config.clone()),
                     }),
+                    Fragment::UpdateProposal(tx) => {
+                        let tx = tx.as_slice();
+                        Some(ExplorerTransaction::from(
+                            &context,
+                            &fragment_id,
+                            &tx,
+                            Some(Certificate::UpdateProposal(tx.payload().into_payload())),
+                            offset,
+                            &current_block_txs,
+                        ))
+                    }
+                    Fragment::UpdateVote(tx) => {
+                        let tx = tx.as_slice();
+                        Some(ExplorerTransaction::from(
+                            &context,
+                            &fragment_id,
+                            &tx,
+                            Some(Certificate::UpdateVote(tx.payload().into_payload())),
+                            offset,
+                            &current_block_txs,
+                        ))
+                    }
                     Fragment::Transaction(tx) => {
                         let tx = tx.as_slice();
                         Some(ExplorerTransaction::from(

--- a/src/jormungandr/testing/jormungandr-integration-tests/src/jormungandr/explorer/certificates.rs
+++ b/src/jormungandr/testing/jormungandr-integration-tests/src/jormungandr/explorer/certificates.rs
@@ -803,7 +803,6 @@ pub fn explorer_vote_tally_certificate_test() {
         .unwrap();
 }
 
-#[should_panic] //bug NPG-2742
 #[test]
 pub fn explorer_update_proposal_certificate_test() {
     let temp_dir = TempDir::new().unwrap();


### PR DESCRIPTION
_explorer_update_proposal_certificate_test()_  covers _**update_proposal**_ and _**update_vote**_