### PR TITLE
Embed vit-ss migration files

### DIFF
--- a/src/vit-servicing-station/vit-servicing-station-cli/src/api_token.rs
+++ b/src/vit-servicing-station/vit-servicing-station-cli/src/api_token.rs
@@ -188,7 +188,7 @@ mod test {
     fn add_token() {
         let tokens = ApiTokenCmd::generate(10, 10);
         let connection_pool = load_db_connection_pool("").unwrap();
-        initialize_db_with_migration(&connection_pool.get().unwrap());
+        initialize_db_with_migration(&connection_pool.get().unwrap()).unwrap();
         let db_conn = connection_pool.get().unwrap();
         ApiTokenCmd::add_tokens(&tokens, &db_conn).unwrap();
         for token in tokens

--- a/src/vit-servicing-station/vit-servicing-station-cli/src/init_db.rs
+++ b/src/vit-servicing-station/vit-servicing-station-cli/src/init_db.rs
@@ -7,11 +7,14 @@ use vit_servicing_station_lib::db::{
 
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error("Error connecting db pool")]
-    DbPoolError(#[from] DbPoolError),
-
-    #[error("Error connecting to db")]
-    DbConnectionError(#[from] r2d2::Error),
+    #[error("Error connecting db pool: {0}")]
+    DbPool(#[from] DbPoolError),
+    #[error("Error connecting to db: {0}")]
+    DbConnection(#[from] r2d2::Error),
+    #[error("Error running db migrations: {0}")]
+    InitializeDbWithMigration(
+        #[from] vit_servicing_station_lib::db::migrations::InitializeDbWithMigrationError,
+    ),
 }
 
 #[derive(Debug, PartialEq, Eq, StructOpt)]
@@ -28,7 +31,7 @@ impl Db {
     fn init_with_migrations(db_url: &str) -> Result<(), Error> {
         let pool = load_db_connection_pool(db_url)?;
         let db_conn = pool.get()?;
-        initialize_db_with_migration(&db_conn);
+        initialize_db_with_migration(&db_conn)?;
         Ok(())
     }
 }

--- a/src/vit-servicing-station/vit-servicing-station-lib/Cargo.toml
+++ b/src/vit-servicing-station/vit-servicing-station-lib/Cargo.toml
@@ -36,6 +36,7 @@ eccoxide = { git = "https://github.com/eugene-babichenko/eccoxide.git", branch =
 http-zipkin = "0.3.0"
 notify = "5"
 url = { version = "2", features = ["serde"] }
+tempfile = "3"
 
 # This solves building on windows when sqlite3lib is not installed or missing in the `$PATH`
 # as it happens with the github actions pipeline associated to this project.

--- a/src/vit-servicing-station/vit-servicing-station-lib/src/db/migrations.rs
+++ b/src/vit-servicing-station/vit-servicing-station-lib/src/db/migrations.rs
@@ -1,20 +1,46 @@
+use tempfile::TempDir;
+
 use crate::db::DbConnection;
+
+const PG_INITIAL_SETUP_UP: &str =
+    include_str!("../../migrations/postgres/00000000000000_diesel_initial_setup/up.sql");
+const PG_SETUP_UP: &str =
+    include_str!("../../migrations/postgres/2022-11-03-210841_setup_db/up.sql");
+const SQLITE_SETUP_UP: &str =
+    include_str!("../../migrations/sqlite/2020-05-22-112032_setup_db/up.sql");
 
 pub fn initialize_db_with_migration(db_conn: &DbConnection) {
     // Discard all output
     let mut sink = std::io::sink();
 
     match db_conn {
-        DbConnection::Sqlite(db_conn) => diesel_migrations::run_pending_migrations_in_directory(
-            db_conn,
-            &std::path::PathBuf::from("./migrations/sqlite"),
-            &mut sink,
-        ),
-        DbConnection::Postgres(db_conn) => diesel_migrations::run_pending_migrations_in_directory(
-            db_conn,
-            &std::path::PathBuf::from("./migrations/postgres"),
-            &mut sink,
-        ),
+        DbConnection::Sqlite(db_conn) => {
+            let t = TempDir::new().unwrap();
+
+            write_tmp_migration(&t, "2020-05-22-112032_setup_db", SQLITE_SETUP_UP);
+
+            diesel_migrations::run_pending_migrations_in_directory(db_conn, t.path(), &mut sink)
+        }
+        DbConnection::Postgres(db_conn) => {
+            let t = TempDir::new().unwrap();
+
+            write_tmp_migration(
+                &t,
+                "00000000000000_diesel_initial_setup",
+                PG_INITIAL_SETUP_UP,
+            );
+            write_tmp_migration(&t, "2022-11-03-210841_setup_db", PG_SETUP_UP);
+
+            diesel_migrations::run_pending_migrations_in_directory(db_conn, t.path(), &mut sink)
+        }
     }
     .unwrap();
+}
+
+fn write_tmp_migration(dir: &TempDir, migration_name: &str, up_contents: &str) {
+    let migration_dir = dir.path().join(migration_name);
+
+    std::fs::create_dir(migration_dir.as_path()).unwrap();
+    std::fs::write(migration_dir.as_path().join("up.sql"), up_contents).unwrap();
+    std::fs::write(migration_dir.join("down.sql"), "").unwrap();
 }

--- a/src/vit-servicing-station/vit-servicing-station-lib/src/db/migrations.rs
+++ b/src/vit-servicing-station/vit-servicing-station-lib/src/db/migrations.rs
@@ -1,4 +1,5 @@
 use tempfile::TempDir;
+use thiserror::Error;
 
 use crate::db::DbConnection;
 
@@ -9,38 +10,52 @@ const PG_SETUP_UP: &str =
 const SQLITE_SETUP_UP: &str =
     include_str!("../../migrations/sqlite/2020-05-22-112032_setup_db/up.sql");
 
-pub fn initialize_db_with_migration(db_conn: &DbConnection) {
-    // Discard all output
-    let mut sink = std::io::sink();
+#[derive(Debug, Error)]
+pub enum InitializeDbWithMigrationError {
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("Failed to run migrations: {0}")]
+    RunMigration(#[from] diesel_migrations::RunMigrationsError),
+}
 
-    match db_conn {
-        DbConnection::Sqlite(db_conn) => {
-            let t = TempDir::new().unwrap();
+pub fn initialize_db_with_migration(
+    db_conn: &DbConnection,
+) -> Result<(), InitializeDbWithMigrationError> {
+    let t = TempDir::new()?;
 
-            write_tmp_migration(&t, "2020-05-22-112032_setup_db", SQLITE_SETUP_UP);
-
-            diesel_migrations::run_pending_migrations_in_directory(db_conn, t.path(), &mut sink)
+    match &db_conn {
+        DbConnection::Sqlite(_) => {
+            write_tmp_migration(&t, "2020-05-22-112032_setup_db", SQLITE_SETUP_UP)?;
         }
-        DbConnection::Postgres(db_conn) => {
-            let t = TempDir::new().unwrap();
-
+        DbConnection::Postgres(_) => {
             write_tmp_migration(
                 &t,
                 "00000000000000_diesel_initial_setup",
                 PG_INITIAL_SETUP_UP,
-            );
-            write_tmp_migration(&t, "2022-11-03-210841_setup_db", PG_SETUP_UP);
-
-            diesel_migrations::run_pending_migrations_in_directory(db_conn, t.path(), &mut sink)
+            )?;
+            write_tmp_migration(&t, "2022-11-03-210841_setup_db", PG_SETUP_UP)?;
         }
     }
-    .unwrap();
+
+    // Discard all output
+    let mut sink = std::io::sink();
+
+    crate::q!(
+        db_conn,
+        diesel_migrations::run_pending_migrations_in_directory(db_conn, t.path(), &mut sink)
+    )?;
+
+    Ok(())
 }
 
-fn write_tmp_migration(dir: &TempDir, migration_name: &str, up_contents: &str) {
+fn write_tmp_migration(
+    dir: &TempDir,
+    migration_name: &str,
+    up_contents: &str,
+) -> std::io::Result<()> {
     let migration_dir = dir.path().join(migration_name);
 
-    std::fs::create_dir(migration_dir.as_path()).unwrap();
-    std::fs::write(migration_dir.as_path().join("up.sql"), up_contents).unwrap();
-    std::fs::write(migration_dir.join("down.sql"), "").unwrap();
+    std::fs::create_dir(migration_dir.as_path())?;
+    std::fs::write(migration_dir.as_path().join("up.sql"), up_contents)?;
+    std::fs::write(migration_dir.join("down.sql"), "")
 }

--- a/src/vit-servicing-station/vit-servicing-station-lib/src/db/queries/api_tokens.rs
+++ b/src/vit-servicing-station/vit-servicing-station-lib/src/db/queries/api_tokens.rs
@@ -93,7 +93,7 @@ mod test {
     async fn api_token_insert_and_retrieve() {
         // initialize db
         let pool: DbConnectionPool = load_db_connection_pool("").unwrap();
-        db_testing::initialize_db_with_migration(&pool.get().unwrap());
+        db_testing::initialize_db_with_migration(&pool.get().unwrap()).unwrap();
 
         // checks
         let token = ApiToken::new(b"foo_bar_zen".to_vec());

--- a/src/vit-servicing-station/vit-servicing-station-lib/src/testing/filters.rs
+++ b/src/vit-servicing-station/vit-servicing-station-lib/src/testing/filters.rs
@@ -26,7 +26,7 @@ pub async fn test_context() -> (
         .db_connection_pool
         .get()
         .unwrap();
-    initialize_db_with_migration(&conn);
+    initialize_db_with_migration(&conn).unwrap();
     (warp::any().map(move || shared_context.clone()), conn)
 }
 

--- a/src/vit-servicing-station/vit-servicing-station-lib/src/v0/api_token.rs
+++ b/src/vit-servicing-station/vit-servicing-station-lib/src/v0/api_token.rs
@@ -156,7 +156,7 @@ mod test {
 
         // initialize db
         let pool = &shared_context.read().await.db_connection_pool;
-        db_testing::initialize_db_with_migration(&pool.get().unwrap());
+        db_testing::initialize_db_with_migration(&pool.get().unwrap()).unwrap();
         let (token, base64_token) = get_testing_token();
         insert_token_to_db(token, pool);
 

--- a/src/vit-servicing-station/vit-servicing-station-lib/src/v0/endpoints/funds/handlers.rs
+++ b/src/vit-servicing-station/vit-servicing-station-lib/src/v0/endpoints/funds/handlers.rs
@@ -39,7 +39,7 @@ pub mod test {
 
         // initialize db
         let pool = &shared_context.read().await.db_connection_pool;
-        db_testing::initialize_db_with_migration(&pool.get().unwrap());
+        db_testing::initialize_db_with_migration(&pool.get().unwrap()).unwrap();
         let fund: Fund = funds_testing::get_test_fund(Some(1));
         let mut next_fund: Fund = funds_testing::get_test_fund(Some(2));
 
@@ -76,7 +76,7 @@ pub mod test {
 
         // initialize db
         let pool = &shared_context.read().await.db_connection_pool;
-        db_testing::initialize_db_with_migration(&pool.get().unwrap());
+        db_testing::initialize_db_with_migration(&pool.get().unwrap()).unwrap();
         let fund: Fund = funds_testing::get_test_fund(None);
         funds_testing::populate_db_with_fund(&fund, pool);
 
@@ -104,7 +104,7 @@ pub mod test {
         let with_context = warp::any().map(move || filter_context.clone());
 
         let pool = &shared_context.read().await.db_connection_pool;
-        db_testing::initialize_db_with_migration(&pool.get().unwrap());
+        db_testing::initialize_db_with_migration(&pool.get().unwrap()).unwrap();
 
         let fund1: Fund = funds_testing::get_test_fund(Some(1));
         let mut fund2: Fund = funds_testing::get_test_fund(Some(2));
@@ -135,7 +135,7 @@ pub mod test {
         let with_context = warp::any().map(move || filter_context.clone());
 
         let pool = &shared_context.read().await.db_connection_pool;
-        db_testing::initialize_db_with_migration(&pool.get().unwrap());
+        db_testing::initialize_db_with_migration(&pool.get().unwrap()).unwrap();
 
         let fund1: Fund = funds_testing::get_test_fund(Some(1));
         let mut fund2: Fund = funds_testing::get_test_fund(Some(2));

--- a/src/vit-servicing-station/vit-servicing-station-lib/src/v0/endpoints/proposals/handlers.rs
+++ b/src/vit-servicing-station/vit-servicing-station-lib/src/v0/endpoints/proposals/handlers.rs
@@ -55,7 +55,7 @@ pub mod test {
 
         // initialize db
         let pool = &shared_context.read().await.db_connection_pool;
-        db_testing::initialize_db_with_migration(&pool.get().unwrap());
+        db_testing::initialize_db_with_migration(&pool.get().unwrap()).unwrap();
         let mut proposal: FullProposalInfo = proposals_testing::get_test_proposal("group1");
         proposals_testing::populate_db_with_proposal(&proposal, pool);
         let challenge: Challenge =
@@ -94,7 +94,7 @@ pub mod test {
 
         // initialize db
         let pool = &shared_context.read().await.db_connection_pool;
-        db_testing::initialize_db_with_migration(&pool.get().unwrap());
+        db_testing::initialize_db_with_migration(&pool.get().unwrap()).unwrap();
         let proposal: FullProposalInfo = proposals_testing::get_test_proposal("group1");
         proposals_testing::populate_db_with_proposal(&proposal, pool);
         let challenge: Challenge =
@@ -127,7 +127,7 @@ pub mod test {
 
         // initialize db
         let pool = &shared_context.read().await.db_connection_pool;
-        db_testing::initialize_db_with_migration(&pool.get().unwrap());
+        db_testing::initialize_db_with_migration(&pool.get().unwrap()).unwrap();
         let proposal: FullProposalInfo = proposals_testing::get_test_proposal("group1");
         proposals_testing::populate_db_with_proposal(&proposal, pool);
         let challenge: Challenge =

--- a/src/vit-servicing-station/vit-servicing-station-lib/src/v0/endpoints/snapshot/mod.rs
+++ b/src/vit-servicing-station/vit-servicing-station-lib/src/v0/endpoints/snapshot/mod.rs
@@ -249,7 +249,7 @@ mod test {
     pub async fn test_snapshot() {
         let context = new_db_test_shared_context();
         let db_conn = &context.read().await.db_connection_pool.get().unwrap();
-        initialize_db_with_migration(db_conn);
+        initialize_db_with_migration(db_conn).unwrap();
 
         let keys = [
             Identifier::from_hex(
@@ -530,7 +530,7 @@ mod test {
 
         let context = new_db_test_shared_context();
         let db_conn = &context.read().await.db_connection_pool.get().unwrap();
-        initialize_db_with_migration(db_conn);
+        initialize_db_with_migration(db_conn).unwrap();
 
         let voting_key = Identifier::from_hex(
             "0000000000000000000000000000000000000000000000000000000000000000",
@@ -756,7 +756,7 @@ mod test {
 
         let context = new_db_test_shared_context();
         let db_conn = &context.read().await.db_connection_pool.get().unwrap();
-        initialize_db_with_migration(db_conn);
+        initialize_db_with_migration(db_conn).unwrap();
 
         let snapshot_root = warp::path!("snapshot" / ..).boxed();
         let filter = filter(snapshot_root.clone(), context.clone());
@@ -893,7 +893,7 @@ mod test {
 
         let context = new_db_test_shared_context();
         let db_conn = &context.read().await.db_connection_pool.get().unwrap();
-        initialize_db_with_migration(db_conn);
+        initialize_db_with_migration(db_conn).unwrap();
 
         let snapshot_root = warp::path!("snapshot" / ..).boxed();
         let filter = filter(snapshot_root.clone(), context.clone());

--- a/src/vit-servicing-station/vit-servicing-station-lib/src/v0/endpoints/votes/handlers.rs
+++ b/src/vit-servicing-station/vit-servicing-station-lib/src/v0/endpoints/votes/handlers.rs
@@ -32,7 +32,7 @@ mod test {
 
         // initialize db
         let pool = &shared_context.read().await.db_connection_pool;
-        db_testing::initialize_db_with_migration(&pool.get().unwrap());
+        db_testing::initialize_db_with_migration(&pool.get().unwrap()).unwrap();
         let vote: Vote = votes_testing::get_test_vote();
 
         votes_testing::populate_db_with_vote(&vote, pool);

--- a/src/vit-servicing-station/vit-servicing-station-tests/src/common/paths.rs
+++ b/src/vit-servicing-station/vit-servicing-station-tests/src/common/paths.rs
@@ -1,2 +1,2 @@
-pub const MIGRATION_DIR: &str = "../vit-servicing-station-lib/migrations";
+pub const MIGRATION_DIR: &str = "../vit-servicing-station-lib/migrations/sqlite";
 pub const BLOCK0_BIN: &str = "../resources/tests/block0.bin";


### PR DESCRIPTION
vit-ss used to embed the migration files but after [these changes](https://github.com/input-output-hk/catalyst-core/commit/586ae82961c79894f251d148a5a7cbd04c31b21e#diff-e125a6865c74aefe3235510a1fbb72cded9672ac918e9be8214466a53a0ac1c1L3) migration files were being read from relative directories which broke things.

This makes the vit-ss CLI init db command work correctly again and also fixes the vit-ss integration tests (still testing only SQLite).

*PS: Since diesel migrations lib seems to only provide functions for running migrations that receive directory paths as arguments, I decided to embed the migration files and write them to a temporary directory when running the migrations. Not sure if this is the best solution.*