### PR TITLE
Docs for chain time

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.65"
+channel = "nightly"
 components = ["rust-src", "rustfmt", "rust-std"]

--- a/src/catalyst-toolbox/catalyst-toolbox/src/bin/cli/kedqr/decode/img.rs
+++ b/src/catalyst-toolbox/catalyst-toolbox/src/bin/cli/kedqr/decode/img.rs
@@ -11,7 +11,7 @@ use std::path::Path;
 use std::path::PathBuf;
 
 pub fn save_secret_from_qr(qr: PathBuf, output: Option<PathBuf>, pin: QrPin) -> Result<(), Report> {
-    let sk = secret_from_qr(&qr, pin)?;
+    let sk = secret_from_qr(qr, pin)?;
     let hrp = Ed25519Extended::SECRET_BECH32_HRP;
     let secret_key = bech32::encode(hrp, sk.leak_secret().to_base32(), Variant::Bech32)?;
 

--- a/src/catalyst-toolbox/catalyst-toolbox/src/bin/cli/kedqr/encode/img.rs
+++ b/src/catalyst-toolbox/catalyst-toolbox/src/bin/cli/kedqr/encode/img.rs
@@ -15,7 +15,7 @@ pub fn generate_qr(input: PathBuf, output: Option<PathBuf>, pin: QrPin) -> Resul
         .read(true)
         .write(false)
         .append(false)
-        .open(&input)
+        .open(input)
         .expect("Could not open input file.");
 
     let mut reader = BufReader::new(key_file);

--- a/src/catalyst-toolbox/catalyst-toolbox/src/bin/cli/kedqr/encode/payload.rs
+++ b/src/catalyst-toolbox/catalyst-toolbox/src/bin/cli/kedqr/encode/payload.rs
@@ -18,7 +18,7 @@ pub fn generate_payload(input: PathBuf, output: Option<PathBuf>, pin: QrPin) -> 
         .read(true)
         .write(false)
         .append(false)
-        .open(&input)
+        .open(input)
         .expect("Could not open input file.");
 
     let mut reader = BufReader::new(key_file);

--- a/src/catalyst-toolbox/catalyst-toolbox/src/bin/cli/stats/snapshot.rs
+++ b/src/catalyst-toolbox/catalyst-toolbox/src/bin/cli/stats/snapshot.rs
@@ -25,7 +25,7 @@ pub enum Command {
 
 impl SnapshotCommand {
     pub fn exec(&self) -> Result<(), Report> {
-        let initials: Vec<Initial> = read_initials(&jortestkit::file::read_file(&self.snapshot)?)?;
+        let initials: Vec<Initial> = read_initials(jortestkit::file::read_file(&self.snapshot)?)?;
 
         match self.command {
             Command::Count => calculate_wallet_distribution_from_initials(

--- a/src/catalyst-toolbox/snapshot-lib/src/registration.rs
+++ b/src/catalyst-toolbox/snapshot-lib/src/registration.rs
@@ -173,7 +173,7 @@ mod serde_impl {
         use bech32::ToBase32;
         let bytes = hex::decode(String::deserialize(deserializer)?.trim_start_matches("0x"))
             .map_err(|e| D::Error::custom(format!("invalid hex string: {}", e)))?;
-        bech32::encode("stake", &bytes.to_base32(), bech32::Variant::Bech32)
+        bech32::encode("stake", bytes.to_base32(), bech32::Variant::Bech32)
             .map_err(|e| D::Error::custom(format!("bech32 encoding failed: {}", e)))
     }
 }
@@ -237,7 +237,7 @@ mod tests {
                 .prop_map(|((stake_key, rewards_addr, delegations), vp)| {
                     let stake_public_key = hex::encode(stake_key);
                     let reward_address =
-                        bech32::encode("stake", &rewards_addr.to_base32(), bech32::Variant::Bech32)
+                        bech32::encode("stake", rewards_addr.to_base32(), bech32::Variant::Bech32)
                             .unwrap();
                     let voting_power: Value = vp.into();
                     VotingRegistration {

--- a/src/chain-libs/chain-impl-mockchain/src/accounting/account/last_rewards.rs
+++ b/src/chain-libs/chain-impl-mockchain/src/accounting/account/last_rewards.rs
@@ -15,18 +15,20 @@ pub struct LastRewards {
     pub reward: Value,
 }
 
-impl LastRewards {
+impl Default for LastRewards {
     /// Create an initial value of epoch=0 reward=0
     ///
     /// It is also safe as the "uninitialized" value, since
     /// epoch 0 doesn't have by construction any reward associated.
-    pub fn default() -> Self {
+    fn default() -> Self {
         LastRewards {
             epoch: 0,
             reward: Value::zero(),
         }
     }
+}
 
+impl LastRewards {
     /// Add some value to the last reward, if the epoch is the same, then the
     /// result is just added, however.account
     ///

--- a/src/chain-libs/chain-impl-mockchain/src/certificate/pool.rs
+++ b/src/chain-libs/chain-impl-mockchain/src/certificate/pool.rs
@@ -764,7 +764,7 @@ mod tests {
         let mut sigs = Vec::new();
         for (i, key) in pool_owner_with_sign.indexed_signatories_sks() {
             let sig = SingleAccountBindingSignature::new(&auth_data, |d| key.sign_slice(d.0));
-            sigs.push((i as u8, sig))
+            sigs.push((i, sig))
         }
         let pool_owner_signed = PoolOwnersSigned { signatures: sigs };
         let verification = if should_pass {

--- a/src/chain-libs/chain-impl-mockchain/src/header/test.rs
+++ b/src/chain-libs/chain-impl-mockchain/src/header/test.rs
@@ -63,8 +63,8 @@ impl Arbitrary for GenesisPraosProof {
         let node_id = Arbitrary::arbitrary(g);
 
         let vrf_proof = {
-            let sk = RistrettoGroup2HashDh::generate(&mut tcg.get_rng(0));
-            RistrettoGroup2HashDh::evaluate_and_prove(&sk, &[0, 1, 2, 3], &mut tcg.get_rng(1))
+            let sk = RistrettoGroup2HashDh::generate(tcg.get_rng(0));
+            RistrettoGroup2HashDh::evaluate_and_prove(&sk, &[0, 1, 2, 3], tcg.get_rng(1))
         };
 
         let kes_proof = {

--- a/src/chain-libs/chain-impl-mockchain/src/key.rs
+++ b/src/chain-libs/chain-impl-mockchain/src/key.rs
@@ -428,8 +428,8 @@ mod tests {
             }
 
             let tcg = testing::TestCryptoGen::arbitrary(g);
-            let mut rng = tcg.get_rng(0);
-            let vrf_sk: SecretKey<RistrettoGroup2HashDh> = SecretKey::generate(&mut rng);
+            let rng = tcg.get_rng(0);
+            let vrf_sk: SecretKey<RistrettoGroup2HashDh> = SecretKey::generate(rng);
             GenesisPraosLeader {
                 vrf_public_key: vrf_sk.to_public(),
                 kes_public_key: PK_KES.clone(),

--- a/src/chain-libs/chain-impl-mockchain/src/leadership/bft.rs
+++ b/src/chain-libs/chain-impl-mockchain/src/leadership/bft.rs
@@ -36,7 +36,7 @@ impl LeadershipData {
     #[inline]
     fn offset(&self, block_number: u64) -> BftRoundRobinIndex {
         let max = self.number_of_leaders() as u64;
-        BftRoundRobinIndex((block_number % max) as u64)
+        BftRoundRobinIndex(block_number % max)
     }
 
     pub(crate) fn verify(&self, block_header: &Header) -> Verification {

--- a/src/chain-libs/chain-impl-mockchain/src/leadership/genesis/mod.rs
+++ b/src/chain-libs/chain-impl-mockchain/src/leadership/genesis/mod.rs
@@ -395,11 +395,11 @@ mod tests {
         println!("Calculating percentage of election per pool....");
         println!("parameters = {:?}", leader_election_parameters);
         println!("empty slots = {}", empty_slots);
-        let total_election_count: u64 = pools.iter().map(|(_, y)| y.1).sum();
+        let total_election_count: u64 = pools.values().map(|y| y.1).sum();
         let ideal_election_count_per_pool: f32 =
             total_election_count as f32 / leader_election_parameters.pools_count as f32;
         let ideal_election_percentage =
-            ideal_election_count_per_pool as f32 / total_election_count as f32;
+            ideal_election_count_per_pool / total_election_count as f32;
         let grace_percentage: f32 = 0.08;
         println!(
             "ideal percentage: {:.2}, grace_percentage: {:.2}",

--- a/src/chain-libs/chain-impl-mockchain/src/stake/distribution.rs
+++ b/src/chain-libs/chain-impl-mockchain/src/stake/distribution.rs
@@ -95,7 +95,7 @@ impl StakeDistribution {
 
     /// Return the total stake held by the eligible stake pools.
     pub fn total_stake(&self) -> Stake {
-        Stake::sum(self.to_pools.iter().map(|(_, pool)| pool.stake.total))
+        Stake::sum(self.to_pools.values().map(|pool| pool.stake.total))
     }
 
     pub fn get_stake_for(&self, poolid: &PoolId) -> Option<Stake> {
@@ -596,19 +596,19 @@ mod tests {
         pools: Stake,
     ) -> TestResult {
         if stake_distribution.unassigned != unassigned {
-            return TestResult::error(&format!(
+            return TestResult::error(format!(
                 "wrong unassigned {} vs {}",
                 stake_distribution.unassigned, unassigned
             ));
         }
         if stake_distribution.dangling != dangling {
-            return TestResult::error(&format!(
+            return TestResult::error(format!(
                 "wrong dangling {} vs {}",
                 stake_distribution.dangling, dangling
             ));
         }
         if stake_distribution.total_stake() != pools {
-            return TestResult::error(&format!(
+            return TestResult::error(format!(
                 "wrong to_pools {} vs {}",
                 stake_distribution.total_stake(),
                 pools

--- a/src/chain-libs/chain-impl-mockchain/src/testing/arbitrary/update_proposal.rs
+++ b/src/chain-libs/chain-impl-mockchain/src/testing/arbitrary/update_proposal.rs
@@ -38,9 +38,7 @@ impl UpdateProposalData {
     }
 
     pub fn gen_votes(&self, proposal_id: UpdateProposalId) -> Vec<UpdateVote> {
-        self.voters
-            .iter()
-            .map(|(id, _)| UpdateVote::new(proposal_id, id.clone()))
+        self.voters.keys().map(|id| UpdateVote::new(proposal_id, id.clone()))
             .collect()
     }
 }

--- a/src/chain-libs/chain-impl-mockchain/src/testing/builders/vote.rs
+++ b/src/chain-libs/chain-impl-mockchain/src/testing/builders/vote.rs
@@ -38,7 +38,7 @@ pub fn decrypt_tally(
         })
         .unzip();
 
-    let tallies = batch_decrypt(&tallies).unwrap();
+    let tallies = batch_decrypt(tallies).unwrap();
 
     let proposals = shares
         .into_iter()

--- a/src/chain-libs/chain-impl-mockchain/src/testing/scenario/fragment_factory.rs
+++ b/src/chain-libs/chain-impl-mockchain/src/testing/scenario/fragment_factory.rs
@@ -111,7 +111,7 @@ impl FragmentFactory {
         from: &Wallet,
         distribution: &[(&StakePool, u8)],
     ) -> Fragment {
-        let pools_ratio_sum: u8 = distribution.iter().map(|(_st, ratio)| *ratio as u8).sum();
+        let pools_ratio_sum: u8 = distribution.iter().map(|(_st, ratio)| *ratio).sum();
         let pools: Vec<(PoolId, u8)> = distribution
             .iter()
             .map(|(st, ratio)| (st.info().to_id(), *ratio))

--- a/src/chain-libs/chain-impl-mockchain/src/utxo.rs
+++ b/src/chain-libs/chain-impl-mockchain/src/utxo.rs
@@ -360,7 +360,7 @@ mod tests {
         pub fn to_vec(&self) -> Vec<(TransactionIndex, Output<Address>)> {
             let mut outputs = Vec::with_capacity(self.utxos.len());
             for (key, value) in self.utxos.iter() {
-                outputs.push((*key as u8, value.clone()));
+                outputs.push((*key, value.clone()));
             }
             outputs
         }

--- a/src/chain-libs/chain-storage/src/lib.rs
+++ b/src/chain-libs/chain-storage/src/lib.rs
@@ -41,7 +41,7 @@
 //! __fig.1 - note that root does not actually exist, this is an ID referredby__
 //! __the first block in the chain__
 //!
-//! ```ignore
+//! ```text
 //! +---------+       +---------+
 //! |         |       |         |
 //! | Block 4 |       | Block 4'|
@@ -104,7 +104,7 @@
 //!
 //! __fig. 2 - permanent storage structure__
 //!
-//! ```ignore
+//! ```text
 //! store                  block no. index
 //!
 //! +--------------+       +-------------+
@@ -128,7 +128,7 @@
 //!
 //! # Storage directory layout
 //!
-//! ```ignore
+//! ```text
 //! store
 //! ├── permanent       - permanent storage directory
 //! │   └── flatfile    - storage file that can be transferred over the network

--- a/src/chain-libs/chain-time/src/era.rs
+++ b/src/chain-libs/chain-time/src/era.rs
@@ -30,7 +30,9 @@ pub struct EpochSlotOffset(pub u32);
     derive(test_strategy::Arbitrary)
 )]
 pub struct EpochPosition {
+    /// The base epoch
     pub epoch: Epoch,
+    /// The offset from `epoch`
     pub slot: EpochSlotOffset,
 }
 
@@ -53,6 +55,7 @@ pub struct TimeEra {
     slots_per_epoch: u32,
 }
 
+/// Write a [`TimeEra`] into a [`Codec`]
 pub fn pack_time_era<W: std::io::Write>(
     time_era: &TimeEra,
     codec: &mut Codec<W>,
@@ -63,6 +66,7 @@ pub fn pack_time_era<W: std::io::Write>(
     Ok(())
 }
 
+/// Read a [`TimeEra`] from a [`Codec`]
 pub fn unpack_time_era<R: std::io::BufRead>(codec: &mut Codec<R>) -> Result<TimeEra, ReadError> {
     let epoch_start = Epoch(codec.get_be_u32()?);
     let slot_start = Slot(codec.get_be_u64()?);

--- a/src/chain-libs/chain-time/src/lib.rs
+++ b/src/chain-libs/chain-time/src/lib.rs
@@ -1,3 +1,5 @@
+// #![warn(clippy::all)]
+// #![deny(missing_docs)]
 pub mod era;
 pub mod timeframe;
 pub mod timeline;
@@ -10,3 +12,4 @@ pub use units::DurationSeconds;
 
 #[cfg(any(test, feature = "property-test-api"))]
 pub mod testing;
+

--- a/src/chain-libs/chain-time/src/lib.rs
+++ b/src/chain-libs/chain-time/src/lib.rs
@@ -1,5 +1,8 @@
-// #![warn(clippy::all)]
-// #![deny(missing_docs)]
+//! Chain-time
+//!
+//! Utilities for working with time
+#![warn(clippy::all)]
+#![deny(missing_docs)]
 pub mod era;
 pub mod timeframe;
 pub mod timeline;
@@ -11,5 +14,5 @@ pub use timeline::{TimeOffsetSeconds, Timeline};
 pub use units::DurationSeconds;
 
 #[cfg(any(test, feature = "property-test-api"))]
+#[doc(hidden)]
 pub mod testing;
-

--- a/src/chain-libs/chain-time/src/timeframe.rs
+++ b/src/chain-libs/chain-time/src/timeframe.rs
@@ -1,4 +1,6 @@
-//! Timeframe
+//! Timeframes
+//!
+//! A [`TimeFrame`] represents a [`Timeline`] that is split into discrete slots
 //!
 
 use crate::timeline::Timeline;
@@ -30,6 +32,7 @@ impl From<Slot> for u64 {
 /// Identify a slot in a specific timeframe and a leftover duration
 #[derive(Debug)]
 pub struct SlotAndDuration {
+    /// The slot
     pub slot: Slot,
     /// The offset of a specific time frame in
     pub offset: Duration,
@@ -50,11 +53,17 @@ pub struct TimeFrame {
 pub struct SlotDuration(u64);
 
 impl SlotDuration {
+    /// Create a [`SlotDuration`] from a number of seconds
+    ///
+    /// # Panics
+    ///
+    /// Panics if `seconds >= 600`
     pub fn from_secs(seconds: u32) -> Self {
         assert!(seconds < 600);
         SlotDuration(seconds as u64)
     }
 
+    /// Convert this [`SlotDuration`] to a [`core::time::Duration`]
     pub fn to_duration(self) -> Duration {
         Duration::from_secs(self.0)
     }
@@ -106,8 +115,9 @@ impl TimeFrame {
         }
     }
 
+    /// The current slot offset
     pub fn slot0(&self) -> Slot {
-        Slot(self.slot_offset.0)
+        self.slot_offset
     }
 
     /// Given a system time get the slot and associated duration leftover

--- a/src/chain-libs/chain-time/src/timeframe.rs
+++ b/src/chain-libs/chain-time/src/timeframe.rs
@@ -1,3 +1,6 @@
+//! Timeframe
+//!
+
 use crate::timeline::Timeline;
 use std::time::{Duration, SystemTime};
 

--- a/src/chain-libs/chain-time/src/timeline.rs
+++ b/src/chain-libs/chain-time/src/timeline.rs
@@ -1,3 +1,6 @@
+//! Timeline
+//!
+//! A [`Timeline`] represents a frame of reference relative to a point in earth time
 use crate::units::DurationSeconds;
 use std::time::{Duration, SystemTime};
 

--- a/src/chain-libs/chain-time/src/units.rs
+++ b/src/chain-libs/chain-time/src/units.rs
@@ -1,3 +1,4 @@
+//! Units used for time calculations
 use std::time::Duration;
 
 /// Represent a Duration where the maximum precision is in the second

--- a/src/chain-libs/chain-vote/src/cryptography/zkps/unit_vector/zkp.rs
+++ b/src/chain-libs/chain-vote/src/cryptography/zkps/unit_vector/zkp.rs
@@ -316,7 +316,7 @@ fn powers_z_encs(
     index: usize,
     bit_size: u32,
 ) -> Scalar {
-    let idx = binrep(index, bit_size as u32);
+    let idx = binrep(index, bit_size);
 
     let multz = z.iter().enumerate().fold(Scalar::one(), |acc, (j, zwv)| {
         let m = if idx[j] {

--- a/src/chain-libs/chain-vote/src/lib.rs
+++ b/src/chain-libs/chain-vote/src/lib.rs
@@ -1,3 +1,5 @@
+
+
 #[macro_use]
 mod macros;
 pub mod committee;

--- a/src/chain-libs/chain-vote/src/lib.rs
+++ b/src/chain-libs/chain-vote/src/lib.rs
@@ -1,5 +1,3 @@
-
-
 #[macro_use]
 mod macros;
 pub mod committee;

--- a/src/chain-wallet-libs/bindings/wallet-core/src/wallet.rs
+++ b/src/chain-wallet-libs/bindings/wallet-core/src/wallet.rs
@@ -35,7 +35,7 @@ impl Wallet {
     /// Retrieve a wallet from a list of free keys used as utxo's
     ///
     /// You can also use this function to recover a wallet even after you have
-    /// transferred all the funds to the new format (see the [Self::convert] function).
+    /// transferred all the funds to the new format
     ///
     /// Parameters
     ///

--- a/src/chain-wallet-libs/chain-path-derivation/src/bip44.rs
+++ b/src/chain-wallet-libs/chain-path-derivation/src/bip44.rs
@@ -107,7 +107,7 @@ impl DerivationPath<Bip44<Root>> {
     /// use the same "model" of 5 derivation level but instead of starting with the
     /// bip44 Hard Derivation uses the `'1852` (`'0x073C`) derivation path.
     ///
-    /// see https://input-output-hk.github.io/adrestia/docs/key-concepts/hierarchical-deterministic-wallets/
+    /// see <https://input-output-hk.github.io/adrestia/docs/key-concepts/hierarchical-deterministic-wallets/>
     ///
     pub fn chimeric(&self) -> DerivationPath<Bip44<Purpose>> {
         let mut p = self.clone();

--- a/src/jormungandr/jcli/src/jcli_lib/utils/output_format.rs
+++ b/src/jormungandr/jcli/src/jcli_lib/utils/output_format.rs
@@ -8,7 +8,7 @@ use thiserror::Error;
 pub struct OutputFormat {
     /// Format of output data. Possible values: json, yaml.
     /// Any other value is treated as a custom format using values from output data structure.
-    /// Syntax is Go text template: https://golang.org/pkg/text/template/.
+    /// Syntax is Go text template: <https://golang.org/pkg/text/template/>.
     #[structopt(long = "output-format", default_value = "yaml", parse(from_str))]
     format: FormatVariant,
 }

--- a/src/jormungandr/jormungandr-lib/src/crypto/key.rs
+++ b/src/jormungandr/jormungandr-lib/src/crypto/key.rs
@@ -168,7 +168,7 @@ impl<A: AsymmetricPublicKey> Identifier<A> {
     /// encode the `Identifier` into an hexadecimal string
     ///
     /// While this is still a human readable format. it is lesser than
-    /// the output of [`to_bech32_str`] as it does not provide user input
+    /// the output of [`Self::to_bech32_str`] as it does not provide user input
     /// verification.
     ///
     /// `Display` implementation of `Identifier` provides the hexadecimal string support.

--- a/src/jormungandr/jormungandr-lib/src/interfaces/certificate.rs
+++ b/src/jormungandr/jormungandr-lib/src/interfaces/certificate.rs
@@ -356,7 +356,7 @@ impl Certificate {
         // jormungandr_lib::Certificate is only used in jcli so we don't
         Ok(bech32::encode(
             CERTIFICATE_HRP,
-            &bytes.to_base32(),
+            bytes.to_base32(),
             bech32::Variant::Bech32m,
         )?)
     }
@@ -382,7 +382,7 @@ impl SignedCertificate {
         let bytes = property::Serialize::serialize_as_vec(&self)?;
         Ok(bech32::encode(
             SIGNED_CERTIFICATE_HRP,
-            &bytes.to_base32(),
+            bytes.to_base32(),
             bech32::Variant::Bech32m,
         )?)
     }

--- a/src/jormungandr/jormungandr-lib/src/interfaces/evm_transaction.rs
+++ b/src/jormungandr/jormungandr-lib/src/interfaces/evm_transaction.rs
@@ -73,7 +73,7 @@ impl<'de> Deserialize<'de> for EvmTransaction {
     {
         if deserializer.is_human_readable() {
             let s = String::deserialize(deserializer)?;
-            let data = hex::decode(&s).map_err(<D::Error as serde::de::Error>::custom)?;
+            let data = hex::decode(s).map_err(<D::Error as serde::de::Error>::custom)?;
             Ok(Self(
                 evm::EvmTransaction::deserialize_from_slice(&mut Codec::new(data.as_slice()))
                     .map_err(<D::Error as serde::de::Error>::custom)?,

--- a/src/jormungandr/jormungandr-lib/src/interfaces/fragment.rs
+++ b/src/jormungandr/jormungandr-lib/src/interfaces/fragment.rs
@@ -41,7 +41,7 @@ impl<'de> Deserialize<'de> for FragmentDef {
     {
         let bytes = if deserializer.is_human_readable() {
             let h = String::deserialize(deserializer)?;
-            hex::decode(&h).map_err(serde::de::Error::custom)?
+            hex::decode(h).map_err(serde::de::Error::custom)?
         } else {
             Vec::<u8>::deserialize(deserializer)?
         };

--- a/src/jormungandr/jormungandr-lib/src/interfaces/mint_token.rs
+++ b/src/jormungandr/jormungandr-lib/src/interfaces/mint_token.rs
@@ -37,7 +37,7 @@ impl<'de> Deserialize<'de> for TokenName {
     {
         if deserializer.is_human_readable() {
             let s = String::deserialize(deserializer)?;
-            let data = hex::decode(&s).map_err(<D::Error as serde::de::Error>::custom)?;
+            let data = hex::decode(s).map_err(<D::Error as serde::de::Error>::custom)?;
             Ok(Self(
                 name::TokenName::try_from(data).map_err(<D::Error as serde::de::Error>::custom)?,
             ))

--- a/src/jormungandr/testing/hersir/src/builder/mod.rs
+++ b/src/jormungandr/testing/hersir/src/builder/mod.rs
@@ -127,7 +127,7 @@ impl NetworkBuilder {
                         alias: alias.clone(),
                         config: node_config,
                         secret: NodeSecret::default(),
-                        topology_secret: SigningKey::generate(&mut rand::thread_rng()),
+                        topology_secret: SigningKey::generate(rand::thread_rng()),
                         node_topology: node.clone(),
                     },
                 )
@@ -175,7 +175,7 @@ impl NetworkBuilder {
 }
 
 fn document(path: &Path, settings: &Settings) -> Result<(), Error> {
-    let file = std::fs::File::create(&path.join("initial_setup.dot"))?;
+    let file = std::fs::File::create(path.join("initial_setup.dot"))?;
 
     let dotifier = Dotifier;
     dotifier.dottify(settings, file)?;
@@ -184,7 +184,7 @@ fn document(path: &Path, settings: &Settings) -> Result<(), Error> {
         wallet.save_to(path)?;
     }
 
-    let file = std::fs::File::create(&path.join("genesis.yaml"))?;
+    let file = std::fs::File::create(path.join("genesis.yaml"))?;
     serde_yaml::to_writer(file, &settings.block0).unwrap();
 
     Ok(())

--- a/src/jormungandr/testing/hersir/src/builder/settings/wallet.rs
+++ b/src/jormungandr/testing/hersir/src/builder/settings/wallet.rs
@@ -29,7 +29,7 @@ impl Wallet {
     pub fn save_to<P: AsRef<Path>>(&self, dir: P) -> std::io::Result<()> {
         if let Some(inner) = &self.inner {
             let dir = dir.as_ref().join(self.template().id());
-            let file = std::fs::File::create(&dir)?;
+            let file = std::fs::File::create(dir)?;
             inner.save_to(file)
         } else {
             Ok(())

--- a/src/jormungandr/testing/hersir/src/controller/monitor/node/legacy.rs
+++ b/src/jormungandr/testing/hersir/src/controller/monitor/node/legacy.rs
@@ -129,7 +129,7 @@ impl LegacyNode {
         let reader = BufReader::new(stderr);
         for line_result in reader.lines() {
             let line = line_result.expect("failed to read a line from log output");
-            self.progress_bar.log_info(&line);
+            self.progress_bar.log_info(line);
         }
     }
 
@@ -149,7 +149,7 @@ impl LegacyNode {
     }
 
     fn progress_bar_failure(&self) {
-        self.progress_bar.finish_with_message(&format!(
+        self.progress_bar.finish_with_message(format!(
             "{} {} {}",
             *style::icons::jormungandr,
             style::binary.apply_to(self.alias()),
@@ -158,7 +158,7 @@ impl LegacyNode {
     }
 
     fn progress_bar_success(&self) {
-        self.progress_bar.finish_with_message(&format!(
+        self.progress_bar.finish_with_message(format!(
             "{} {} {}",
             *style::icons::jormungandr,
             style::binary.apply_to(self.alias()),

--- a/src/jormungandr/testing/hersir/src/controller/monitor/node/mod.rs
+++ b/src/jormungandr/testing/hersir/src/controller/monitor/node/mod.rs
@@ -267,7 +267,7 @@ impl Node {
         let reader = BufReader::new(stderr);
         for line_result in reader.lines() {
             let line = line_result.expect("failed to read a line from log output");
-            self.progress_bar.log_info(&line);
+            self.progress_bar.log_info(line);
         }
     }
 
@@ -287,7 +287,7 @@ impl Node {
     }
 
     fn progress_bar_failure(&self) {
-        self.progress_bar.finish_with_message(&format!(
+        self.progress_bar.finish_with_message(format!(
             "{} {} {}",
             *style::icons::jormungandr,
             style::binary.apply_to(self.alias()),
@@ -296,7 +296,7 @@ impl Node {
     }
 
     fn progress_bar_success(&self) {
-        self.progress_bar.finish_with_message(&format!(
+        self.progress_bar.finish_with_message(format!(
             "{} {} {}",
             *style::icons::jormungandr,
             style::binary.apply_to(self.alias()),

--- a/src/jormungandr/testing/jormungandr-automation/src/jcli/api/transaction.rs
+++ b/src/jormungandr/testing/jormungandr-automation/src/jcli/api/transaction.rs
@@ -311,7 +311,7 @@ impl Transaction {
 
     pub fn fragment_id<P: AsRef<Path>>(self, staging_file: P) -> Hash {
         let fragment_hex = self.convert_to_message(staging_file);
-        let fragment_bytes = hex::decode(&fragment_hex).expect("Failed to parse message hex");
+        let fragment_bytes = hex::decode(fragment_hex).expect("Failed to parse message hex");
         Fragment::deserialize_from_slice(&mut Codec::new(fragment_bytes.as_slice()))
             .expect("Failed to parse message")
             .hash()

--- a/src/jormungandr/testing/jormungandr-automation/src/jcli/services/fragment_check.rs
+++ b/src/jormungandr/testing/jormungandr-automation/src/jcli/services/fragment_check.rs
@@ -102,7 +102,7 @@ impl<'a> FragmentCheck<'a> {
                     .rest()
                     .v0()
                     .message()
-                    .logs(&self.jormungandr.rest_uri())
+                    .logs(self.jormungandr.rest_uri())
             ),
             transaction_id: Hash::from_hash(self.id),
             log_content: self.jormungandr.logger.get_log_content(),

--- a/src/jormungandr/testing/jormungandr-automation/src/jcli/services/transaction_builder.rs
+++ b/src/jormungandr/testing/jormungandr-automation/src/jcli/services/transaction_builder.rs
@@ -276,7 +276,7 @@ impl TransactionBuilder {
 
     pub fn fragment_id(&self) -> Hash {
         let fragment_hex = self.to_message();
-        let fragment_bytes = hex::decode(&fragment_hex).expect("Failed to parse message hex");
+        let fragment_bytes = hex::decode(fragment_hex).expect("Failed to parse message hex");
         Fragment::deserialize_from_slice(&mut Codec::new(fragment_bytes.as_slice()))
             .expect("Failed to parse message")
             .hash()

--- a/src/jormungandr/testing/jormungandr-automation/src/jormungandr/configuration/block0/block0_config_builder.rs
+++ b/src/jormungandr/testing/jormungandr-automation/src/jormungandr/configuration/block0/block0_config_builder.rs
@@ -113,7 +113,7 @@ impl Block0ConfigurationBuilder {
     }
 
     pub fn with_some_consensus_leader(self) -> Self {
-        let leader_key = KeyPair::generate(&mut rand::thread_rng());
+        let leader_key = KeyPair::generate(rand::thread_rng());
         self.with_leader_key_pair(&leader_key)
     }
 
@@ -309,11 +309,11 @@ impl Block0ConfigurationBuilder {
 }
 
 fn default_initial(discrimination: Discrimination) -> Vec<Initial> {
-    let sk1: SecretKey<Ed25519Extended> = SecretKey::generate(&mut ChaChaRng::from_seed([1; 32]));
+    let sk1: SecretKey<Ed25519Extended> = SecretKey::generate(ChaChaRng::from_seed([1; 32]));
     let pk1: PublicKey<Ed25519> = sk1.to_public();
     let initial_funds_address1 = ChainAddress(discrimination, Kind::Single(pk1));
 
-    let sk2: SecretKey<Ed25519Extended> = SecretKey::generate(&mut ChaChaRng::from_seed([2; 32]));
+    let sk2: SecretKey<Ed25519Extended> = SecretKey::generate(ChaChaRng::from_seed([2; 32]));
     let pk2: PublicKey<Ed25519> = sk2.to_public();
     let initial_funds_address2 = ChainAddress(discrimination, Kind::Single(pk2));
     let initial_funds = vec![Initial::Fund(vec![
@@ -330,8 +330,8 @@ fn default_initial(discrimination: Discrimination) -> Vec<Initial> {
 }
 
 fn default_leaders() -> Vec<ConsensusLeaderId> {
-    let leader_1: KeyPair<Ed25519Extended> = KeyPair::generate(&mut ChaChaRng::from_seed([1; 32]));
-    let leader_2: KeyPair<Ed25519Extended> = KeyPair::generate(&mut ChaChaRng::from_seed([2; 32]));
+    let leader_1: KeyPair<Ed25519Extended> = KeyPair::generate(ChaChaRng::from_seed([1; 32]));
+    let leader_2: KeyPair<Ed25519Extended> = KeyPair::generate(ChaChaRng::from_seed([2; 32]));
     let mut leaders: Vec<ConsensusLeaderId> = Vec::new();
     let leader_1_pk: ConsensusLeaderId = leader_1.0.public_key().clone().into();
     let leader_2_pk: ConsensusLeaderId = leader_2.0.public_key().clone().into();

--- a/src/jormungandr/testing/jormungandr-automation/src/jormungandr/configuration/node/manager.rs
+++ b/src/jormungandr/testing/jormungandr-automation/src/jormungandr/configuration/node/manager.rs
@@ -28,7 +28,7 @@ impl ConfigurableNodeConfig for NodeConfigManager {
     }
 
     fn write_node_config(&self) {
-        let mut output_file = File::create(&self.node_config_path()).unwrap();
+        let mut output_file = File::create(self.node_config_path()).unwrap();
         serde_yaml::to_writer(&mut output_file, &self.node_config)
             .expect("cannot serialize node config");
     }

--- a/src/jormungandr/testing/jormungandr-automation/src/jormungandr/grpc/server/data.rs
+++ b/src/jormungandr/testing/jormungandr-automation/src/jormungandr/grpc/server/data.rs
@@ -44,8 +44,8 @@ impl MockServerData {
         storage: BlockStore,
         invalid_get_blocks_hash: bool,
     ) -> Self {
-        let keypair = KeyPair::generate(&mut rand::thread_rng());
-        let topology_key = keynesis::key::ed25519::SecretKey::new(&mut rand::thread_rng());
+        let keypair = KeyPair::generate(rand::thread_rng());
+        let topology_key = keynesis::key::ed25519::SecretKey::new(rand::thread_rng());
         let profile = poldercast::Profile::new(addr, &topology_key);
         Self {
             genesis_hash,

--- a/src/jormungandr/testing/jormungandr-automation/src/jormungandr/legacy/mod.rs
+++ b/src/jormungandr/testing/jormungandr-automation/src/jormungandr/legacy/mod.rs
@@ -40,7 +40,7 @@ pub fn get_jormungandr_bin(release: &Release, temp_dir: &impl PathChild) -> Path
         .unwrap()
         .unwrap();
     let asset_name = asset.name();
-    let output = temp_dir.child(&asset_name);
+    let output = temp_dir.child(asset_name);
     asset
         .download_to(output.path())
         .expect("cannot download file");

--- a/src/jormungandr/testing/jormungandr-automation/src/jormungandr/rest/raw.rs
+++ b/src/jormungandr/testing/jormungandr-automation/src/jormungandr/rest/raw.rs
@@ -183,7 +183,7 @@ impl RawRest {
         let key = hex::encode(account::Identifier::from(pk.clone()).as_ref());
 
         let request = format!("votes/plan/account-votes/{}", key);
-        self.client.get(&self.path(ApiVersion::V1, &request)).send()
+        self.client.get(self.path(ApiVersion::V1, &request)).send()
     }
 
     pub fn account_votes_with_plan_id(
@@ -195,7 +195,7 @@ impl RawRest {
         let key = hex::encode(account::Identifier::from(pk.clone()).as_ref());
 
         let request = format!("votes/plan/{}/account-votes/{}", vote_plan_id, key);
-        self.client.get(&self.path(ApiVersion::V1, &request)).send()
+        self.client.get(self.path(ApiVersion::V1, &request)).send()
     }
 
     pub fn stake_distribution_at(&self, epoch: u32) -> Result<Response, reqwest::Error> {
@@ -205,7 +205,7 @@ impl RawRest {
 
     pub fn account_votes_all(&self) -> Result<Response, reqwest::Error> {
         self.client
-            .get(&self.path(ApiVersion::V1, "votes/plan/accounts-votes-all"))
+            .get(self.path(ApiVersion::V1, "votes/plan/accounts-votes-all"))
             .send()
     }
 
@@ -272,7 +272,7 @@ impl RawRest {
         body: Vec<u8>,
     ) -> Result<reqwest::blocking::Response, reqwest::Error> {
         self.client
-            .post(&self.path(ApiVersion::V0, path))
+            .post(self.path(ApiVersion::V0, path))
             .headers(self.construct_headers())
             .body(body)
             .send()
@@ -295,7 +295,7 @@ impl RawRest {
             .into_iter()
             .map(|body| {
                 self.client
-                    .post(&self.path(ApiVersion::V0, "message"))
+                    .post(self.path(ApiVersion::V0, "message"))
                     .headers(self.construct_headers())
                     .body(body)
             })
@@ -309,13 +309,13 @@ impl RawRest {
 
     pub fn fragments_logs(&self) -> Result<Response, reqwest::Error> {
         self.client
-            .get(&self.path(ApiVersion::V1, "fragments/logs"))
+            .get(self.path(ApiVersion::V1, "fragments/logs"))
             .send()
     }
 
     pub fn fragments_statuses(&self, ids: Vec<String>) -> Result<Response, reqwest::Error> {
         self.client
-            .get(&self.path(ApiVersion::V1, "fragments/statuses"))
+            .get(self.path(ApiVersion::V1, "fragments/statuses"))
             .query(&[("fragment_ids", ids.join(","))])
             .send()
     }
@@ -326,7 +326,7 @@ impl RawRest {
         fail_fast: bool,
     ) -> Result<Response, reqwest::Error> {
         self.client
-            .post(&self.path(ApiVersion::V1, "fragments"))
+            .post(self.path(ApiVersion::V1, "fragments"))
             .headers(self.construct_headers())
             .json(&FragmentsBatch {
                 fail_fast,

--- a/src/jormungandr/testing/jormungandr-automation/src/jormungandr/starter/mod.rs
+++ b/src/jormungandr/testing/jormungandr-automation/src/jormungandr/starter/mod.rs
@@ -212,7 +212,7 @@ impl Starter {
             comm,
             temp_dir,
             expected_msg_in_logs,
-            get_command(&params, &app, params.leadership()),
+            get_command(&params, app, params.leadership()),
         )
     }
 
@@ -224,7 +224,7 @@ impl Starter {
         self.configured_starter.start_async(
             comm,
             temp_dir,
-            get_command(&params, &app, params.leadership()),
+            get_command(&params, app, params.leadership()),
         )
     }
 

--- a/src/jormungandr/testing/jormungandr-automation/src/jormungandr/starter/params/builder.rs
+++ b/src/jormungandr/testing/jormungandr-automation/src/jormungandr/starter/params/builder.rs
@@ -154,5 +154,5 @@ impl JormungandrBootstrapper {
 }
 
 fn create_new_leader_key() -> KeyPair<Ed25519> {
-    KeyPair::generate(&mut rand::thread_rng())
+    KeyPair::generate(rand::thread_rng())
 }

--- a/src/jormungandr/testing/jormungandr-integration-tests/src/jcli/address/info.rs
+++ b/src/jormungandr/testing/jormungandr-integration-tests/src/jcli/address/info.rs
@@ -15,11 +15,11 @@ pub fn test_info_account_address() {
     let jcli: JCli = Default::default();
 
     let private_key = jcli.key().generate("ed25519Extended");
-    let public_key = jcli.key().convert_to_public_string(&private_key);
+    let public_key = jcli.key().convert_to_public_string(private_key);
     let account_address = jcli
         .address()
         .account(&public_key, None, Discrimination::Test);
-    let info = jcli.address().info(&account_address);
+    let info = jcli.address().info(account_address);
     assert_eq!(
         info.get("discrimination").unwrap(),
         "testing",
@@ -33,11 +33,11 @@ pub fn test_info_account_address_for_prod() {
     let jcli: JCli = Default::default();
 
     let private_key = jcli.key().generate("ed25519Extended");
-    let public_key = jcli.key().convert_to_public_string(&private_key);
+    let public_key = jcli.key().convert_to_public_string(private_key);
     let account_address = jcli
         .address()
         .account(&public_key, None, Discrimination::Production);
-    let info = jcli.address().info(&account_address);
+    let info = jcli.address().info(account_address);
     assert_eq!(
         info.get("discrimination").unwrap(),
         "production",
@@ -51,14 +51,14 @@ pub fn test_info_delegation_address() {
     let jcli: JCli = Default::default();
 
     let private_key = jcli.key().generate("ed25519Extended");
-    let public_key = jcli.key().convert_to_public_string(&private_key);
+    let public_key = jcli.key().convert_to_public_string(private_key);
 
     let private_key = jcli.key().generate("ed25519Extended");
-    let delegation_key = jcli.key().convert_to_public_string(&private_key);
+    let delegation_key = jcli.key().convert_to_public_string(private_key);
     let account_address =
         jcli.address()
             .delegation(&public_key, &delegation_key, Discrimination::Test);
-    let info = jcli.address().info(&account_address);
+    let info = jcli.address().info(account_address);
     assert_eq!(
         info.get("discrimination").unwrap(),
         "testing",

--- a/src/jormungandr/testing/jormungandr-integration-tests/src/jcli/certificate/e2e.rs
+++ b/src/jormungandr/testing/jormungandr-integration-tests/src/jcli/certificate/e2e.rs
@@ -25,7 +25,7 @@ pub fn test_create_and_sign_new_stake_delegation() {
     let stake_pool_id = jcli.certificate().stake_pool_id(input_file.path()).unwrap();
     let certificate = jcli
         .certificate()
-        .new_stake_delegation(&stake_pool_id, &owner.identifier().to_bech32_str());
+        .new_stake_delegation(stake_pool_id, owner.identifier().to_bech32_str());
 
     assert_ne!(certificate, "", "delegation cert is empty");
 

--- a/src/jormungandr/testing/jormungandr-integration-tests/src/jcli/key/to_public.rs
+++ b/src/jormungandr/testing/jormungandr-integration-tests/src/jcli/key/to_public.rs
@@ -30,6 +30,6 @@ pub fn test_key_to_public_invalid_chars_key() {
 pub fn test_private_key_to_public_key() {
     let jcli: JCli = Default::default();
     let private_key = jcli.key().generate("Ed25519Extended");
-    let public_key = jcli.key().convert_to_public_string(&private_key);
+    let public_key = jcli.key().convert_to_public_string(private_key);
     assert_ne!(public_key, "", "generated key is empty");
 }

--- a/src/jormungandr/testing/jormungandr-integration-tests/src/jcli/transaction/e2e.rs
+++ b/src/jormungandr/testing/jormungandr-integration-tests/src/jcli/transaction/e2e.rs
@@ -219,7 +219,7 @@ pub fn test_account_is_created_if_transaction_out_is_account() {
     jcli.rest()
         .v0()
         .utxo()
-        .assert_contains(&utxo, &jormungandr.rest_uri());
+        .assert_contains(&utxo, jormungandr.rest_uri());
 
     let transaction_message = jcli
         .transaction_builder(block0_config.to_block_hash())

--- a/src/jormungandr/testing/jormungandr-integration-tests/src/jormungandr/genesis/stake_pool.rs
+++ b/src/jormungandr/testing/jormungandr-integration-tests/src/jormungandr/genesis/stake_pool.rs
@@ -125,7 +125,7 @@ pub fn create_new_stake_pool(
     assert!(
         jcli.rest()
             .v0()
-            .stake_pools(&jormungandr.rest_uri())
+            .stake_pools(jormungandr.rest_uri())
             .contains(&stake_pool_id),
         "cannot find stake-pool certificate in blockchain"
     );
@@ -151,9 +151,9 @@ pub fn delegate_stake(
 
     let stake_pool_delegation = jcli
         .certificate()
-        .new_stake_delegation(stake_pool_id, &account.identifier().to_bech32_str());
+        .new_stake_delegation(stake_pool_id, account.identifier().to_bech32_str());
 
-    let settings = jcli.rest().v0().settings(&jormungandr.rest_uri());
+    let settings = jcli.rest().v0().settings(jormungandr.rest_uri());
     let fees: LinearFee = settings.fees;
     let fee_value: Value = (fees.certificate + fees.coefficient + fees.constant).into();
 
@@ -247,7 +247,7 @@ pub fn retire_stake_pool(
         !jcli
             .rest()
             .v0()
-            .stake_pools(&jormungandr.rest_uri())
+            .stake_pools(jormungandr.rest_uri())
             .contains(&stake_pool_id.to_owned()),
         "stake pool should not be listed among active stake pools"
     );

--- a/src/jormungandr/testing/jormungandr-integration-tests/src/jormungandr/tls.rs
+++ b/src/jormungandr/testing/jormungandr-integration-tests/src/jormungandr/tls.rs
@@ -33,6 +33,6 @@ pub fn test_rest_tls_config() {
 
     println!(
         "{:?}",
-        jormungandr.secure_rest(&ca_crt_file).stats().unwrap()
+        jormungandr.secure_rest(ca_crt_file).stats().unwrap()
     );
 }

--- a/src/jormungandr/testing/jormungandr-integration-tests/src/jormungandr/transactions.rs
+++ b/src/jormungandr/testing/jormungandr-integration-tests/src/jormungandr/transactions.rs
@@ -39,7 +39,7 @@ pub fn accounts_funds_are_updated_after_transaction() {
     let receiever_account_state_before = jcli
         .rest()
         .v0()
-        .account_stats(&receiver.address().to_string(), &jormungandr.rest_uri());
+        .account_stats(receiver.address().to_string(), jormungandr.rest_uri());
 
     let sender_value_before = sender_account_state_before.value();
     let receiver_value_before = receiever_account_state_before.value();
@@ -61,11 +61,11 @@ pub fn accounts_funds_are_updated_after_transaction() {
     let sender_account_state = jcli
         .rest()
         .v0()
-        .account_stats(sender.address().to_string(), &jormungandr.rest_uri());
+        .account_stats(sender.address().to_string(), jormungandr.rest_uri());
     let receiver_account_state = jcli
         .rest()
         .v0()
-        .account_stats(receiver.address().to_string(), &jormungandr.rest_uri());
+        .account_stats(receiver.address().to_string(), jormungandr.rest_uri());
 
     let sender_value_before_u64: u64 = (*sender_value_before).into();
     let receiver_value_before_u64: u64 = (*receiver_value_before).into();

--- a/src/jormungandr/testing/jormungandr-integration-tests/src/jormungandr/vit/public.rs
+++ b/src/jormungandr/testing/jormungandr-integration-tests/src/jormungandr/vit/public.rs
@@ -80,7 +80,7 @@ pub fn test_get_committee_id() {
         .rest()
         .v0()
         .vote()
-        .active_voting_committees(&jormungandr.rest_uri());
+        .active_voting_committees(jormungandr.rest_uri());
 
     assert_eq!(expected_committee_ids, actual_committee_ids);
 }

--- a/src/jormungandr/testing/jormungandr-integration-tests/src/startup.rs
+++ b/src/jormungandr/testing/jormungandr-integration-tests/src/startup.rs
@@ -206,7 +206,7 @@ pub fn create_new_utxo_address() -> Wallet {
 }
 
 pub fn create_new_leader_key() -> KeyPair<Ed25519> {
-    KeyPair::generate(&mut rand::thread_rng())
+    KeyPair::generate(rand::thread_rng())
 }
 
 pub fn create_new_account_address() -> Wallet {

--- a/src/jormungandr/testing/mjolnir/src/mjolnir_lib/bootstrap/mod.rs
+++ b/src/jormungandr/testing/mjolnir/src/mjolnir_lib/bootstrap/mod.rs
@@ -28,18 +28,18 @@ pub struct ClientLoadCommand {
     #[structopt(short = "a", long = "address")]
     pub address: String,
 
-    /// amount of delay [seconds] between sync attempts
+    /// amount of delay (in seconds) between sync attempts
     #[structopt(short = "p", long = "pace", default_value = "2")]
     pub pace: u64,
 
     #[structopt(short = "d", long = "storage")]
     pub initial_storage: Option<PathBuf>,
 
-    /// amount of delay [seconds] between sync attempts
+    /// amount of delay (in seconds) between sync attempts
     #[structopt(short = "r", long = "duration")]
     pub duration: Option<u64>,
 
-    /// amount of delay [seconds] between sync attempts
+    /// amount of delay (in seconds) between sync attempts
     #[structopt(short = "n", long = "iterations")]
     pub sync_iteration: Option<u32>,
 

--- a/src/jormungandr/testing/mjolnir/src/mjolnir_lib/bootstrap/scenario/duration.rs
+++ b/src/jormungandr/testing/mjolnir/src/mjolnir_lib/bootstrap/scenario/duration.rs
@@ -111,7 +111,7 @@ impl DurationBasedClientLoad {
 
         Ok(thread::spawn(move || {
             loop {
-                let benchmark = benchmark_speed(&storage_folder_name.clone())
+                let benchmark = benchmark_speed(storage_folder_name.clone())
                     .no_target()
                     .start();
                 let benchmark_result = Self::wait_for_bootstrap_phase_completed(

--- a/src/jormungandr/testing/mjolnir/src/mjolnir_lib/explorer.rs
+++ b/src/jormungandr/testing/mjolnir/src/mjolnir_lib/explorer.rs
@@ -24,7 +24,7 @@ pub struct ExplorerLoadCommand {
     #[structopt(short = "e", long = "endpoint")]
     pub endpoint: String,
 
-    /// Amount of delay [milliseconds] between sync attempts
+    /// Amount of delay (in milliseconds) between sync attempts
     #[structopt(long = "delay", default_value = "50")]
     pub delay: u64,
 

--- a/src/jormungandr/testing/mjolnir/src/mjolnir_lib/rest.rs
+++ b/src/jormungandr/testing/mjolnir/src/mjolnir_lib/rest.rs
@@ -24,11 +24,11 @@ pub struct RestLoadCommand {
     #[structopt(short = "e", long = "endpoint")]
     pub endpoint: String,
 
-    /// Amount of delay [milliseconds] between sync attempts
+    /// Amount of delay (in milliseconds) between sync attempts
     #[structopt(long = "delay", default_value = "50")]
     pub delay: u64,
 
-    /// Amount of delay [seconds] between sync attempts
+    /// Amount of delay (in seconds) between sync attempts
     #[structopt(short = "d", long = "duration")]
     pub duration: u64,
 

--- a/src/jormungandr/testing/thor/src/cli/config.rs
+++ b/src/jormungandr/testing/thor/src/cli/config.rs
@@ -146,7 +146,7 @@ impl ConfigManager {
         let config_file = self.config_file()?;
 
         if !config_file.exists() {
-            std::fs::create_dir_all(&app_dir)
+            std::fs::create_dir_all(app_dir)
                 .map_err(|_| Error::CannotCreateConfigFileFolder(config_file.to_path_buf()))?;
             let mut file = std::fs::File::create(&config_file)
                 .map_err(|_| Error::CannotCreateConfigFile(config_file.to_path_buf()))?;

--- a/src/jormungandr/testing/thor/src/fragment/export.rs
+++ b/src/jormungandr/testing/thor/src/fragment/export.rs
@@ -159,7 +159,7 @@ impl FragmentExporter {
         use chain_core::property::Serialize;
 
         let bytes = fragment.serialize_as_vec().unwrap();
-        hex::encode(&bytes)
+        hex::encode(bytes)
     }
 
     fn format_address(&self, address: Address) -> String {

--- a/src/jormungandr/testing/thor/src/fragment/mod.rs
+++ b/src/jormungandr/testing/thor/src/fragment/mod.rs
@@ -293,7 +293,7 @@ impl FragmentBuilder {
         let inner_wallet = wallet.clone().into();
         let vote_cast = VoteCast::new(
             vote_plan.to_id(),
-            proposal_index as u8,
+            proposal_index,
             Payload::public(*choice),
         );
         self.fragment_factory
@@ -333,7 +333,7 @@ impl FragmentBuilder {
 
         let vote_cast = VoteCast::new(
             vote_plan.to_id(),
-            proposal_index as u8,
+            proposal_index,
             Payload::Private {
                 encrypted_vote,
                 proof,

--- a/src/jormungandr/testing/thor/src/fragment/transaction_utils.rs
+++ b/src/jormungandr/testing/thor/src/fragment/transaction_utils.rs
@@ -8,6 +8,6 @@ pub trait TransactionHash {
 impl TransactionHash for Fragment {
     fn encode(&self) -> String {
         let bytes = self.serialize_as_vec().unwrap();
-        hex::encode(&bytes)
+        hex::encode(bytes)
     }
 }

--- a/src/jormungandr/testing/thor/src/wallet/committee/mod.rs
+++ b/src/jormungandr/testing/thor/src/wallet/committee/mod.rs
@@ -208,7 +208,7 @@ impl CommitteeDataManager {
                 (decrypt_shares, tally)
             })
             .unzip();
-        let tallies = batch_decrypt(&tallies).unwrap();
+        let tallies = batch_decrypt(tallies).unwrap();
 
         DecryptedPrivateTally::new(
             tallies

--- a/src/jortestkit/src/archive/mod.rs
+++ b/src/jortestkit/src/archive/mod.rs
@@ -42,7 +42,7 @@ pub fn decompress(input: &Path, output: &Path) -> Result<(), DecompressError> {
                 .ok_or_else(|| DecompressError::UnsafeFileName(file.name().to_owned()))?;
             let outpath = output.join(file_name);
             let mut outfile =
-                File::create(&outpath).map_err(DecompressError::CannotWriteOutputFile)?;
+                File::create(outpath).map_err(DecompressError::CannotWriteOutputFile)?;
             io::copy(&mut file, &mut outfile)?;
         }
         return Ok(());

--- a/src/jortestkit/src/github/mod.rs
+++ b/src/jortestkit/src/github/mod.rs
@@ -103,7 +103,7 @@ impl Asset {
     pub fn download_to(&self, path: &Path) -> Result<(), GitHubApiError> {
         download_file(self.download_url(), path)?;
         if let Some((checksum_type, asset)) = &self.checksum {
-            let checksum = reqwest::blocking::get(&asset.download_url())?;
+            let checksum = reqwest::blocking::get(asset.download_url())?;
             if !checksum_type.check(&hex::decode(checksum.text()?)?, path)? {
                 return Err(GitHubApiError::WrongChecksum);
             }
@@ -266,7 +266,7 @@ impl GitHubApi {
     fn get(&self, path: &str) -> Result<reqwest::blocking::Response, GitHubApiError> {
         let client = reqwest::blocking::Client::new();
         let mut req = client
-            .get(&format!("{}/{}", self.base_url, path))
+            .get(format!("{}/{}", self.base_url, path))
             .header(USER_AGENT, "request");
         if let Some(token) = &self.token {
             req = req.bearer_auth(token);

--- a/src/jortestkit/src/load/stats.rs
+++ b/src/jortestkit/src/load/stats.rs
@@ -21,7 +21,7 @@ impl Stats {
             .map(|r| r.duration().as_secs_f64())
             .sum();
 
-        total_duration / total_requests as f64
+        total_duration / total_requests
     }
 
     pub fn total_requests_made(&self) -> usize {

--- a/src/jortestkit/src/web/mod.rs
+++ b/src/jortestkit/src/web/mod.rs
@@ -17,7 +17,7 @@ pub enum WebError {
 }
 
 pub fn download_file(link: String, output: &Path) -> Result<(), WebError> {
-    let mut resp = reqwest::blocking::get(&link).map_err(WebError::CannotDownloadFile)?;
+    let mut resp = reqwest::blocking::get(link).map_err(WebError::CannotDownloadFile)?;
     let mut out = File::create(output.as_os_str()).map_err(|_| WebError::CannotCreateOutputFile)?;
     io::copy(&mut resp, &mut out)?;
     Ok(())

--- a/src/vit-servicing-station/vit-servicing-station-lib/src/lib.rs
+++ b/src/vit-servicing-station/vit-servicing-station-lib/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(opaque_hidden_inferred_bound)]
+
 #[macro_use]
 extern crate diesel;
 #[macro_use]

--- a/src/vit-servicing-station/vit-servicing-station-tests/src/common/data/generator/voting/template/external.rs
+++ b/src/vit-servicing-station/vit-servicing-station-tests/src/common/data/generator/voting/template/external.rs
@@ -63,24 +63,24 @@ impl ExternalValidVotingTemplateGenerator {
 }
 
 pub fn parse_proposals(proposals: PathBuf) -> Result<LinkedList<ProposalTemplate>, TemplateLoad> {
-    serde_json::from_str(&std::fs::read_to_string(&proposals)?)
+    serde_json::from_str(&std::fs::read_to_string(proposals)?)
         .map_err(|err| TemplateLoad::Proposal(err.to_string()))
 }
 
 pub fn parse_challenges(
     challenges: PathBuf,
 ) -> Result<LinkedList<ChallengeTemplate>, TemplateLoad> {
-    serde_json::from_str(&std::fs::read_to_string(&challenges)?)
+    serde_json::from_str(&std::fs::read_to_string(challenges)?)
         .map_err(|err| TemplateLoad::Challenge(err.to_string()))
 }
 
 pub fn parse_funds(funds: PathBuf) -> Result<LinkedList<FundTemplate>, TemplateLoad> {
-    serde_json::from_str(&std::fs::read_to_string(&funds)?)
+    serde_json::from_str(&std::fs::read_to_string(funds)?)
         .map_err(|err| TemplateLoad::Fund(err.to_string()))
 }
 
 pub fn parse_reviews(reviews: PathBuf) -> Result<LinkedList<ReviewTemplate>, TemplateLoad> {
-    serde_json::from_str(&std::fs::read_to_string(&reviews)?)
+    serde_json::from_str(&std::fs::read_to_string(reviews)?)
         .map_err(|err| TemplateLoad::Review(err.to_string()))
 }
 

--- a/src/vit-testing/iapyx/src/bin/load/burst/count.rs
+++ b/src/vit-testing/iapyx/src/bin/load/burst/count.rs
@@ -16,7 +16,7 @@ pub struct BurstCountIapyxLoadCommand {
     #[structopt(short = "a", long = "address", default_value = "127.0.0.1:8000")]
     pub address: String,
 
-    /// Amount of delay [miliseconds] between requests
+    /// Amount of delay (in miliseconds) between requests
     #[structopt(short = "d", long = "delay", default_value = "10000")]
     pub delay: u64,
 

--- a/src/vit-testing/iapyx/src/bin/load/burst/duration.rs
+++ b/src/vit-testing/iapyx/src/bin/load/burst/duration.rs
@@ -18,7 +18,7 @@ pub struct BurstDurationIapyxLoadCommand {
     #[structopt(short = "a", long = "address", default_value = "127.0.0.1:8000")]
     pub address: String,
 
-    /// Amount of delay [miliseconds] between requests
+    /// Amount of delay (in miliseconds) between requests
     #[structopt(short = "d", long = "delay", default_value = "10000")]
     pub delay: u64,
 

--- a/src/vit-testing/iapyx/src/bin/load/constant/count.rs
+++ b/src/vit-testing/iapyx/src/bin/load/constant/count.rs
@@ -19,7 +19,7 @@ pub struct ConstantCountIapyxLoadCommand {
     #[structopt(short = "a", long = "address", default_value = "127.0.0.1:8000")]
     pub address: String,
 
-    /// Amount of delay [miliseconds] between requests
+    /// Amount of delay (in miliseconds) between requests
     #[structopt(short = "d", long = "delay", default_value = "10000")]
     pub delay: u64,
 

--- a/src/vit-testing/iapyx/src/bin/load/constant/duration.rs
+++ b/src/vit-testing/iapyx/src/bin/load/constant/duration.rs
@@ -19,7 +19,7 @@ pub struct ConstDurationIapyxLoadCommand {
     #[structopt(short = "a", long = "address", default_value = "127.0.0.1:8000")]
     pub address: String,
 
-    /// Amount of delay [miliseconds] between requests
+    /// Amount of delay (in miliseconds) between requests
     #[structopt(short = "d", long = "delay", default_value = "10000")]
     pub delay: u64,
 

--- a/src/vit-testing/mainnet-lib/src/lib.rs
+++ b/src/vit-testing/mainnet-lib/src/lib.rs
@@ -1,6 +1,6 @@
 //! Rust implementation of Cardano various tools
 //!
-//! [`DbSyncInstance`] - mock of db sync based on json file rather than postgres db
+//! [`InMemoryDbSync`] - mock of db sync based on json file rather than postgres db
 //! Network - mock of cardano network in memory
 //! Wallet - api implementation of cardano wallet which is capable of sending and signing registration
 //! transactions

--- a/src/vit-testing/registration-service/src/rest.rs
+++ b/src/vit-testing/registration-service/src/rest.rs
@@ -179,7 +179,7 @@ pub async fn submit_transaction_handler(
     context_lock
         .cardano_cli_executor()
         .transaction()
-        .submit_from_bytes(bytes.to_vec(), &working_dir)?;
+        .submit_from_bytes(bytes.to_vec(), working_dir)?;
     Ok(warp::reply())
 }
 

--- a/src/vit-testing/registration-service/src/voter_registration/mod.rs
+++ b/src/vit-testing/registration-service/src/voter_registration/mod.rs
@@ -30,7 +30,7 @@ impl VoterRegistrationCli {
         slot: u64,
         metadata_path: Q,
     ) -> Result<(), Error> {
-        let mut command = Command::new(&self.path);
+        let mut command = Command::new(self.path);
         command
             .arg("--rewards-address")
             .arg(rewards_address.into())
@@ -58,7 +58,7 @@ impl VoterRegistrationCli {
         slot: u64,
         metadata_path: R,
     ) -> Result<(), Error> {
-        let mut command = Command::new(&self.path);
+        let mut command = Command::new(self.path);
 
         command.arg("--rewards-address").arg(rewards_address.into());
 

--- a/src/vit-testing/scheduler-service-lib/src/client/rest.rs
+++ b/src/vit-testing/scheduler-service-lib/src/client/rest.rs
@@ -75,7 +75,7 @@ impl SchedulerRestClient {
         let local_path = format!("api/job/files/get/{}", sub_location.into());
         let path = self.path(local_path);
         let client = reqwest::blocking::Client::new();
-        let request = self.set_header(client.get(&path));
+        let request = self.set_header(client.get(path));
         let bytes = request.send()?.bytes()?;
         let mut file = std::fs::File::create(&output)?;
         file.write_all(&bytes)?;
@@ -106,7 +106,7 @@ impl SchedulerRestClient {
     }
 
     pub fn is_up(&self) -> bool {
-        if let Ok(response) = reqwest::blocking::get(&self.path("api/health")) {
+        if let Ok(response) = reqwest::blocking::get(self.path("api/health")) {
             return response.status() == reqwest::StatusCode::OK;
         }
         false

--- a/src/vit-testing/scheduler-service-lib/src/lib.rs
+++ b/src/vit-testing/scheduler-service-lib/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(opaque_hidden_inferred_bound)]
 mod client;
 mod config;
 mod context;

--- a/src/vit-testing/snapshot-trigger-service/src/client/mod.rs
+++ b/src/vit-testing/snapshot-trigger-service/src/client/mod.rs
@@ -33,7 +33,7 @@ pub fn do_snapshot<S: Into<String>, P: Into<String>>(
 
     Ok(SnapshotResult {
         status: snapshot_jobs_status,
-        snapshot: read_initials(&snapshot)?,
+        snapshot: read_initials(snapshot)?,
     })
 }
 
@@ -52,7 +52,7 @@ pub fn get_snapshot_by_id<Q: Into<String>, S: Into<String>, P: Into<String>>(
 
     Ok(SnapshotResult {
         status,
-        snapshot: read_initials(&snapshot)?,
+        snapshot: read_initials(snapshot)?,
     })
 }
 
@@ -71,7 +71,7 @@ pub fn get_snapshot_from_history_by_id<Q: Into<String>, S: Into<String>, P: Into
 
     Ok(SnapshotResult {
         status,
-        snapshot: read_initials(&snapshot)?,
+        snapshot: read_initials(snapshot)?,
     })
 }
 

--- a/src/vit-testing/valgrind/src/client/proxy.rs
+++ b/src/vit-testing/valgrind/src/client/proxy.rs
@@ -36,7 +36,7 @@ impl ProxyClient {
     }
 
     pub fn health(&self) -> Result<(), Error> {
-        let status_code = reqwest::blocking::get(&self.path("health")).map(|r| r.status())?;
+        let status_code = reqwest::blocking::get(self.path("health")).map(|r| r.status())?;
 
         if status_code != StatusCode::OK {
             Err(Error::ServerIsNotUp(status_code))
@@ -46,7 +46,7 @@ impl ProxyClient {
     }
 
     pub fn block0(&self) -> Result<Vec<u8>, Error> {
-        let response = reqwest::blocking::get(&self.path("api/v0/block0"))?;
+        let response = reqwest::blocking::get(self.path("api/v0/block0"))?;
         self.print_response(&response);
         Ok(response.bytes()?.to_vec())
     }

--- a/src/vit-testing/vitup/src/builders/helpers/qr.rs
+++ b/src/vit-testing/vitup/src/builders/helpers/qr.rs
@@ -62,7 +62,7 @@ pub fn generate_qr_and_hashes<P: AsRef<Path>>(
             let sk = SecretKey::generate(rand::thread_rng());
             let qr = KeyQrCode::generate(sk.clone(), &pin_to_bytes(&zero_funds_pin));
             let img = qr.to_img();
-            let png = folder.join(&format!("zero_funds_{}_{}.png", i, zero_funds_pin));
+            let png = folder.join(format!("zero_funds_{}_{}.png", i, zero_funds_pin));
             trace!(
                 "[{}/{}] Qr code dumped to {:?}",
                 i + 1,

--- a/src/vit-testing/vitup/src/cli/generate/snapshot.rs
+++ b/src/vit-testing/vitup/src/cli/generate/snapshot.rs
@@ -80,7 +80,7 @@ impl SnapshotCommandArgs {
         let genesis_yaml = deployment_tree.genesis_path();
 
         //remove all files except qr codes and genesis
-        for entry in std::fs::read_dir(&deployment_tree.root_path())? {
+        for entry in std::fs::read_dir(deployment_tree.root_path())? {
             let entry = entry?;
             let md = std::fs::metadata(entry.path()).unwrap();
             if md.is_dir() {
@@ -119,7 +119,7 @@ impl SnapshotCommandArgs {
                 i += 1;
                 std::fs::rename(
                     path.clone(),
-                    std::path::Path::new(path.parent().unwrap()).join(&new_file_name),
+                    std::path::Path::new(path.parent().unwrap()).join(new_file_name),
                 )?;
             }
             println!("Qr codes dumped into {:?}", qr_codes);

--- a/src/vit-testing/vitup/src/cli/time.rs
+++ b/src/vit-testing/vitup/src/cli/time.rs
@@ -14,7 +14,7 @@ pub struct TimeCommand {
 impl TimeCommand {
     pub fn exec(self) -> Result<()> {
         std::env::set_var("RUST_BACKTRACE", "full");
-        read_config(&self.config)?.print_report(None);
+        read_config(self.config)?.print_report(None);
         Ok(())
     }
 }

--- a/src/vit-testing/vitup/src/cli/validate/ideascale.rs
+++ b/src/vit-testing/vitup/src/cli/validate/ideascale.rs
@@ -115,10 +115,10 @@ impl IdeascaleValidateCommand {
         std::env::set_var("RUST_BACKTRACE", "full");
         std::fs::create_dir_all(&self.output)?;
 
-        let proposals_path = self.input.join(&self.add_prefix("proposals.json"));
-        let funds_path = self.input.join(&self.add_prefix("funds.json"));
-        let challenges_path = self.input.join(&self.add_prefix("challenges.json"));
-        let reviews_path = self.input.join(&self.add_prefix("reviews.json"));
+        let proposals_path = self.input.join(self.add_prefix("proposals.json"));
+        let funds_path = self.input.join(self.add_prefix("funds.json"));
+        let challenges_path = self.input.join(self.add_prefix("challenges.json"));
+        let reviews_path = self.input.join(self.add_prefix("reviews.json"));
 
         let mut funds = parse_funds(funds_path.clone())?;
         let challenges = self.validate_challenges(

--- a/src/vit-testing/vitup/src/client/rest.rs
+++ b/src/vit-testing/vitup/src/client/rest.rs
@@ -10,7 +10,7 @@ pub struct VitupRest {
 
 impl VitupRest {
     pub fn is_up(&self) -> bool {
-        let response = reqwest::blocking::get(&self.path("api/health"));
+        let response = reqwest::blocking::get(self.path("api/health"));
 
         if response.is_err() {
             return false;
@@ -102,7 +102,7 @@ impl VitupDisruptionRestClient {
     pub fn reset_with_config(&self, config: &Config) -> Result<Response, Error> {
         let client = reqwest::blocking::Client::new();
         client
-            .post(&self.inner.path("api/control/command/reset"))
+            .post(self.inner.path("api/control/command/reset"))
             .json(&config)
             .send()
             .map_err(Into::into)
@@ -148,7 +148,7 @@ impl VitupDisruptionRestClient {
 
     pub fn is_up(&self) -> bool {
         if let Ok(path) = self.inner.get("api/health") {
-            if let Ok(response) = reqwest::blocking::get(&path) {
+            if let Ok(response) = reqwest::blocking::get(path) {
                 return response.status() == reqwest::StatusCode::OK;
             }
         }
@@ -177,7 +177,7 @@ impl VitupAdminRestClient {
     pub fn start_custom(&self, params: Config) -> Result<String, Error> {
         let path = self.inner.path("control/command/start/custom");
         let client = reqwest::blocking::Client::new();
-        let response = client.post(&path).json(&params).send()?;
+        let response = client.post(path).json(&params).send()?;
         Ok(response.text()?)
     }
 

--- a/src/vit-testing/vitup/src/config/initials/block0.rs
+++ b/src/vit-testing/vitup/src/config/initials/block0.rs
@@ -215,7 +215,7 @@ impl Initials {
                 role,
             } = initial
             {
-                let funds = *funds as u64;
+                let funds = *funds;
 
                 let mut tokens = HashMap::new();
                 tokens.insert(roles(role), funds);
@@ -256,7 +256,7 @@ impl Initials {
                         let value: u64 =
                             threshold + rand.gen_range(GRACE_VALUE..=threshold - GRACE_VALUE);
                         templates.insert(
-                            WalletTemplateBuilder::new(&wallet_alias)
+                            WalletTemplateBuilder::new(wallet_alias)
                                 .with(value)
                                 .with_token(roles(role), value)
                                 .discrimination(discrimination)
@@ -277,7 +277,7 @@ impl Initials {
                         let value: u64 =
                             threshold - rand.gen_range(GRACE_VALUE..=threshold - GRACE_VALUE);
                         templates.insert(
-                            WalletTemplateBuilder::new(&wallet_alias)
+                            WalletTemplateBuilder::new(wallet_alias)
                                 .with(value)
                                 .with_token(roles(role), value)
                                 .discrimination(discrimination)
@@ -294,9 +294,9 @@ impl Initials {
                 } => {
                     templates.insert(
                         WalletTemplateBuilder::new(name)
-                            .with(*funds as u64)
+                            .with(*funds)
                             .discrimination(discrimination)
-                            .with_token(roles(role), (*funds) as u64)
+                            .with_token(roles(role), *funds)
                             .build(),
                         pin.to_string(),
                     );
@@ -313,7 +313,7 @@ impl Initials {
                             format!("wallet_{}_around_{}", around_level_index, threshold);
                         let value: u64 = rand.gen_range(level - GRACE_VALUE..=level + GRACE_VALUE);
                         templates.insert(
-                            WalletTemplateBuilder::new(&wallet_alias)
+                            WalletTemplateBuilder::new(wallet_alias)
                                 .with(value)
                                 .discrimination(discrimination)
                                 .with_token(roles(role), value)

--- a/src/vit-testing/vitup/src/lib.rs
+++ b/src/vit-testing/vitup/src/lib.rs
@@ -1,5 +1,6 @@
 #![recursion_limit = "256"]
 #![allow(clippy::result_large_err)]
+#![allow(opaque_hidden_inferred_bound)]
 
 pub mod builders;
 pub mod cli;

--- a/src/vit-testing/vitup/src/mode/monitor/explorer.rs
+++ b/src/vit-testing/vitup/src/mode/monitor/explorer.rs
@@ -63,7 +63,7 @@ impl ExplorerMonitorController {
     }
     #[allow(dead_code)]
     fn progress_bar_failure(&self) {
-        self.progress_bar.finish_with_message(&format!(
+        self.progress_bar.finish_with_message(format!(
             "{} {} {}",
             *style::icons::jormungandr,
             style::binary.apply_to(self.alias()),
@@ -73,7 +73,7 @@ impl ExplorerMonitorController {
 
     #[allow(dead_code)]
     fn progress_bar_success(&self) {
-        self.progress_bar.finish_with_message(&format!(
+        self.progress_bar.finish_with_message(format!(
             "{} {} {}",
             *style::icons::jormungandr,
             style::binary.apply_to(self.alias()),

--- a/src/vit-testing/vitup/src/mode/monitor/vit_station.rs
+++ b/src/vit-testing/vitup/src/mode/monitor/vit_station.rs
@@ -63,7 +63,7 @@ impl VitStationMonitorController {
     }
     #[allow(dead_code)]
     fn progress_bar_failure(&self) {
-        self.progress_bar.finish_with_message(&format!(
+        self.progress_bar.finish_with_message(format!(
             "{} {} {}",
             *style::icons::jormungandr,
             style::binary.apply_to(self.alias()),
@@ -73,7 +73,7 @@ impl VitStationMonitorController {
 
     #[allow(dead_code)]
     fn progress_bar_success(&self) {
-        self.progress_bar.finish_with_message(&format!(
+        self.progress_bar.finish_with_message(format!(
             "{} {} {}",
             *style::icons::jormungandr,
             style::binary.apply_to(self.alias()),

--- a/src/vit-testing/vitup/src/mode/monitor/wallet.rs
+++ b/src/vit-testing/vitup/src/mode/monitor/wallet.rs
@@ -63,7 +63,7 @@ impl WalletProxyMonitorController {
 
     #[allow(dead_code)]
     fn progress_bar_failure(&self) {
-        self.progress_bar.finish_with_message(&format!(
+        self.progress_bar.finish_with_message(format!(
             "{} {} {}",
             *style::icons::jormungandr,
             style::binary.apply_to(self.alias()),
@@ -73,7 +73,7 @@ impl WalletProxyMonitorController {
 
     #[allow(dead_code)]
     fn progress_bar_success(&self) {
-        self.progress_bar.finish_with_message(&format!(
+        self.progress_bar.finish_with_message(format!(
             "{} {} {}",
             *style::icons::jormungandr,
             style::binary.apply_to(self.alias()),

--- a/src/vit-testing/vitup/src/mode/standard/controllers/main.rs
+++ b/src/vit-testing/vitup/src/mode/standard/controllers/main.rs
@@ -319,7 +319,7 @@ impl VitController {
         let working_directory = self.hersir_controller.working_directory();
 
         let dir = working_directory.child(alias);
-        std::fs::DirBuilder::new().recursive(true).create(&dir)?;
+        std::fs::DirBuilder::new().recursive(true).create(dir)?;
 
         settings_overriden.node_backend_address = Some(node_setting.config.rest.listen);
 

--- a/src/voting-tools-rs/src/bin/snapshot_tool.rs
+++ b/src/voting-tools-rs/src/bin/snapshot_tool.rs
@@ -56,7 +56,7 @@ fn get_data_provider(
     if let Some(dry_run) = maybe_dry_run {
         match dry_run {
             DryRunCommand::DryRun { mock_json_file } => Ok(Box::new(MockDbProvider::from(
-                InMemoryDbSync::restore(&mock_json_file)?,
+                InMemoryDbSync::restore(mock_json_file)?,
             ))),
         }
     } else {

--- a/src/voting-tools-rs/src/db/mod.rs
+++ b/src/voting-tools-rs/src/db/mod.rs
@@ -32,12 +32,6 @@ pub struct DbConfig {
 }
 
 /// Inner module to hide database internals from database code
-///
-/// Calls to the database are blocking, which blocks tokio. Instead, all calls should go through
-/// `exec`, which uses runs them on a thread pool with [`tokio::task::spawn_blocking`].
-///
-/// This module hides the inner connection pool from queries, so they cannot accidentally get a
-/// regular connection and block the executor
 mod inner {
     use super::DbConfig;
     use color_eyre::Result;
@@ -77,7 +71,7 @@ mod inner {
                 .unwrap_or_default();
 
             let url = format!("postgres://{user}{password}@{host}/{name}",);
-            let manager = ConnectionManager::new(&url);
+            let manager = ConnectionManager::new(url);
             let pool = Pool::new(manager)?;
 
             password.zeroize();

--- a/src/voting-tools-rs/src/logic.rs
+++ b/src/voting-tools-rs/src/logic.rs
@@ -88,7 +88,7 @@ pub(crate) fn get_stake_address(
         let cred = StakeCredential::from_keyhash(&pub_key.hash());
         let stake_addr = RewardAddress::new(network.network_id(), &cred).to_address();
         let stake_addr_bytes = stake_addr.to_bytes();
-        let stake_addr_bytes_hex = hex::encode(&stake_addr_bytes);
+        let stake_addr_bytes_hex = hex::encode(stake_addr_bytes);
         Ok(stake_addr_bytes_hex)
     }
 }
@@ -131,7 +131,7 @@ impl Reg {
                             delegation.trim_start_matches("0x"),
                         )?)
                         .map_err(|e| {
-                            eyre!(format!("cannot decode delegation key, due to: {}", e))
+                            eyre!(format!("cannot decode delegation key, due to: {e}"))
                         })?,
                     );
                     inner_metadata_list.add(&TransactionMetadatum::new_int(&Int::new(

--- a/src/voting-tools-rs/src/testing/test_api/fake.rs
+++ b/src/voting-tools-rs/src/testing/test_api/fake.rs
@@ -13,7 +13,7 @@ use mainnet_lib::{
 use std::collections::HashMap;
 use std::str::FromStr;
 
-/// Mock db provider based on [`DbSyncInstance`] struct from [`mainnet_lib`] project.
+/// Mock db provider based on [`InMemoryDbSync`] struct from [`mainnet_lib`] project.
 /// In essence struct keep data in memory and provides query for voting tools logic
 #[derive(Debug)]
 pub struct MockDbProvider {
@@ -45,8 +45,8 @@ impl DataProvider for MockDbProvider {
         let mut tx_id = 0;
 
         Ok(filtered_regs
-            .iter()
-            .map(|(_block0, registrations)| {
+            .values()
+            .map(|registrations| {
                 registrations
                     .iter()
                     .map(|r| {


### PR DESCRIPTION
Enables `#![deny(missing_docs)]` on `chain-time`, and fills in doc comments for all of the places where it was missing