### PR TITLE
Add explorer and archiver to vitup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,6 +436,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-x"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
+
+[[package]]
 name = "base64"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1215,6 +1221,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "common-multipart-rfc7578"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baee326bc603965b0f26583e1ecd7c111c41b49bd92a344897476a352798869"
+dependencies = [
+ "bytes 1.2.1",
+ "futures-core",
+ "futures-util",
+ "http",
+ "mime",
+ "mime_guess",
+ "rand 0.8.5",
+ "thiserror",
+]
+
+[[package]]
 name = "console"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1643,6 +1665,26 @@ name = "data-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
+
+[[package]]
+name = "data-encoding-macro"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86927b7cd2fe88fa698b87404b287ab98d1a0063a34071d92e575b72d3029aca"
+dependencies = [
+ "data-encoding",
+ "data-encoding-macro-internal",
+]
+
+[[package]]
+name = "data-encoding-macro-internal"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5bbed42daaa95e780b60a50546aa345b8413a1e46f9a40a12907d3598f038db"
+dependencies = [
+ "data-encoding",
+ "syn",
+]
 
 [[package]]
 name = "data-pile"
@@ -3002,6 +3044,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-multipart-rfc7578"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0eb2cf73e96e9925f4bed948e763aa2901c2f1a3a5f713ee41917433ced6671"
+dependencies = [
+ "bytes 1.2.1",
+ "common-multipart-rfc7578",
+ "futures-core",
+ "http",
+ "hyper 0.14.20",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3376,6 +3431,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "ipfs-api"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d4854b5cde0a7e935ee4246c5b6c67fbf4961e303963537f10e184a4830bd17"
+dependencies = [
+ "ipfs-api-backend-hyper",
+]
+
+[[package]]
+name = "ipfs-api-backend-hyper"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "114341e043a87eff0e43ec192f0a495988323dc14c468448e62b20aaf96bd1e6"
+dependencies = [
+ "async-trait",
+ "bytes 1.2.1",
+ "futures",
+ "http",
+ "hyper 0.14.20",
+ "hyper-multipart-rfc7578",
+ "ipfs-api-prelude",
+ "thiserror",
+]
+
+[[package]]
+name = "ipfs-api-prelude"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbaf47fa129710ae041d5844a15b1365bdad8551673aee237449ba9dec6bcadc"
+dependencies = [
+ "async-trait",
+ "bytes 1.2.1",
+ "cfg-if 1.0.0",
+ "common-multipart-rfc7578",
+ "dirs 4.0.0",
+ "futures",
+ "http",
+ "multibase",
+ "parity-multiaddr 0.11.2",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror",
+ "tokio 1.21.2",
+ "tokio-util 0.6.10",
+ "tracing",
+ "typed-builder",
+ "walkdir",
 ]
 
 [[package]]
@@ -4306,6 +4412,17 @@ dependencies = [
  "mime",
  "spin 0.9.4",
  "version_check",
+]
+
+[[package]]
+name = "multibase"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b3539ec3c1f04ac9748a260728e855f261b4977f5c3406612c884564f329404"
+dependencies = [
+ "base-x",
+ "data-encoding",
+ "data-encoding-macro",
 ]
 
 [[package]]
@@ -7623,6 +7740,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "typed-builder"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89851716b67b937e393b3daa8423e67ddfc4bbbf1654bcf05488e95e0828db0c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "typed-bytes"
 version = "0.1.0"
 
@@ -8030,6 +8158,7 @@ dependencies = [
  "hyper 0.14.20",
  "image",
  "indicatif",
+ "ipfs-api",
  "itertools 0.10.5",
  "jormungandr-automation",
  "jormungandr-lib",
@@ -8066,6 +8195,7 @@ dependencies = [
  "tracing",
  "tracing-appender 0.1.2",
  "tracing-subscriber 0.2.25",
+ "url",
  "uuid",
  "valgrind",
  "vit-servicing-station-lib",

--- a/src/chain-libs/chain-impl-mockchain/src/certificate/vote_plan.rs
+++ b/src/chain-libs/chain-impl-mockchain/src/certificate/vote_plan.rs
@@ -184,6 +184,10 @@ impl Proposals {
             PushProposal::Success
         }
     }
+
+    pub fn proposals(&self) -> &Vec<Proposal> {
+        &self.proposals
+    }
 }
 
 impl VotePlan {

--- a/src/jormungandr/testing/jormungandr-automation/src/jormungandr/explorer/configuration.rs
+++ b/src/jormungandr/testing/jormungandr-automation/src/jormungandr/explorer/configuration.rs
@@ -39,7 +39,7 @@ pub struct ExplorerConfiguration {
 }
 
 impl ExplorerConfiguration {
-    pub(crate) fn explorer_listen_http_address(&self) -> String {
+    pub fn explorer_listen_http_address(&self) -> String {
         format!(
             "http://{}:{}/",
             &self.explorer_listen_address, &self.explorer_port

--- a/src/jortestkit/src/csv/mod.rs
+++ b/src/jortestkit/src/csv/mod.rs
@@ -40,7 +40,7 @@ impl CsvFileBuilder {
         let mut wtr = Writer::from_path(&self.file)?;
         wtr.write_record(&self.header)?;
         for line in self.content.iter() {
-            wtr.write_record(&*line)?;
+            wtr.write_record(line)?;
         }
         wtr.flush()?;
         Ok(())

--- a/src/vit-servicing-station/vit-servicing-station-lib/src/db/models/snapshot.rs
+++ b/src/vit-servicing-station/vit-servicing-station-lib/src/db/models/snapshot.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::extra_unused_lifetimes)]
+
 use crate::db::schema::{contributions, snapshots, voters};
 use diesel::{Insertable, Queryable};
 use serde::{Deserialize, Serialize};

--- a/src/vit-servicing-station/vit-servicing-station-server/src/main.rs
+++ b/src/vit-servicing-station/vit-servicing-station-server/src/main.rs
@@ -118,7 +118,9 @@ async fn main() {
     let paths: Vec<PathBuf> = if let Some(single_block0_path) = &settings.block0_path {
         vec![PathBuf::from_str(single_block0_path).unwrap()]
     } else {
-        fs::read_dir(settings.block0_paths.as_ref().unwrap())
+        fs::read_dir(settings.block0_paths.as_ref().unwrap_or_else(|_|
+            std::process::exit(ApplicationExitCode::EmptyBlock0FolderError.into())
+        ))
             .unwrap()
             .filter_map(|path| {
                 let path = path.unwrap().path();

--- a/src/vit-servicing-station/vit-servicing-station-tests/src/common/startup/server/command.rs
+++ b/src/vit-servicing-station/vit-servicing-station-tests/src/common/startup/server/command.rs
@@ -139,6 +139,10 @@ impl BootstrapCommandBuilder {
             command.arg("--block0-path").arg(block0_path);
         }
 
+        if let Some(block0_paths) = &self.block0_paths {
+            command.arg("--block0-paths").arg(block0_paths);
+        }
+
         if let Some(cert_file) = &self.cert_file {
             command.arg("--cert-file").arg(cert_file.to_str().unwrap());
         }

--- a/src/vit-servicing-station/vit-servicing-station-tests/src/common/startup/server/settings.rs
+++ b/src/vit-servicing-station/vit-servicing-station-tests/src/common/startup/server/settings.rs
@@ -39,6 +39,12 @@ impl ServerSettingsBuilder {
         self
     }
 
+    pub fn with_block0_folder_path(&mut self, block0_folder_path: impl AsRef<Path>) -> &mut Self {
+        self.settings.block0_paths = Some(block0_folder_path.as_ref().to_path_buf());
+        self
+    }
+
+
     pub fn with_cors(&mut self, cors: Cors) -> &mut Self {
         self.cors = Some(cors);
         self

--- a/src/vit-testing/vitup/Cargo.toml
+++ b/src/vit-testing/vitup/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+ipfs-api = "0.16.0"
+url = "2.3.1"
 custom_debug = "0.5"
 dialoguer = "0.10.0"
 assert_fs = "1.0"

--- a/src/vit-testing/vitup/src/builders/helpers/archive.rs
+++ b/src/vit-testing/vitup/src/builders/helpers/archive.rs
@@ -1,0 +1,110 @@
+use reqwest::Url;
+use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
+use walkdir::WalkDir;
+
+#[derive(Debug, Clone)]
+pub struct ArchiveConfiguration {
+    pub block_folder: PathBuf,
+    pub archive_db: PathBuf,
+}
+
+pub fn discover_archive_input_files(url: impl Into<String>) -> Result<ArchiveConfiguration, Error> {
+    let url = Url::parse(&url.into())?;
+    match url.scheme() {
+        "file" => get_configuration_from_file_url(
+            url.to_file_path()
+                .map_err(|()| DiscoverArchiveByFileError::IncorrectFolderUrl)?,
+        )
+        .map_err(Into::into),
+        _ => unimplemented!("only file scheme is supported for archive location"),
+    }
+}
+
+pub fn get_configuration_from_file_url(
+    path: impl AsRef<Path>,
+) -> Result<ArchiveConfiguration, DiscoverArchiveByFileError> {
+    let path = path.as_ref();
+    if !path.is_dir() {
+        return Err(DiscoverArchiveByFileError::ExpectedUrlToFolder);
+    }
+    find_archive_db(path)
+}
+
+fn find_archive_db(
+    path: impl AsRef<Path>,
+) -> Result<ArchiveConfiguration, DiscoverArchiveByFileError> {
+    let possible_db_extensions = vec!["db".to_string(), "database".to_string()];
+    let possible_block0_extensions = vec!["bin".to_string()];
+
+    let path = path.as_ref();
+
+    let archive_db = WalkDir::new(path)
+        .follow_links(true)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .find(|entry| {
+            if entry.path().is_dir() {
+                return false;
+            }
+
+            let extension = entry.path().extension().and_then(OsStr::to_str).unwrap();
+            possible_db_extensions.contains(&extension.to_string())
+        })
+        .map(|entry| entry.path().to_path_buf());
+
+    let block_folder = WalkDir::new(path)
+        .follow_links(true)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .find(|entry| {
+            if entry.path().is_dir() {
+                return false;
+            }
+
+            let extension = entry.path().extension().and_then(OsStr::to_str).unwrap();
+            possible_block0_extensions.contains(&extension.to_string())
+        })
+        .map(|entry| entry.path().parent().unwrap().to_path_buf());
+
+    Ok(ArchiveConfiguration {
+        archive_db: archive_db.ok_or(DiscoverArchiveByFileError::CannotFindArchiveDB {
+            path: path.to_path_buf(),
+            possible_extensions: possible_db_extensions,
+        })?,
+        block_folder: block_folder.ok_or(DiscoverArchiveByFileError::CannotFindBlock0Folder {
+            path: path.to_path_buf(),
+            possible_extensions: possible_block0_extensions,
+        })?,
+    })
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error(transparent)]
+    DiscoverArchiveByFile(#[from] DiscoverArchiveByFileError),
+    #[error("parse url error")]
+    Url(#[from] url::ParseError),
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum DiscoverArchiveByFileError {
+    #[error(
+        "cannot find archive db in path: {path}, expected extensions: {possible_extensions:?}"
+    )]
+    CannotFindArchiveDB {
+        path: PathBuf,
+        possible_extensions: Vec<String>,
+    },
+    #[error(
+        "cannot find block0 folder in path: {path}, expected extensions: {possible_extensions:?}"
+    )]
+    CannotFindBlock0Folder {
+        path: PathBuf,
+        possible_extensions: Vec<String>,
+    },
+    #[error("incorrect file url ")]
+    IncorrectFolderUrl,
+    #[error("expected file url")]
+    ExpectedUrlToFolder,
+}

--- a/src/vit-testing/vitup/src/builders/helpers/mod.rs
+++ b/src/vit-testing/vitup/src/builders/helpers/mod.rs
@@ -1,9 +1,14 @@
+mod archive;
 mod qr;
 mod static_data;
 mod time;
 mod vote_plan;
 
 pub use self::time::{convert_to_blockchain_date, convert_to_human_date};
+pub use archive::{
+    discover_archive_input_files, get_configuration_from_file_url, ArchiveConfiguration,
+    Error as ArchiveConfError,
+};
 pub use qr::{generate_qr_and_hashes, Error as QrError, WalletExtension};
 pub use static_data::{build_current_fund, build_servicing_station_parameters};
 pub use vote_plan::VitVotePlanDefBuilder;

--- a/src/vit-testing/vitup/src/builders/helpers/vote_plan.rs
+++ b/src/vit-testing/vitup/src/builders/helpers/vote_plan.rs
@@ -125,16 +125,16 @@ impl VitVotePlanDefBuilder {
                         vote_start: BlockDate::new(self.vote_phases.vote_start, 0),
                         vote_end: BlockDate::new(self.vote_phases.tally_start, 0),
                         committee_end: BlockDate::new(self.vote_phases.tally_end, 0),
-                        proposals: proposal_builders
-                            .into_iter()
-                            .map(|pb| pb.clone().build())
-                            .fold(Proposals::new(), |mut acc, p| {
+                        proposals: proposal_builders.iter().map(|pb| pb.clone().build()).fold(
+                            Proposals::new(),
+                            |mut acc, p| {
                                 let proposal: Proposal = p.into();
                                 assert_eq!(acc.push(proposal), PushProposal::Success);
                                 acc
-                            }),
+                            },
+                        ),
                         committee_member_public_keys: vec![],
-                        voting_token: voting_token.clone().into(),
+                        voting_token: voting_token.clone(),
                         vote_plan_key,
                         private: self.private.then_some(PrivateParameters {
                             crs: None,
@@ -164,9 +164,9 @@ mod tests {
         TestResult::from_bool(
             vote_plans_defs
                 .into_iter()
-                .flat_map(|v| v.proposals())
+                .flat_map(|v| v.proposals.proposals().clone())
                 .into_iter()
-                .map(|p| p.id())
+                .map(|p| p.external_id().clone())
                 .all(move |x| uniq.insert(x)),
         )
     }

--- a/src/vit-testing/vitup/src/config/additional.rs
+++ b/src/vit-testing/vitup/src/config/additional.rs
@@ -1,0 +1,7 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct AdditionalServices {
+    pub explorer: bool,
+    pub archive: Option<String>,
+}

--- a/src/vit-testing/vitup/src/config/mod.rs
+++ b/src/vit-testing/vitup/src/config/mod.rs
@@ -7,9 +7,11 @@ mod static_data;
 mod vote_plan;
 mod vote_time;
 
+mod additional;
 pub mod certs;
 pub mod mode;
 
+use crate::config::additional::AdditionalServices;
 use crate::config::builder::convert_to_human_date;
 use crate::config::vote_time::FORMAT;
 use crate::Result;
@@ -44,6 +46,8 @@ pub struct Config {
     pub data: StaticData,
     #[serde(default)]
     pub service: Service,
+    #[serde(default)]
+    pub additional: AdditionalServices,
 }
 
 impl Config {

--- a/src/vit-testing/vitup/src/mode/interactive/controller.rs
+++ b/src/vit-testing/vitup/src/mode/interactive/controller.rs
@@ -1,7 +1,8 @@
-use crate::mode::standard::{VitStationController, WalletProxyController};
+use crate::mode::standard::{ExplorerController, VitStationController, WalletProxyController};
 
 pub struct VitUserInteractionController {
     vit_stations: Vec<VitStationController>,
+    explorers: Vec<ExplorerController>,
     proxies: Vec<WalletProxyController>,
 }
 
@@ -16,6 +17,7 @@ impl VitUserInteractionController {
         Self {
             vit_stations: Vec::new(),
             proxies: Vec::new(),
+            explorers: Vec::new(),
         }
     }
 
@@ -29,6 +31,10 @@ impl VitUserInteractionController {
 
     pub fn vit_stations(&self) -> &[VitStationController] {
         &self.vit_stations
+    }
+
+    pub fn explorers(&self) -> &[ExplorerController] {
+        &self.explorers
     }
 
     pub fn proxies_mut(&mut self) -> &mut Vec<WalletProxyController> {

--- a/src/vit-testing/vitup/src/mode/monitor/explorer.rs
+++ b/src/vit-testing/vitup/src/mode/monitor/explorer.rs
@@ -1,0 +1,83 @@
+use crate::mode::standard::ExplorerController;
+use crate::Result;
+use hersir::controller::ProgressBarController;
+use hersir::style;
+use jormungandr_automation::jormungandr::{NodeAlias, Status};
+
+pub struct ExplorerMonitorController {
+    controller: ExplorerController,
+    progress_bar: ProgressBarController,
+}
+
+impl ExplorerMonitorController {
+    pub fn new(controller: ExplorerController, progress_bar: ProgressBarController) -> Self {
+        let monitor = Self {
+            controller,
+            progress_bar,
+        };
+        monitor.progress_bar_start();
+        monitor
+    }
+
+    pub fn alias(&self) -> NodeAlias {
+        self.controller.alias().to_string()
+    }
+
+    pub fn status(&self) -> Result<Status> {
+        //TODO: add proper erro handling
+        Ok(self.controller.status())
+    }
+
+    pub fn is_up(&self) -> bool {
+        match self.status() {
+            Ok(status) => status == Status::Running,
+            Err(_) => false,
+        }
+    }
+
+    pub fn finish_monitoring(&self) {
+        self.progress_bar.finish_with_message("monitoring shutdown");
+    }
+
+    pub fn progress_bar(&self) -> &ProgressBarController {
+        &self.progress_bar
+    }
+
+    pub fn shutdown(self) {
+        self.controller.shutdown();
+    }
+
+    fn progress_bar_start(&self) {
+        self.progress_bar.set_style(
+            indicatif::ProgressStyle::default_spinner()
+                .template("{spinner:.green} {wide_msg}")
+                .tick_chars(style::TICKER),
+        );
+        self.progress_bar.enable_steady_tick(100);
+        self.progress_bar.set_message(&format!(
+            "{} {} ... [{}] Vit station is up",
+            *style::icons::jormungandr,
+            style::binary.apply_to(self.alias()),
+            self.controller.address(),
+        ));
+    }
+    #[allow(dead_code)]
+    fn progress_bar_failure(&self) {
+        self.progress_bar.finish_with_message(&format!(
+            "{} {} {}",
+            *style::icons::jormungandr,
+            style::binary.apply_to(self.alias()),
+            style::error.apply_to(*style::icons::failure)
+        ));
+    }
+
+    #[allow(dead_code)]
+    fn progress_bar_success(&self) {
+        self.progress_bar.finish_with_message(&format!(
+            "{} {} {}",
+            *style::icons::jormungandr,
+            style::binary.apply_to(self.alias()),
+            style::success.apply_to(*style::icons::success)
+        ));
+    }
+}

--- a/src/vit-testing/vitup/src/mode/monitor/main.rs
+++ b/src/vit-testing/vitup/src/mode/monitor/main.rs
@@ -1,4 +1,5 @@
 use super::{VitStationMonitorController, WalletProxyMonitorController};
+use crate::mode::monitor::ExplorerMonitorController;
 use crate::mode::standard::{
     ValidVotePlanParameters, ValidVotingTemplateGenerator, VitController as InnerController,
     WalletProxySpawnParams,
@@ -69,6 +70,24 @@ impl MonitorController {
             self.build_progress_bar(vit_station.alias(), vit_station.address().to_string());
 
         Ok(VitStationMonitorController::new(vit_station, progress_bar))
+    }
+
+    pub fn spawn_vit_station_archiver(
+        &mut self,
+        version: String,
+    ) -> Result<VitStationMonitorController> {
+        let vit_station = self.inner.spawn_vit_station_archive(version)?;
+        let progress_bar =
+            self.build_progress_bar(vit_station.alias(), vit_station.address().to_string());
+
+        Ok(VitStationMonitorController::new(vit_station, progress_bar))
+    }
+
+    pub fn spawn_explorer(&mut self) -> Result<ExplorerMonitorController> {
+        let explorer = self.inner.spawn_explorer()?;
+        let progress_bar = self.build_progress_bar(explorer.alias(), explorer.address());
+
+        Ok(ExplorerMonitorController::new(explorer, progress_bar))
     }
 
     pub fn spawn_wallet_proxy_custom(

--- a/src/vit-testing/vitup/src/mode/monitor/mod.rs
+++ b/src/vit-testing/vitup/src/mode/monitor/mod.rs
@@ -1,7 +1,9 @@
+mod explorer;
 mod main;
 mod vit_station;
 mod wallet;
 
+pub use explorer::ExplorerMonitorController;
 pub use main::MonitorController;
 pub use vit_station::VitStationMonitorController;
 pub use wallet::WalletProxyMonitorController;

--- a/src/vit-testing/vitup/src/mode/spawn/monitor.rs
+++ b/src/vit-testing/vitup/src/mode/spawn/monitor.rs
@@ -40,6 +40,7 @@ pub fn spawn_network(
         template_generator,
         config.service.version,
     )?;
+
     let _wallet_proxy =
         monitor_controller.spawn_wallet_proxy_custom(&mut network_spawn_params.proxy_params())?;
 

--- a/src/vit-testing/vitup/src/mode/spawn/standard.rs
+++ b/src/vit-testing/vitup/src/mode/spawn/standard.rs
@@ -23,11 +23,24 @@ pub fn spawn_network(
     }
     let _wallet_proxy =
         vit_controller.spawn_wallet_proxy_custom(&mut network_spawn_params.proxy_params())?;
-    let _vit_station = vit_controller.spawn_vit_station(
+
+    let mut vit_stations = vec![];
+
+    vit_stations.push(vit_controller.spawn_vit_station(
         vit_parameters,
         template_generator,
         network_spawn_params.version(),
-    );
+    ));
+
+    if config.additional.archive.is_some() {
+        vit_stations.push(vit_controller.spawn_vit_station_archive(network_spawn_params.version()));
+    };
+
+    let mut explorers = vec![];
+
+    if config.additional.explorer {
+        explorers.push(vit_controller.spawn_explorer());
+    };
 
     println!("Waiting for Ctrl-C to exit..");
     ctrlc::set_handler(move || {

--- a/src/vit-testing/vitup/src/mode/standard/controllers/explorer.rs
+++ b/src/vit-testing/vitup/src/mode/standard/controllers/explorer.rs
@@ -1,0 +1,41 @@
+use jormungandr_automation::jormungandr::{Explorer, ExplorerProcess, NodeAlias, Status};
+use std::process::Output;
+
+pub struct ExplorerController {
+    alias: NodeAlias,
+    explorer_process: ExplorerProcess,
+}
+
+impl ExplorerController {
+    pub fn new(alias: NodeAlias, explorer_process: ExplorerProcess) -> Self {
+        Self {
+            alias,
+            explorer_process,
+        }
+    }
+
+    pub(crate) fn status(&self) -> Status {
+        if self.explorer_process.is_up() {
+            Status::Running
+        } else {
+            Status::Starting
+        }
+    }
+
+    pub fn client(&self) -> &Explorer {
+        self.explorer_process.client()
+    }
+
+    pub(crate) fn address(&self) -> String {
+        self.explorer_process
+            .configuration()
+            .explorer_listen_http_address()
+    }
+    pub fn alias(&self) -> &str {
+        &self.alias
+    }
+
+    pub fn shutdown(self) -> Option<Output> {
+        self.explorer_process.shutdown()
+    }
+}

--- a/src/vit-testing/vitup/src/mode/standard/controllers/mod.rs
+++ b/src/vit-testing/vitup/src/mode/standard/controllers/mod.rs
@@ -1,3 +1,4 @@
+mod explorer;
 mod main;
 mod vit_station;
 mod wallet_proxy;
@@ -12,5 +13,7 @@ pub use wallet_proxy::{
     Error as WalletProxyError, WalletProxyController, WalletProxyControllerError,
     WalletProxySettings, WalletProxySpawnParams,
 };
+
+pub use explorer::ExplorerController;
 
 pub use main::{Error as VitControllerError, VitController, VitControllerBuilder};

--- a/src/vit-testing/vitup/src/mode/standard/controllers/vit_station/mod.rs
+++ b/src/vit-testing/vitup/src/mode/standard/controllers/vit_station/mod.rs
@@ -31,6 +31,8 @@ pub enum Error {
     PortAlreadyBinded(u16),
     #[error("no vit station defined in settings")]
     NoVitStationDefinedInSettings,
+    #[error("no vit station archiver defined in settings")]
+    NoVitStationArchiverDefinedInSettings,
     #[error("fragment logs in an invalid format")]
     InvalidFragmentLogs(#[source] serde_json::Error),
     #[error("node '{alias}' failed to start after {} s", .duration.as_secs())]

--- a/src/vit-testing/vitup/src/mode/standard/controllers/wallet_proxy/mod.rs
+++ b/src/vit-testing/vitup/src/mode/standard/controllers/wallet_proxy/mod.rs
@@ -53,6 +53,8 @@ pub enum Error {
     PortAlreadyBinded(u16),
     #[error("no wallet proxy defined in settings")]
     NoWalletProxiesDefinedInSettings,
+    #[error("no explorer defined in settings")]
+    NoExplorerDefinedInSettings,
     #[error("fragment logs in an invalid format")]
     InvalidFragmentLogs(#[source] serde_json::Error),
     #[error("node stats in an invalid format")]

--- a/src/vit-testing/vitup/src/mode/standard/controllers/wallet_proxy/settings.rs
+++ b/src/vit-testing/vitup/src/mode/standard/controllers/wallet_proxy/settings.rs
@@ -1,5 +1,5 @@
 use super::NodeAlias;
-use crate::mode::standard::settings::PrepareWalletProxySettings;
+use crate::mode::standard::settings::{PrepareWalletProxySettings, VIT_STATION};
 
 type VitStationSettings = vit_servicing_station_lib::server::settings::ServiceSettings;
 
@@ -51,8 +51,7 @@ impl PrepareWalletProxySettings for WalletProxySettings {
         vit_stations: &HashMap<NodeAlias, VitStationSettings>,
     ) -> Self {
         let vit_station_settings = vit_stations
-            .values()
-            .next()
+            .get(VIT_STATION)
             .expect("no vit stations defined");
 
         WalletProxySettings {

--- a/src/vit-testing/vitup/src/mode/standard/settings.rs
+++ b/src/vit-testing/vitup/src/mode/standard/settings.rs
@@ -1,4 +1,5 @@
 use super::{VitStationSettings, WalletProxySettings};
+use crate::builders::ArchiveConfiguration;
 use crate::config::Blockchain;
 use hersir::{
     builder::{NodeAlias, Topology},
@@ -8,6 +9,9 @@ use jormungandr_automation::jormungandr::get_available_port;
 use std::collections::HashMap;
 use vit_servicing_station_lib::server::settings::ServiceSettings;
 use vit_servicing_station_tests::common::startup::server::ServerSettingsBuilder;
+
+pub const VIT_STATION: &str = "vit_station";
+pub const VIT_STATION_ARCHIVE: &str = "vit_station_archive";
 
 pub trait PrepareVitServerSettings: Clone + Send {
     fn prepare(session_settings: &mut SessionSettings) -> Self;
@@ -35,10 +39,29 @@ pub struct VitSettings {
 }
 
 impl VitSettings {
-    pub fn new(session_settings: &mut SessionSettings) -> Self {
+    pub fn new(
+        session_settings: &mut SessionSettings,
+        archive_conf: Option<ArchiveConfiguration>,
+    ) -> Self {
         let mut vit_stations = HashMap::new();
-        let vit_station = VitStationSettings::prepare(session_settings);
-        vit_stations.insert("vit_station".to_string(), vit_station);
+
+        let mut settings_builder = ServerSettingsBuilder::default();
+
+        vit_stations.insert(
+            VIT_STATION.to_string(),
+            settings_builder
+                .with_localhost_address(get_available_port() as u32)
+                .build(),
+        );
+
+        if let Some(archive_conf) = archive_conf {
+            let mut settings_builder = ServerSettingsBuilder::default();
+            settings_builder
+                .with_localhost_address(get_available_port() as u32)
+                .with_block0_folder_path(archive_conf.block_folder)
+                .with_db_path(archive_conf.archive_db.to_str().unwrap());
+            vit_stations.insert(VIT_STATION_ARCHIVE.to_string(), settings_builder.build());
+        }
 
         let mut wallet_proxies = HashMap::new();
         let wallet_proxy_setting = WalletProxySettings::prepare(session_settings, &vit_stations);
@@ -48,14 +71,5 @@ impl VitSettings {
             vit_stations,
             wallet_proxies,
         }
-    }
-}
-
-impl PrepareVitServerSettings for VitStationSettings {
-    fn prepare(_session_settings: &mut SessionSettings) -> Self {
-        let mut settings_builder: ServerSettingsBuilder = Default::default();
-        settings_builder
-            .with_localhost_address(get_available_port() as u32)
-            .build()
     }
 }


### PR DESCRIPTION
Allow to bootstrap vit-servicing-station archiver and explorer by adding:

for example
```
    "additional": {
        "explorer": true,
        "archive": "file://./iohk/vit-servicing-station-archive/catalyst-archive/"
    }
```