### PR TITLE
Gateway node 3887

### DIFF
--- a/src/jormungandr/jormungandr/Cargo.toml
+++ b/src/jormungandr/jormungandr/Cargo.toml
@@ -101,3 +101,13 @@ systemd = ["tracing-journald"]
 gelf = ["tracing-gelf"]
 prometheus-metrics = ["prometheus"]
 evm = [ "chain-impl-mockchain/evm", "jormungandr-lib/evm", "chain-evm" ]
+gateway=[]
+
+[[bin]]
+name = "jormungandr"
+path = "src/bin/jormungandr.rs"
+
+[[bin]]
+name = "gateway"
+required-features = ["gateway"]
+path = "src/bin/jormungandr.rs"

--- a/src/jormungandr/jormungandr/src/intercom.rs
+++ b/src/jormungandr/jormungandr/src/intercom.rs
@@ -588,7 +588,7 @@ pub enum BlockMsg {
 }
 
 /// Propagation requests for the network task.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum PropagateMsg {
     Block(Box<Header>),
     Fragment(Fragment),

--- a/src/jormungandr/jormungandr/src/network/mod.rs
+++ b/src/jormungandr/jormungandr/src/network/mod.rs
@@ -346,7 +346,7 @@ async fn handle_network_input(
     channels: Channels,
 ) {
     while let Some(msg) = input.next().await {
-        tracing::trace!("handling new network task item");
+        tracing::trace!("handling new gateway network task item");
         match msg {
             NetworkMsg::Propagate(msg) => match *(msg.clone()) {
                 PropagateMsg::Block(_) | PropagateMsg::Fragment(_) => {
@@ -359,6 +359,7 @@ async fn handle_network_input(
                 PropagateMsg::Gossip(peer, _gossips) => {
                     // drop all gossip from public nodes
                     if peer.is_global() {
+                        tracing::trace!("dropping gossip msg from {:?}", peer);
                         continue;
                     } else {
                         handle_propagation_msg(*(msg.clone()), state.clone(), channels.clone())

--- a/src/jormungandr/testing/jormungandr-automation/src/jormungandr/legacy/config/mod.rs
+++ b/src/jormungandr/testing/jormungandr-automation/src/jormungandr/legacy/config/mod.rs
@@ -70,6 +70,10 @@ impl ConfigurableNodeConfig for LegacyNodeConfigManager {
     }
 
     fn as_communication_params(&self) -> CommunicationParams {
-        todo!()
+        CommunicationParams {
+            p2p_public_address: self.p2p_public_address(),
+            p2p_listen_address: self.p2p_listen_address(),
+            rest_socket_addr: self.rest_socket_addr(),
+        }
     }
 }

--- a/src/jormungandr/testing/jormungandr-integration-tests/src/lib.rs
+++ b/src/jormungandr/testing/jormungandr-integration-tests/src/lib.rs
@@ -7,7 +7,7 @@ pub mod context;
 pub mod jcli;
 #[cfg(test)]
 pub mod jormungandr;
-#[cfg(all(test, feature = "network"))]
+#[cfg(all(test, feature = "networking"))]
 pub mod networking;
 #[cfg(all(test, feature = "non-functional"))]
 pub mod non_functional;

--- a/src/jormungandr/testing/jormungandr-integration-tests/src/networking/cross_version/fragment_propagation.rs
+++ b/src/jormungandr/testing/jormungandr-integration-tests/src/networking/cross_version/fragment_propagation.rs
@@ -6,7 +6,8 @@ use hersir::{
 };
 use jormungandr_automation::{
     jormungandr::{
-        download_last_n_releases, get_jormungandr_bin, version_0_8_19, FragmentNode, Version,
+        download_last_n_releases, get_jormungandr_bin, version_0_8_19, FragmentNode, LogLevel,
+        Version,
     },
     testing::SyncNode,
 };

--- a/src/jormungandr/testing/jormungandr-integration-tests/src/networking/gateway/gateway_node.rs
+++ b/src/jormungandr/testing/jormungandr-integration-tests/src/networking/gateway/gateway_node.rs
@@ -1,0 +1,292 @@
+use crate::{build_network, jormungandr::grpc::setup::client, networking::utils};
+
+use hersir::{
+    builder::{NetworkBuilder, Node, Topology},
+    config::{BlockchainBuilder, BlockchainConfiguration, SpawnParams, WalletTemplateBuilder},
+};
+use jormungandr_automation::{
+    jormungandr::LogLevel,
+    testing::{ensure_nodes_are_in_sync, SyncWaitParams},
+};
+
+use jormungandr_lib::{
+    interfaces::SlotDuration,
+    time::{Duration, SystemTime},
+};
+use std::{
+    net::{Ipv6Addr, SocketAddr, SocketAddrV6},
+    path::PathBuf,
+};
+use thor::{FragmentSender, FragmentVerifier};
+
+const CLIENT: &str = "CLIENT";
+const CLIENT_B: &str = "CLIENT_B";
+const CLIENT_C: &str = "CLIENT_C";
+
+const SERVER: &str = "SERVER";
+
+const ALICE: &str = "ALICE";
+const BOB: &str = "BOB";
+
+const LEADER_CLIENT: &str = "LEADER_CLIENT";
+const LEADER: &str = "LEADER";
+
+#[ignore]
+#[test]
+fn gateway_gossip() {
+    const SERVER_GOSSIP_INTERVAL_SECS: u64 = 1;
+    const DEFAULT_GOSSIP_INTERVAL_SECS: u64 = 10;
+
+    let mut network_controller = NetworkBuilder::default()
+        .topology(
+            Topology::default()
+                .with_node(Node::new(SERVER))
+                .with_node(Node::new(CLIENT).with_trusted_peer(SERVER))
+                .with_node(Node::new(CLIENT_B).with_trusted_peer(SERVER)),
+        )
+        .blockchain_config(BlockchainConfiguration::default().with_leader(SERVER))
+        .wallet_template(
+            WalletTemplateBuilder::new(ALICE)
+                .with(1_000_000)
+                .delegated_to(CLIENT)
+                .build(),
+        )
+        .wallet_template(
+            WalletTemplateBuilder::new(BOB)
+                .with(1_000_000)
+                .delegated_to(SERVER)
+                .build(),
+        )
+        .build()
+        .unwrap();
+
+    let server = network_controller
+        .spawn(
+            SpawnParams::new(SERVER)
+                .gossip_interval(Duration::new(SERVER_GOSSIP_INTERVAL_SECS, 0))
+                .log_level(LogLevel::TRACE),
+        )
+        .unwrap();
+
+    //
+    // spin up gateway node
+    //
+    let mut gateway_node_binary = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+
+    gateway_node_binary.pop();
+    gateway_node_binary.pop();
+    gateway_node_binary.pop();
+    gateway_node_binary.pop();
+    gateway_node_binary.push("target/debug/gateway");
+
+    let _client_gateway = network_controller
+        .spawn(SpawnParams::new(CLIENT).jormungandr(gateway_node_binary))
+        .unwrap();
+
+    utils::wait(DEFAULT_GOSSIP_INTERVAL_SECS);
+
+    //
+    // there should be no gossip from gateway node to server
+    //
+    let last_gossip = server.rest().network_stats().unwrap();
+
+    assert!(last_gossip.is_empty());
+    //
+    // spin up regular client
+    //
+    let mut regular_node_binary = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+
+    regular_node_binary.pop();
+    regular_node_binary.pop();
+    regular_node_binary.pop();
+    regular_node_binary.pop();
+    regular_node_binary.push("target/debug/jormungandr");
+
+    let _client_b = network_controller
+        .spawn(SpawnParams::new(CLIENT_B).jormungandr(regular_node_binary))
+        .unwrap();
+
+    utils::wait(DEFAULT_GOSSIP_INTERVAL_SECS);
+    let last_gossip = server.rest().network_stats().unwrap();
+
+    // regular node gossips as usual
+    assert!(!last_gossip.is_empty());
+}
+
+#[ignore]
+#[test]
+pub fn test_gateway_node_not_publishing() {
+    let mut network_controller = build_network!()
+        .topology(
+            Topology::default()
+                .with_node(Node::new(LEADER))
+                .with_node(Node::new(LEADER_CLIENT).with_trusted_peer(LEADER)),
+        )
+        .wallet_template(
+            WalletTemplateBuilder::new("alice")
+                .with(1_000_000)
+                .delegated_to(LEADER)
+                .build(),
+        )
+        .wallet_template(WalletTemplateBuilder::new("bob").with(1_000_000).build())
+        .blockchain_config(BlockchainConfiguration::default().with_leader(LEADER))
+        .build()
+        .unwrap();
+
+    let leader = network_controller
+        .spawn(SpawnParams::new(LEADER).in_memory())
+        .unwrap();
+
+    //
+    // spin up gateway node
+    //
+    let mut gateway_node_binary = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+
+    gateway_node_binary.pop();
+    gateway_node_binary.pop();
+    gateway_node_binary.pop();
+    gateway_node_binary.pop();
+    gateway_node_binary.push("target/debug/gateway");
+
+    let leader_client = network_controller
+        .spawn(
+            SpawnParams::new(LEADER_CLIENT)
+                .jormungandr(gateway_node_binary)
+                .listen_address(Some(SocketAddr::V6(SocketAddrV6::new(
+                    Ipv6Addr::new(0x26, 0, 0x1c9, 0, 0, 0xafc8, 0x10, 0x1),
+                    1234,
+                    0,
+                    0,
+                )))),
+        )
+        .unwrap();
+
+    let mut alice = network_controller.controlled_wallet("alice").unwrap();
+    let mut bob = network_controller.controlled_wallet("bob").unwrap();
+
+    let fragment_sender = FragmentSender::from(&leader.rest().settings().unwrap());
+
+    // gateway node should not be able to send fragments
+    match fragment_sender.send_transactions_round_trip(
+        5,
+        &mut alice,
+        &mut bob,
+        &leader_client,
+        100.into(),
+    ) {
+        Ok(_) => panic!("gateway node should not be able to send fragments"),
+        Err(err) => assert_eq!(
+            err.to_string(),
+            "Too many attempts failed (1) while trying to send fragment to node: ".to_string()
+        ),
+    };
+}
+
+#[ignore]
+#[test]
+pub fn test_gateway_sync() {
+    const SERVER_GOSSIP_INTERVAL_SECS: u64 = 1;
+    const DEFAULT_GOSSIP_INTERVAL_SECS: u64 = 10;
+
+    let mut network_controller = NetworkBuilder::default()
+        .topology(
+            Topology::default()
+                .with_node(Node::new(SERVER))
+                .with_node(Node::new(CLIENT).with_trusted_peer(SERVER))
+                .with_node(Node::new(CLIENT_B).with_trusted_peer(SERVER))
+                .with_node(Node::new(CLIENT_C).with_trusted_peer(SERVER)),
+        )
+        .blockchain_config(BlockchainConfiguration::default().with_leader(SERVER))
+        .wallet_template(
+            WalletTemplateBuilder::new(ALICE)
+                .with(1_000_000)
+                .delegated_to(CLIENT)
+                .build(),
+        )
+        .wallet_template(
+            WalletTemplateBuilder::new(BOB)
+                .with(1_000_000)
+                .delegated_to(SERVER)
+                .build(),
+        )
+        .build()
+        .unwrap();
+
+    let server = network_controller
+        .spawn(
+            SpawnParams::new(SERVER)
+                .gossip_interval(Duration::new(SERVER_GOSSIP_INTERVAL_SECS, 0))
+                .log_level(LogLevel::TRACE),
+        )
+        .unwrap();
+
+    //
+    // spin up gateway node
+    //
+    let mut gateway_node_binary = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+
+    gateway_node_binary.pop();
+    gateway_node_binary.pop();
+    gateway_node_binary.pop();
+    gateway_node_binary.pop();
+    gateway_node_binary.push("target/debug/gateway");
+
+    let _client_gateway = network_controller
+        .spawn(SpawnParams::new(CLIENT).jormungandr(gateway_node_binary))
+        .unwrap();
+
+    utils::wait(DEFAULT_GOSSIP_INTERVAL_SECS);
+
+    //
+    // spin up regular client
+    //
+    let mut regular_node_binary = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+
+    regular_node_binary.pop();
+    regular_node_binary.pop();
+    regular_node_binary.pop();
+    regular_node_binary.pop();
+    regular_node_binary.push("target/debug/jormungandr");
+
+    // binary without drop gossip from public addrs modifications
+    let regular_node_path = regular_node_binary.clone();
+
+    let _client_b = network_controller
+        .spawn(SpawnParams::new(CLIENT_B).jormungandr(regular_node_binary))
+        .unwrap();
+
+    let _client_c = network_controller
+        .spawn(SpawnParams::new(CLIENT_C).jormungandr(regular_node_path))
+        .unwrap();
+
+    utils::wait(DEFAULT_GOSSIP_INTERVAL_SECS);
+
+    let fragment_sender = FragmentSender::from(&server.rest().settings().unwrap());
+
+    let mut alice = network_controller.controlled_wallet(ALICE).unwrap();
+    let mut bob = network_controller.controlled_wallet(BOB).unwrap();
+
+    match fragment_sender.send_transactions_round_trip(
+        5,
+        &mut alice,
+        &mut bob,
+        &_client_b,
+        100.into(),
+    ) {
+        Ok(()) => println!("fragments sent!"),
+        Err(err) => panic!("{:?}", err),
+    }
+
+    let a = _client_b.grpc().tip().block_content_hash();
+    let b = _client_gateway.grpc().tip().block_content_hash();
+    let c = server.grpc().tip().block_content_hash();
+
+    assert_eq!(a, b);
+    assert_eq!(b, c);
+
+    ensure_nodes_are_in_sync(
+        SyncWaitParams::ZeroWait,
+        &[&_client_gateway, &_client_b, &_client_c],
+    )
+    .unwrap();
+}

--- a/src/jormungandr/testing/jormungandr-integration-tests/src/networking/gateway/mod.rs
+++ b/src/jormungandr/testing/jormungandr-integration-tests/src/networking/gateway/mod.rs
@@ -1,0 +1,1 @@
+pub mod gateway_node;

--- a/src/jormungandr/testing/jormungandr-integration-tests/src/networking/mod.rs
+++ b/src/jormungandr/testing/jormungandr-integration-tests/src/networking/mod.rs
@@ -3,6 +3,7 @@ pub mod communication;
 #[cfg(feature = "cross-version")]
 pub mod cross_version;
 pub mod explorer;
+pub mod gateway;
 pub mod leadership_log;
 pub mod p2p;
 pub mod stake_pool;

--- a/src/jormungandr/testing/jormungandr-integration-tests/src/networking/p2p/connections.rs
+++ b/src/jormungandr/testing/jormungandr-integration-tests/src/networking/p2p/connections.rs
@@ -1,4 +1,10 @@
-use crate::networking::utils;
+use std::path::PathBuf;
+
+use crate::{jormungandr::grpc::setup, networking::utils};
+use chain_core::property::{BlockId, HasHeader};
+
+use chain_impl_mockchain::testing::{GenesisPraosBlockBuilder, StakePoolBuilder};
+use chain_time::{Epoch, TimeEra};
 use hersir::{
     builder::{NetworkBuilder, Node, Topology},
     config::{BlockchainConfiguration, SpawnParams, WalletTemplateBuilder},
@@ -16,6 +22,7 @@ const LEADER3: &str = "LEADER3";
 const LEADER4: &str = "LEADER4";
 
 const CLIENT: &str = "CLIENT";
+const CLIENT_B: &str = "CLIENT_B";
 const SERVER: &str = "SERVER";
 const SERVER_1: &str = "SERVER_1";
 const SERVER_2: &str = "SERVER_2";
@@ -106,6 +113,90 @@ pub fn node_trust_itself() {
             "failed to retrieve the list of bootstrap peers from trusted peer",
         )
         .unwrap();
+}
+
+#[ignore]
+#[test]
+fn gateway_gossip() {
+    const SERVER_GOSSIP_INTERVAL_SECS: u64 = 1;
+    const DEFAULT_GOSSIP_INTERVAL_SECS: u64 = 10;
+
+    let mut network_controller = NetworkBuilder::default()
+        .topology(
+            Topology::default()
+                .with_node(Node::new(SERVER))
+                .with_node(Node::new(CLIENT).with_trusted_peer(SERVER))
+                .with_node(Node::new(CLIENT_B).with_trusted_peer(SERVER)),
+        )
+        .blockchain_config(BlockchainConfiguration::default().with_leader(SERVER))
+        .wallet_template(
+            WalletTemplateBuilder::new(ALICE)
+                .with(1_000_000)
+                .delegated_to(CLIENT)
+                .build(),
+        )
+        .wallet_template(
+            WalletTemplateBuilder::new(BOB)
+                .with(1_000_000)
+                .delegated_to(SERVER)
+                .build(),
+        )
+        .build()
+        .unwrap();
+
+    let server = network_controller
+        .spawn(
+            SpawnParams::new(SERVER)
+                .gossip_interval(Duration::new(SERVER_GOSSIP_INTERVAL_SECS, 0))
+                .log_level(LogLevel::TRACE),
+        )
+        .unwrap();
+
+    //
+    // spin up gateway node
+    //
+    let mut gateway_node_binary = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+
+    gateway_node_binary.pop();
+    gateway_node_binary.pop();
+    gateway_node_binary.pop();
+    gateway_node_binary.pop();
+    gateway_node_binary.push("target/debug/gateway");
+
+    let _client_gateway = network_controller
+        .spawn(SpawnParams::new(CLIENT).jormungandr(gateway_node_binary))
+        .unwrap();
+
+    utils::wait(DEFAULT_GOSSIP_INTERVAL_SECS);
+
+    //
+    // there should be no gossip from gateway node to server
+    //
+    let last_gossip = server.rest().network_stats().unwrap();
+
+    assert!(last_gossip.is_empty());
+    //
+    // spin up regular client
+    //
+    let mut gateway_node_binary = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+
+    gateway_node_binary.pop();
+    gateway_node_binary.pop();
+    gateway_node_binary.pop();
+    gateway_node_binary.pop();
+    gateway_node_binary.push("target/debug/jormungandr");
+
+    let _client_b = network_controller
+        .spawn(SpawnParams::new(CLIENT_B))
+        .unwrap();
+
+    utils::wait(DEFAULT_GOSSIP_INTERVAL_SECS);
+    let last_gossip = server.rest().network_stats().unwrap();
+
+    // regular node gossips as usual
+    assert!(!last_gossip.is_empty());
+
+    // fragment test todo
 }
 
 #[test]

--- a/src/jormungandr/testing/jormungandr-integration-tests/src/networking/p2p/connections.rs
+++ b/src/jormungandr/testing/jormungandr-integration-tests/src/networking/p2p/connections.rs
@@ -178,16 +178,16 @@ fn gateway_gossip() {
     //
     // spin up regular client
     //
-    let mut gateway_node_binary = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut regular_node_binary = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
 
-    gateway_node_binary.pop();
-    gateway_node_binary.pop();
-    gateway_node_binary.pop();
-    gateway_node_binary.pop();
-    gateway_node_binary.push("target/debug/jormungandr");
+    regular_node_binary.pop();
+    regular_node_binary.pop();
+    regular_node_binary.pop();
+    regular_node_binary.pop();
+    regular_node_binary.push("target/debug/jormungandr");
 
     let _client_b = network_controller
-        .spawn(SpawnParams::new(CLIENT_B))
+        .spawn(SpawnParams::new(CLIENT_B).jormungandr(regular_node_binary))
         .unwrap();
 
     utils::wait(DEFAULT_GOSSIP_INTERVAL_SECS);
@@ -197,6 +197,7 @@ fn gateway_gossip() {
     assert!(!last_gossip.is_empty());
 
     // fragment test todo
+    // make sure gateway node cannot publish
 }
 
 #[test]

--- a/src/jormungandr/testing/jormungandr-integration-tests/src/networking/p2p/stats.rs
+++ b/src/jormungandr/testing/jormungandr-integration-tests/src/networking/p2p/stats.rs
@@ -6,7 +6,7 @@ use hersir::{
 };
 use jormungandr_automation::jormungandr::JormungandrProcess;
 use jormungandr_lib::interfaces::{NodeStats, Policy, SlotDuration};
-use std::{fmt::Display, time::Duration};
+use std::{fmt::Display, path::PathBuf, time::Duration};
 use thor::FragmentSender;
 
 const LEADER1: &str = "LEADER1";
@@ -21,6 +21,10 @@ const LEADER: &str = "LEADER";
 const ALICE: &str = "ALICE";
 const BOB: &str = "BOB";
 const CLARICE: &str = "CLARICE";
+
+const CLIENT: &str = "CLIENT";
+const CLIENT_B: &str = "CLIENT_B";
+const SERVER: &str = "SERVER";
 
 #[test]
 pub fn p2p_stats_test() {
@@ -157,6 +161,66 @@ macro_rules! build_network {
             BlockchainConfiguration::default().with_slot_duration(SlotDuration::new(5).unwrap()),
         )
     }};
+}
+
+#[test]
+#[ignore]
+pub fn test_gateway_node_not_publishing() {
+    let mut network_controller = build_network!()
+        .topology(
+            Topology::default()
+                .with_node(Node::new(LEADER))
+                .with_node(Node::new(LEADER_CLIENT).with_trusted_peer(LEADER)),
+        )
+        .wallet_template(
+            WalletTemplateBuilder::new("alice")
+                .with(1_000_000)
+                .delegated_to(LEADER)
+                .build(),
+        )
+        .wallet_template(WalletTemplateBuilder::new("bob").with(1_000_000).build())
+        .blockchain_config(BlockchainConfiguration::default().with_leader(LEADER))
+        .build()
+        .unwrap();
+
+    let leader = network_controller
+        .spawn(SpawnParams::new(LEADER).in_memory())
+        .unwrap();
+
+    //
+    // spin up gateway node
+    //
+    let mut gateway_node_binary = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+
+    gateway_node_binary.pop();
+    gateway_node_binary.pop();
+    gateway_node_binary.pop();
+    gateway_node_binary.pop();
+    gateway_node_binary.push("target/debug/gateway");
+
+    let leader_client = network_controller
+        .spawn(SpawnParams::new(LEADER_CLIENT).jormungandr(gateway_node_binary))
+        .unwrap();
+
+    let mut alice = network_controller.controlled_wallet("alice").unwrap();
+    let mut bob = network_controller.controlled_wallet("bob").unwrap();
+
+    let fragment_sender = FragmentSender::from(&leader.rest().settings().unwrap());
+
+    // gateway node should not be able to send fragments
+    match fragment_sender.send_transactions_round_trip(
+        5,
+        &mut alice,
+        &mut bob,
+        &leader_client,
+        100.into(),
+    ) {
+        Ok(_) => panic!("gateway node should not be able to send fragments"),
+        Err(err) => assert_eq!(
+            err.to_string(),
+            "Too many attempts failed (1) while trying to send fragment to node: ".to_string()
+        ),
+    };
 }
 
 #[test]


### PR DESCRIPTION
As we gradually start to allow full public node participation in the network, we will start by deploying gateway nodes as an entry point. Gateway nodes can only consume from the internal network, they cannot _propagate/gossip/publish_.

This is a _temporary_ solution to prevent flooding attacks etc.

Below is a _crude_ diagram to illustrate the point.

A gateway node that is conditionally compiled (**_d_** in the diagram), 

**d** will be open to the wild - **A, B, C** will not be. 




![Screenshot 2022-11-15 at 13 52 08](https://user-images.githubusercontent.com/60357579/202922835-0522d101-57d9-4b9f-837f-411d260ccc27.png)
