### PR TITLE
Npg 3808 tally per vote cast

### DIFF
--- a/src/jormungandr/explorer/src/api/graphql/mod.rs
+++ b/src/jormungandr/explorer/src/api/graphql/mod.rs
@@ -1418,7 +1418,10 @@ pub fn generic_tally_status(p: ExplorerVoteProposal, payload: OtherPayloadType) 
             }
         }
         OtherPayloadType::Private => TallyStatus::Private(TallyPrivateStatus {
-            results: None,
+            results: Some(vec![
+                Weight("0".to_string());
+                p.options.choice_range().end as usize
+            ]),
             options: p.options.into(),
         }),
     }

--- a/src/jormungandr/explorer/src/api/graphql/mod.rs
+++ b/src/jormungandr/explorer/src/api/graphql/mod.rs
@@ -37,7 +37,7 @@ use chain_impl_mockchain::{
     fragment::FragmentId,
     key::BftLeaderId,
     stake::StakeControl,
-    vote::{EncryptedVote, ProofOfCorrectVote},
+    vote::{EncryptedVote, PayloadType as OtherPayloadType, ProofOfCorrectVote},
 };
 use std::{
     convert::{TryFrom, TryInto},
@@ -1358,12 +1358,15 @@ impl VotePlanStatus {
                     proposal_id: ExternalProposalId::from(proposal.proposal_id.clone()),
                     options: VoteOptionRange::from(proposal.options.clone()),
                     tally: proposal.tally.clone().map_or(
-                        Some(generic_tally_status(ExplorerVoteProposal {
-                            proposal_id: proposal.proposal_id,
-                            options: proposal.options,
-                            tally: proposal.tally,
-                            votes: proposal.votes.clone(),
-                        })),
+                        Some(generic_tally_status(
+                            ExplorerVoteProposal {
+                                proposal_id: proposal.proposal_id,
+                                options: proposal.options,
+                                tally: proposal.tally,
+                                votes: proposal.votes.clone(),
+                            },
+                            payload_type,
+                        )),
                         |tally| Some(TallyStatus::from(tally)),
                     ),
                     votes: proposal
@@ -1395,19 +1398,29 @@ impl VotePlanStatus {
 }
 
 // if the tally is None, convert to generic tally result as per rest api requirements
-pub fn generic_tally_status(p: ExplorerVoteProposal) -> TallyStatus {
-    let s = StakeControl::default();
-    match compute_public_tally(&p, &s) {
-        ExplorerVoteTally::Public { results, options } => TallyStatus::Public(TallyPublicStatus {
-            results: results.iter().map(Into::into).collect(),
-            options: options.into(),
-        }),
-        ExplorerVoteTally::Private { results, options } => {
-            TallyStatus::Private(TallyPrivateStatus {
-                results: results.map(|res| res.iter().map(Into::into).collect()),
-                options: options.into(),
-            })
+pub fn generic_tally_status(p: ExplorerVoteProposal, payload: OtherPayloadType) -> TallyStatus {
+    match payload {
+        OtherPayloadType::Public => {
+            let s = StakeControl::default();
+            match compute_public_tally(&p, &s) {
+                ExplorerVoteTally::Public { results, options } => {
+                    TallyStatus::Public(TallyPublicStatus {
+                        results: results.iter().map(Into::into).collect(),
+                        options: options.into(),
+                    })
+                }
+                ExplorerVoteTally::Private { results, options } => {
+                    TallyStatus::Private(TallyPrivateStatus {
+                        results: results.map(|res| res.iter().map(Into::into).collect()),
+                        options: options.into(),
+                    })
+                }
+            }
         }
+        OtherPayloadType::Private => TallyStatus::Private(TallyPrivateStatus {
+            results: None,
+            options: p.options.into(),
+        }),
     }
 }
 

--- a/src/jormungandr/explorer/src/db/mod.rs
+++ b/src/jormungandr/explorer/src/db/mod.rs
@@ -635,6 +635,11 @@ fn apply_block_to_vote_plans(
                                         },
                                     )
                                     .unwrap();
+
+                                // update the tally every time a vote is cast
+                                let p = &mut proposals[vote_cast.proposal_index() as usize];
+                                p.tally = Some(compute_public_tally(&p, &stake));
+
                                 let vote_plan = ExplorerVotePlan {
                                     proposals,
                                     ..(**vote_plan).clone()
@@ -667,6 +672,7 @@ fn apply_block_to_vote_plans(
                                         },
                                     )
                                     .unwrap();
+
                                 let vote_plan = ExplorerVotePlan {
                                     proposals,
                                     ..(**vote_plan).clone()

--- a/src/jormungandr/explorer/src/db/mod.rs
+++ b/src/jormungandr/explorer/src/db/mod.rs
@@ -13,10 +13,7 @@ use self::{
     },
     persistent_sequence::PersistentSequence,
 };
-use crate::db::{
-    indexing::ExplorerVoteTally,
-    tally::{compute_private_tally, compute_public_tally},
-};
+use crate::db::tally::{compute_private_tally, compute_public_tally};
 use chain_addr::Discrimination;
 use chain_core::property::Block as _;
 use chain_impl_mockchain::{
@@ -675,12 +672,6 @@ fn apply_block_to_vote_plans(
                                         },
                                     )
                                     .unwrap();
-
-                                let p = &mut proposals[vote_cast.proposal_index() as usize];
-                                p.tally = Some(ExplorerVoteTally::Private {
-                                    results: None,
-                                    options: p.options.clone(),
-                                });
 
                                 let vote_plan = ExplorerVotePlan {
                                     proposals,

--- a/src/jormungandr/explorer/src/db/mod.rs
+++ b/src/jormungandr/explorer/src/db/mod.rs
@@ -13,7 +13,10 @@ use self::{
     },
     persistent_sequence::PersistentSequence,
 };
-use crate::db::tally::{compute_private_tally, compute_public_tally};
+use crate::db::{
+    indexing::ExplorerVoteTally,
+    tally::{compute_private_tally, compute_public_tally},
+};
 use chain_addr::Discrimination;
 use chain_core::property::Block as _;
 use chain_impl_mockchain::{
@@ -638,7 +641,7 @@ fn apply_block_to_vote_plans(
 
                                 // update the tally every time a vote is cast
                                 let p = &mut proposals[vote_cast.proposal_index() as usize];
-                                p.tally = Some(compute_public_tally(&p, &stake));
+                                p.tally = Some(compute_public_tally(p, stake));
 
                                 let vote_plan = ExplorerVotePlan {
                                     proposals,
@@ -672,6 +675,12 @@ fn apply_block_to_vote_plans(
                                         },
                                     )
                                     .unwrap();
+
+                                let p = &mut proposals[vote_cast.proposal_index() as usize];
+                                p.tally = Some(ExplorerVoteTally::Private {
+                                    results: None,
+                                    options: p.options.clone(),
+                                });
 
                                 let vote_plan = ExplorerVotePlan {
                                     proposals,

--- a/src/jormungandr/testing/jormungandr-automation/src/jormungandr/explorer/verifiers/all_vote_plans_verifier.rs
+++ b/src/jormungandr/testing/jormungandr-automation/src/jormungandr/explorer/verifiers/all_vote_plans_verifier.rs
@@ -116,10 +116,7 @@ impl ExplorerVerifier {
                                 {
                                     match state {
                                         PrivateTallyState::Encrypted { encrypted_tally: _ } => {
-                                            assert!(
-                                                explorer_tally_status.results.is_none(),
-                                                "BUG NPG-3369 fixed"
-                                            )
+                                            assert!(explorer_tally_status.results.is_some())
                                         }
                                         PrivateTallyState::Decrypted { result } => {
                                             let explorer_tally_result =

--- a/src/jormungandr/testing/jormungandr-automation/src/jormungandr/explorer/verifiers/vote_plan_verifier.rs
+++ b/src/jormungandr/testing/jormungandr-automation/src/jormungandr/explorer/verifiers/vote_plan_verifier.rs
@@ -100,10 +100,9 @@ impl ExplorerVerifier {
                         explorer_proposal.tally.unwrap()
                     {
                         match state {
-                            PrivateTallyState::Encrypted { encrypted_tally: _ } => assert!(
-                                explorer_tally_status.results.is_none(),
-                                "BUG NPG-3369 fixed"
-                            ),
+                            PrivateTallyState::Encrypted { encrypted_tally: _ } => {
+                                assert!(explorer_tally_status.results.is_some())
+                            }
                             PrivateTallyState::Decrypted { result } => {
                                 let explorer_tally_result = explorer_tally_status.results.unwrap();
                                 assert_eq!(result.results.len(), explorer_tally_result.len());

--- a/src/jormungandr/testing/jormungandr-integration-tests/src/jormungandr/explorer/vote_plan.rs
+++ b/src/jormungandr/testing/jormungandr-integration-tests/src/jormungandr/explorer/vote_plan.rs
@@ -116,8 +116,7 @@ pub fn explorer_vote_plan_not_existing() {
     );
 }
 
-#[should_panic]
-#[test] // NPG-3808
+#[test]
 pub fn explorer_vote_plan_public_flow_test() {
     let temp_dir = TempDir::new().unwrap();
     let alice = Wallet::default();
@@ -153,12 +152,10 @@ pub fn explorer_vote_plan_public_flow_test() {
     );
 
     let config = Block0ConfigurationBuilder::default()
-        .with_utxos(
-            voters
-                .iter()
-                .map(|x| x.to_initial_fund(INITIAL_TREASURY))
-                .collect(),
-        )
+        .with_utxos(vec![
+            voters[0].to_initial_fund(INITIAL_FUND_PER_WALLET_1),
+            voters[1].to_initial_fund(INITIAL_FUND_PER_WALLET_2),
+        ])
         .with_token(InitialToken {
             token_id: vote_plan.voting_token().clone().into(),
             policy: MintingPolicy::new().into(),
@@ -454,8 +451,8 @@ pub fn explorer_vote_plan_private_flow_test() {
             token_id: vote_plan.voting_token().clone().into(),
             policy: MintingPolicy::new().into(),
             to: vec![
-                voters[0].to_initial_token(INITIAL_FUND_PER_WALLET_1),
-                voters[1].to_initial_token(INITIAL_FUND_PER_WALLET_2),
+                voters[0].to_initial_token(INITIAL_TOKEN_PER_WALLET_1),
+                voters[1].to_initial_token(INITIAL_TOKEN_PER_WALLET_2),
             ],
         })
         .with_block0_consensus(ConsensusType::Bft)
@@ -710,8 +707,7 @@ pub fn explorer_vote_plan_private_flow_test() {
     );
 }
 
-#[should_panic]
-#[test] // NPG-3808
+#[test]
 pub fn explorer_all_vote_plans_public_flow_test() {
     let temp_dir = TempDir::new().unwrap();
     let alice = Wallet::default();
@@ -765,18 +761,16 @@ pub fn explorer_all_vote_plans_public_flow_test() {
     let jormungandr = SingleNodeTestBootstrapper::default()
         .with_block0_config(
             Block0ConfigurationBuilder::default()
-                .with_utxos(
-                    voters
-                        .iter()
-                        .map(|x| x.to_initial_fund(INITIAL_TREASURY))
-                        .collect(),
-                )
+                .with_utxos(vec![
+                    voters[0].to_initial_fund(INITIAL_FUND_PER_WALLET_1),
+                    voters[1].to_initial_fund(INITIAL_FUND_PER_WALLET_2),
+                ])
                 .with_token(InitialToken {
                     token_id: vote_plans.first().unwrap().voting_token().clone().into(),
                     policy: MintingPolicy::new().into(),
                     to: vec![
-                        voters[0].to_initial_token(INITIAL_FUND_PER_WALLET_1),
-                        voters[1].to_initial_token(INITIAL_FUND_PER_WALLET_2),
+                        voters[0].to_initial_token(INITIAL_TOKEN_PER_WALLET_1),
+                        voters[1].to_initial_token(INITIAL_TOKEN_PER_WALLET_2),
                     ],
                 })
                 .with_committees(&[voters[0].to_committee_id()])

--- a/src/jormungandr/testing/jormungandr-integration-tests/src/jormungandr/explorer/vote_plan.rs
+++ b/src/jormungandr/testing/jormungandr-integration-tests/src/jormungandr/explorer/vote_plan.rs
@@ -395,8 +395,7 @@ pub fn explorer_vote_plan_public_flow_test() {
     );
 }
 
-#[should_panic]
-#[test] //NPG-3808
+#[test]
 pub fn explorer_vote_plan_private_flow_test() {
     let temp_dir = TempDir::new().unwrap().into_persistent();
     let yes_choice = Choice::new(1);
@@ -1021,8 +1020,7 @@ pub fn explorer_all_vote_plans_public_flow_test() {
     );
 }
 
-#[should_panic]
-#[test] //NPG-3808
+#[test]
 pub fn explorer_all_vote_plans_private_flow_test() {
     let temp_dir = TempDir::new().unwrap().into_persistent();
     let yes_choice = Choice::new(1);


### PR DESCRIPTION
- Update the public tally every time a vote is cast. Rather than waiting for the voting to end before being able to check tally results; mainly for _transparency_. 

- The rest of the PR addresses private tally return values in the None case _(3369)._