### PR TITLE
Implement new /api/v0/challenges/{id}/{voter_group_id} endpoint

### DIFF
--- a/src/vit-servicing-station/doc/api/v0.yaml
+++ b/src/vit-servicing-station/doc/api/v0.yaml
@@ -205,6 +205,36 @@ paths:
         "404":
           description: The requested challenge was not found
 
+  /api/v0/challenges/{id}/{voter_group_id}:
+    get:
+      operationId: getChallenge
+      summary: Get challenge by id
+      tags: [challenge]
+      description: |
+        Retrieves information on the identified challenge,
+        including the proposals submitted for it filtered by the provided voter group id.
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          required: true
+        - in: path
+          name: voter_group_id
+          description: Get proposals only for the specified vote group.
+          schema:
+            type: string
+          required: true
+      responses:
+        "200":
+          description: Valid response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ChallengeWithProposals"
+        "404":
+          description: The requested challenge was not found
+
   /api/v0/reviews/{proposal_id}:
     get:
       operationId: getProposalReviews

--- a/src/vit-servicing-station/vit-servicing-station-lib/src/v0/endpoints/challenges/handlers.rs
+++ b/src/vit-servicing-station/vit-servicing-station-lib/src/v0/endpoints/challenges/handlers.rs
@@ -9,3 +9,13 @@ pub async fn get_challenges(context: SharedContext) -> Result<impl Reply, Reject
 pub async fn get_challenge_by_id(id: i32, context: SharedContext) -> Result<impl Reply, Rejection> {
     Ok(HandlerResult(logic::get_challenge_by_id(id, context).await))
 }
+
+pub async fn get_challenge_by_id_and_group_id(
+    id: i32,
+    voter_group_id: String,
+    context: SharedContext,
+) -> Result<impl Reply, Rejection> {
+    Ok(HandlerResult(
+        logic::get_challenge_by_id_and_group_id(id, voter_group_id, context).await,
+    ))
+}

--- a/src/vit-servicing-station/vit-servicing-station-lib/src/v0/endpoints/challenges/logic.rs
+++ b/src/vit-servicing-station/vit-servicing-station-lib/src/v0/endpoints/challenges/logic.rs
@@ -20,3 +20,19 @@ pub async fn get_challenge_by_id(
         proposals,
     })
 }
+
+pub async fn get_challenge_by_id_and_group_id(
+    id: i32,
+    voter_group_id: String,
+    context: SharedContext,
+) -> Result<ChallengeWithProposals, HandleError> {
+    let pool = &context.read().await.db_connection_pool;
+    let challenge = challenges_queries::query_challenge_by_id(id, pool).await?;
+    let proposals =
+        challenges_queries::query_challenge_proposals_by_id_and_group_id(id, voter_group_id, pool)
+            .await?;
+    Ok(ChallengeWithProposals {
+        challenge,
+        proposals,
+    })
+}

--- a/src/vit-servicing-station/vit-servicing-station-lib/src/v0/endpoints/challenges/routes.rs
+++ b/src/vit-servicing-station/vit-servicing-station-lib/src/v0/endpoints/challenges/routes.rs
@@ -16,8 +16,17 @@ pub async fn filter(
 
     let challenge_by_id = warp::path!(i32)
         .and(warp::get())
-        .and(with_context)
+        .and(with_context.clone())
         .and_then(get_challenge_by_id);
 
-    root.and(challenge_by_id.or(challenges))
+    let challenge_by_id_and_group_id = warp::path!(i32 / String)
+        .and(warp::get())
+        .and(with_context)
+        .and_then(get_challenge_by_id_and_group_id);
+
+    root.and(
+        challenge_by_id_and_group_id
+            .or(challenge_by_id)
+            .or(challenges),
+    )
 }


### PR DESCRIPTION
Adding new `/api/v0/challenges/{id}/{voter_group_id}` endpoint which acts mostly the same as `/api/v0/challenges/{id}` but also filtering proposals by `voter_group_id`