### PR TITLE
Fix explorer process incomplete logs in integration tests

### DIFF
--- a/src/jormungandr/testing/jormungandr-automation/src/jormungandr/explorer/mod.rs
+++ b/src/jormungandr/testing/jormungandr-automation/src/jormungandr/explorer/mod.rs
@@ -108,10 +108,17 @@ impl ExplorerProcess {
 
         println!("starting explorer: {:?}", explorer_cmd);
 
-        let stdout_cfg = if let Some(logs_dir) = configuration.logs_dir.as_ref() {
-            Stdio::from(File::create(logs_dir.join("explorer.log")).expect("explorer stdout file"))
+        let (stdout_cfg, stderr_cfg) = if let Some(logs_dir) = configuration.logs_dir.as_ref() {
+            (
+                Stdio::from(
+                    File::create(logs_dir.join("explorer.log")).expect("explorer stdout file"),
+                ),
+                Stdio::from(
+                    File::create(logs_dir.join("explorer.err")).expect("explorer stderr file"),
+                ),
+            )
         } else {
-            Stdio::piped()
+            (Stdio::piped(), Stdio::piped())
         };
 
         let handler = Some(


### PR DESCRIPTION
[ExplorerProcess](https://github.com/input-output-hk/catalyst-core/blob/426dc2fd7dce89d0943a4433805c0ebf74ed28f1/src/jormungandr/testing/jormungandr-automation/src/jormungandr/explorer/mod.rs#L54) logs were being only partially captured by the stdout pipe and written to `/tmp/jormungandr_*/explorer.log`. I'm assuming this is a buffering problem. This PR changes the Explorer's child process spawning code to capture its output to a file which seems to fix that problem.

I also did some refactoring.