### PR TITLE
build: set default devshell

### DIFF
--- a/nix/automation/devshells.nix
+++ b/nix/automation/devshells.nix
@@ -31,7 +31,7 @@
     ];
   };
 in
-  l.mapAttrs (_: std.lib.dev.mkShell) {
+  l.mapAttrs (_: std.lib.dev.mkShell) rec {
     dev = {...}: {
       imports = [
         catalystCore
@@ -42,4 +42,5 @@ in
         catalystCore
       ];
     };
+    default = dev;
   }


### PR DESCRIPTION
Enables `nix develop` to work as expected.