### PR TITLE
remove unsafe send impls

### DIFF
--- a/src/chain-libs/chain-crypto/src/digest.rs
+++ b/src/chain-libs/chain-crypto/src/digest.rs
@@ -191,8 +191,6 @@ macro_rules! define_from_instances {
 
 define_from_instances!(Blake2b256, 32, "blake2b");
 
-unsafe impl<H: DigestAlg> Send for Digest<H> {}
-
 impl<H: DigestAlg> PartialEq for Digest<H> {
     fn eq(&self, other: &Self) -> bool {
         self.0 == other.0
@@ -276,8 +274,6 @@ pub struct DigestOf<H: DigestAlg, T> {
     inner: Digest<H>,
     marker: PhantomData<T>,
 }
-
-unsafe impl<H: DigestAlg, T> Send for DigestOf<H, T> {}
 
 impl<H: DigestAlg, T> Clone for DigestOf<H, T> {
     fn clone(&self) -> Self {

--- a/src/chain-libs/chain-crypto/src/testing.rs
+++ b/src/chain-libs/chain-crypto/src/testing.rs
@@ -150,7 +150,7 @@ impl<H: digest::DigestAlg + 'static> Arbitrary for digest::Digest<H> {
     }
 }
 
-impl<H: digest::DigestAlg + 'static, T: 'static> Arbitrary for digest::DigestOf<H, T> {
+impl<H: digest::DigestAlg + 'static, T: 'static + Send> Arbitrary for digest::DigestOf<H, T> {
     fn arbitrary<G: Gen>(g: &mut G) -> Self {
         let bytes: Vec<_> = std::iter::repeat_with(|| u8::arbitrary(g))
             .take(26) // actual number doesn't really matter

--- a/src/chain-libs/chain-evm/src/transaction.rs
+++ b/src/chain-libs/chain-evm/src/transaction.rs
@@ -99,7 +99,7 @@ impl Decodable for EthereumUnsignedTransaction {
     fn decode(rlp: &Rlp<'_>) -> Result<Self, DecoderError> {
         let slice = rlp.data()?;
 
-        let first = *slice.get(0).ok_or(DecoderError::Custom("empty slice"))?;
+        let first = *slice.first().ok_or(DecoderError::Custom("empty slice"))?;
 
         let item_count = rlp.item_count()?;
 

--- a/src/chain-libs/chain-impl-mockchain/src/lib.rs
+++ b/src/chain-libs/chain-impl-mockchain/src/lib.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::all)]
+#![allow(clippy::derive_partial_eq_without_eq)]
 
 #[cfg(any(test, feature = "property-test-api"))]
 #[macro_use]

--- a/src/chain-libs/chain-network/src/lib.rs
+++ b/src/chain-libs/chain-network/src/lib.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::all)]
+#![allow(clippy::derive_partial_eq_without_eq)]
 
 pub mod core;
 pub mod data;


### PR DESCRIPTION
Removes a few unsafe `Send` impls in chain-libs

A quick look doesn't reveal any unsoundness, since there were other `Send` bounds in places where they should be, but it's a much more fragile solution than relying on auto traits to get the implementation

Also fixes a few clippy errors