### PR TITLE
Update nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -141,11 +141,11 @@
     },
     "flake-utils_2": {
       "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
         "type": "github"
       },
       "original": {
@@ -298,11 +298,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1665940183,
-        "narHash": "sha256-cPe3F7CtnxU9YbJpc3Adl4d9kX+turqTv5FxM98i8vg=",
+        "lastModified": 1667811565,
+        "narHash": "sha256-HYml7RdQPQ7X13VNe2CoDMqmifsXbt4ACTKxHRKQE3Q=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "104e8082de1b20f9d0e1f05b1028795ed0e0e4bc",
+        "rev": "667e5581d16745bcda791300ae7e2d73f49fff25",
         "type": "github"
       },
       "original": {
@@ -393,29 +393,6 @@
         "type": "github"
       }
     },
-    "pre-commit-hooks": {
-      "inputs": {
-        "flake-utils": [
-          "flake-utils"
-        ],
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1665584211,
-        "narHash": "sha256-Qc9zn43UjLpP823BP416hAsoaXugwWw+nKPVqsNhqdY=",
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "rev": "94b0f300dd9a23d4e851aa2a947a1511d3410e2d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "cardano-node": "cardano-node",
@@ -423,7 +400,6 @@
         "flake-utils": "flake-utils_2",
         "naersk": "naersk",
         "nixpkgs": "nixpkgs",
-        "pre-commit-hooks": "pre-commit-hooks",
         "rust-overlay": "rust-overlay"
       }
     },
@@ -437,11 +413,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1665975900,
-        "narHash": "sha256-X8Xnnz9dOVkOY1/LJGf3FmzyaXkB1luVcozFl7bAmT4=",
+        "lastModified": 1667875464,
+        "narHash": "sha256-0rO2Pzn//ANT3AphpEUantCbm86XcmKNEKhM73LFr04=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "ae87512a3e8ee5bfffd42dadce041e7bdcd05a38",
+        "rev": "9235990723630e1a55e1ed6bca5954e4e31cfbd7",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -33,7 +33,7 @@
     flake-utils.lib.eachSystem
     [
       flake-utils.lib.system.x86_64-linux
-      flake-utils.lib.system.aarch64-linux
+      flake-utils.lib.system.x86_64-darwin
     ]
     (
       system: let

--- a/flake.nix
+++ b/flake.nix
@@ -13,9 +13,6 @@
     flake-compat.url = "github:edolstra/flake-compat";
     flake-compat.flake = false;
     flake-utils.url = "github:numtide/flake-utils";
-    pre-commit-hooks.url = "github:cachix/pre-commit-hooks.nix";
-    pre-commit-hooks.inputs.nixpkgs.follows = "nixpkgs";
-    pre-commit-hooks.inputs.flake-utils.follows = "flake-utils";
     rust-overlay.url = "github:oxalica/rust-overlay";
     rust-overlay.inputs.flake-utils.follows = "flake-utils";
     rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
@@ -29,7 +26,6 @@
     nixpkgs,
     flake-compat,
     flake-utils,
-    pre-commit-hooks,
     rust-overlay,
     naersk,
     cardano-node,
@@ -280,27 +276,13 @@
               ]);
           };
 
-        pre-commit = pre-commit-hooks.lib.${system}.run {
-          src = self;
-          hooks = {
-            alejandra = {
-              enable = true;
-            };
-            rustfmt = {
-              enable = true;
-              entry = pkgs.lib.mkForce "${rust-nightly}/bin/cargo-fmt fmt -- --check --color always";
-            };
-          };
-        };
-
         warnToUpdateNix = pkgs.lib.warn "Consider updating to Nix > 2.7 to remove this warning!";
       in rec {
         packages =
           workspace
           // workspace-nightly
           // {
-            inherit jormungandr-entrypoint pre-commit;
-            default = pre-commit;
+            inherit jormungandr-entrypoint;
           };
 
         devShells.default = pkgs.mkShell {
@@ -317,20 +299,14 @@
               diesel-cli
               cargo-insta # snapshot testing lib
             ]);
-          shellHook =
-            pre-commit.shellHook
-            + ''
-              echo "=== Catalyst Core development shell ==="
-              echo "Info: Git hooks can be installed using \`pre-commit install\`"
-            '';
+          shellHook = ''
+            echo "=== Catalyst Core development shell ==="
+          '';
           # TODO: is this needed for vit-testing development
           # export PATH="${jormungandr}/bin:$PATH"
           # export PATH="${vit-servicing-station-server}/bin:$PATH"
         };
 
-        checks.pre-commit = pre-commit;
-
-        defaultPackage = warnToUpdateNix packages.default;
         devShell = warnToUpdateNix devShells.default;
       }
     );

--- a/flake.nix
+++ b/flake.nix
@@ -79,7 +79,7 @@
 
         rust-stable = mkRust {
           channel = "stable";
-          version = "1.64.0";
+          version = "1.65.0";
         };
         rust-nightly = mkRust {channel = "nightly";};
 


### PR DESCRIPTION
Sets Rust stable v1.65.0, removes pre-commit package, uses same system support as [cardano-node](https://github.com/input-output-hk/cardano-node), removes default package for monorepo.