### PR TITLE
fix hex-encoded string conversion for chain_proposal_id

### DIFF
--- a/src/catalyst-toolbox/catalyst-toolbox/src/rewards/dreps.rs
+++ b/src/catalyst-toolbox/catalyst-toolbox/src/rewards/dreps.rs
@@ -167,11 +167,8 @@ mod tests {
         let voters = snapshot.to_full_snapshot_info();
 
         let snapshot = ArbitrarySnapshotGenerator::default().snapshot();
-        let mut proposals = snapshot.proposals();
-        // for some reasone they are base64 encoded and truncatin is just easier
-        for proposal in &mut proposals {
-            proposal.proposal.chain_proposal_id.truncate(32);
-        }
+        let proposals = snapshot.proposals();
+
         let proposals_by_challenge =
             proposals
                 .iter()
@@ -179,7 +176,10 @@ mod tests {
                     acc.entry(prop.proposal.challenge_id)
                         .or_default()
                         .push(Hash::from(
-                            <[u8; 32]>::try_from(prop.proposal.chain_proposal_id.clone()).unwrap(),
+                            crate::rewards::chain_proposal_id_bytes(
+                                &prop.proposal.chain_proposal_id,
+                            )
+                            .unwrap(),
                         ));
                     acc
                 });

--- a/src/catalyst-toolbox/catalyst-toolbox/src/rewards/mod.rs
+++ b/src/catalyst-toolbox/catalyst-toolbox/src/rewards/mod.rs
@@ -23,6 +23,21 @@ pub enum Error {
     InvalidHash(Vec<u8>),
 }
 
+/// Convert a slice of bytes that represent a valid `ExternalProposalId`, and returns an array of
+/// the decoded 32-byte array.
+pub(crate) fn chain_proposal_id_bytes(v: &[u8]) -> Result<[u8; 32], Error> {
+    // the chain_proposal_id comes as hex-encoded string digest of a blake2b256 key
+    // the first step is to decode the &str
+    let chain_proposal_str =
+        std::str::from_utf8(v).map_err(|_| Error::InvalidHash(v.to_owned()))?;
+    // second step is to convert &str into a digest so that it can be converted into
+    // [u8;32]
+    let chain_proposal_id = ExternalProposalId::from_str(chain_proposal_str)
+        .map_err(|_| Error::InvalidHash(v.to_owned()))?;
+    let bytes: [u8; 32] = chain_proposal_id.into();
+    Ok(bytes)
+}
+
 pub struct Threshold {
     total: usize,
     per_challenge: HashMap<i32, usize>,
@@ -38,15 +53,7 @@ impl Threshold {
         let proposals = proposals
             .into_iter()
             .map(|p| {
-                // the chain_proposal_id comes as hex-encoded string digest of a blake2b256 key
-                // the first step is to decode the &str
-                let chain_proposal_str = std::str::from_utf8(&p.proposal.chain_proposal_id)
-                    .map_err(|_| Error::InvalidHash(p.proposal.chain_proposal_id.clone()))?;
-                // second step is to convert &str into a digest so that it can be converted into
-                // [u8;32]
-                let chain_proposal_id = ExternalProposalId::from_str(chain_proposal_str)
-                    .map_err(|_| Error::InvalidHash(p.proposal.chain_proposal_id.clone()))?;
-                let bytes: [u8; 32] = chain_proposal_id.into();
+                let bytes = chain_proposal_id_bytes(&p.proposal.chain_proposal_id)?;
                 Ok((p.proposal.challenge_id, Hash::from(bytes)))
             })
             .collect::<Result<Vec<_>, Error>>()?;

--- a/src/catalyst-toolbox/catalyst-toolbox/src/rewards/voters.rs
+++ b/src/catalyst-toolbox/catalyst-toolbox/src/rewards/voters.rs
@@ -397,11 +397,8 @@ mod tests {
         let voters = snapshot.to_full_snapshot_info();
 
         let snapshot = ArbitrarySnapshotGenerator::default().snapshot();
-        let mut proposals = snapshot.proposals();
-        // for some reasone they are base64 encoded and truncatin is just easier
-        for proposal in &mut proposals {
-            proposal.proposal.chain_proposal_id.truncate(32);
-        }
+        let proposals = snapshot.proposals();
+
         let proposals_by_challenge =
             proposals
                 .iter()
@@ -409,7 +406,10 @@ mod tests {
                     acc.entry(prop.proposal.challenge_id)
                         .or_default()
                         .push(Hash::from(
-                            <[u8; 32]>::try_from(prop.proposal.chain_proposal_id.clone()).unwrap(),
+                            crate::rewards::chain_proposal_id_bytes(
+                                &prop.proposal.chain_proposal_id,
+                            )
+                            .unwrap(),
                         ));
                     acc
                 });

--- a/src/vit-servicing-station/vit-servicing-station-tests/src/common/data/generator/arbitrary/snapshot_generator.rs
+++ b/src/vit-servicing-station/vit-servicing-station-tests/src/common/data/generator/arbitrary/snapshot_generator.rs
@@ -1,6 +1,7 @@
 use crate::common::data::ArbitraryGenerator;
 use crate::common::data::ArbitraryValidVotingTemplateGenerator;
 use crate::common::data::{Snapshot, ValidVotingTemplateGenerator};
+use chain_impl_mockchain::certificate::ExternalProposalId;
 use std::collections::BTreeSet;
 use std::iter;
 use time::{Duration, OffsetDateTime};
@@ -129,6 +130,10 @@ impl ArbitrarySnapshotGenerator {
         let challenge_info = self
             .template_generator
             .proposals_challenge_info(&challenge.challenge_type);
+        let chain_proposal_id = ExternalProposalId::from(self.id_generator.bytes())
+            .to_string()
+            .as_bytes()
+            .to_vec();
         let proposal = Proposal {
             internal_id: id.abs(),
             proposal_id: id.abs().to_string(),
@@ -142,7 +147,7 @@ impl ArbitrarySnapshotGenerator {
             reviews_count: 0,
             proposal_files_url: proposal.files_url,
             proposer: self.template_generator.proposer(),
-            chain_proposal_id: self.id_generator.hash().as_bytes().to_vec(),
+            chain_proposal_id,
             chain_vote_options: proposal.chain_vote_options,
             chain_vote_start_time: voteplan.chain_vote_start_time,
             chain_vote_end_time: voteplan.chain_vote_end_time,


### PR DESCRIPTION
An issue for extracting the correct bytes from a hex-encoded string is resolved.

The fix was added to convert the 64-character hex-encoded digest of a Blake2b256 into the underlying 32-byte array used to define the `chain_proposal_id` field of the `FullProposalInfo` type.