### PR TITLE
do not install pre-commit hooks

### DIFF
--- a/nix/automation/configs.nix
+++ b/nix/automation/configs.nix
@@ -41,13 +41,13 @@ in {
       #     };
       #   };
       # };
-      pre-commit = {
-        commands = {
-          treefmt = {
-            run = "${nixpkgs.treefmt}/bin/treefmt --fail-on-change {staged_files}";
-          };
-        };
-      };
+      #pre-commit = {
+      #  commands = {
+      #    treefmt = {
+      #      run = "${nixpkgs.treefmt}/bin/treefmt --fail-on-change {staged_files}";
+      #    };
+      #  };
+      #};
     };
   };
   prettier =

--- a/nix/automation/configs.nix
+++ b/nix/automation/configs.nix
@@ -41,13 +41,13 @@ in {
       #     };
       #   };
       # };
-      #pre-commit = {
-      #  commands = {
-      #    treefmt = {
-      #      run = "${nixpkgs.treefmt}/bin/treefmt --fail-on-change {staged_files}";
-      #    };
-      #  };
-      #};
+      pre-commit = {
+        commands = {
+          treefmt = {
+            run = "${nixpkgs.treefmt}/bin/treefmt --fail-on-change {staged_files}";
+          };
+        };
+      };
     };
   };
   prettier =

--- a/nix/automation/devshells.nix
+++ b/nix/automation/devshells.nix
@@ -19,7 +19,7 @@
         PROTOC_INCLUDE = "${protobuf}/include";
       };
     nixago = [
-      cell.configs.lefthook
+      # cell.configs.lefthook
       cell.configs.prettier
       cell.configs.treefmt
     ];


### PR DESCRIPTION
Pre commit hooks get installed without warning when running a nix dev shell.  This has the effect of changing the development environment outside the dev shell.

The pre-commit hooks do not take into consideration the local developers environment or tooling, such as IDE of choice.  Also, the pre-commit hooks assume tooling which may only be present inside the dev shell.  This can lead to an inability to commit and interferes with local development.

This patch removes that, so that running the dev shell does not change the development environment outside the dev shell.