### PR TITLE
Refactor SpendingCounter, replace Vec usage with array

### DIFF
--- a/src/chain-libs/chain-impl-mockchain/src/account.rs
+++ b/src/chain-libs/chain-impl-mockchain/src/account.rs
@@ -8,7 +8,9 @@ use chain_core::{
 };
 use chain_crypto::{Ed25519, PublicKey, Signature};
 
-pub use account::{DelegationRatio, DelegationType, LedgerError, SpendingCounter};
+pub use account::{
+    DelegationRatio, DelegationType, LedgerError, SpendingCounter, SpendingCounterIncreasing,
+};
 
 pub type AccountAlg = Ed25519;
 

--- a/src/chain-libs/chain-impl-mockchain/src/accounting/account/spending.rs
+++ b/src/chain-libs/chain-impl-mockchain/src/accounting/account/spending.rs
@@ -51,7 +51,7 @@ impl SpendingCounterIncreasing {
     }
 
     pub fn get_valid_counters(&self) -> [SpendingCounter; Self::LANES] {
-        self.nexts.clone()
+        self.nexts
     }
 
     /// try to match the lane of the counter in argument, if it doesn't match

--- a/src/chain-libs/chain-impl-mockchain/src/accounting/account/spending.rs
+++ b/src/chain-libs/chain-impl-mockchain/src/accounting/account/spending.rs
@@ -6,6 +6,8 @@ pub enum Error {
         expected: SpendingCounter,
         actual: SpendingCounter,
     },
+    #[error("Invalid lane value during the SpendingCountersIncreasingInitialization, expected: {0}, got: {1}")]
+    InvalidLaneValue(usize, usize),
     #[error("Invalid lane: {0} or counter: {1}, expected lane < (1 << LANES_BITS), counter < (1 << UNLANES_BITS)")]
     InvalidLaneOrCounter(usize, u32),
 }
@@ -13,7 +15,7 @@ pub enum Error {
 /// Simple strategy to spend from multiple increasing counters
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SpendingCounterIncreasing {
-    nexts: Vec<SpendingCounter>,
+    nexts: [SpendingCounter; Self::LANES],
 }
 
 // SpendingCounterIncreasing has extra invariants (e.g. nexts has 8 elements, each belongs to a different lane), so a derived implementation is not suitable
@@ -33,24 +35,22 @@ impl SpendingCounterIncreasing {
         x
     }
 
-    pub fn new_from_counters(set: Vec<SpendingCounter>) -> Option<Self> {
-        if set.len() == Self::LANES {
-            for (i, i_set_value) in set.iter().enumerate() {
-                if i_set_value.lane() != i {
-                    return None;
-                }
+    pub fn new_from_counters(
+        nexts: [SpendingCounter; SpendingCounterIncreasing::LANES],
+    ) -> Result<Self, Error> {
+        for (i, i_set_value) in nexts.iter().enumerate() {
+            if i_set_value.lane() != i {
+                return Err(Error::InvalidLaneValue(i, i_set_value.lane()));
             }
-            Some(SpendingCounterIncreasing { nexts: set })
-        } else {
-            None
         }
+        Ok(SpendingCounterIncreasing { nexts })
     }
 
     pub fn get_valid_counter(&self) -> SpendingCounter {
         self.nexts[0]
     }
 
-    pub fn get_valid_counters(&self) -> Vec<SpendingCounter> {
+    pub fn get_valid_counters(&self) -> [SpendingCounter; Self::LANES] {
         self.nexts.clone()
     }
 
@@ -85,10 +85,16 @@ impl std::fmt::Display for SpendingCounterIncreasing {
 
 impl Default for SpendingCounterIncreasing {
     fn default() -> Self {
-        let mut nexts = Vec::new();
-        for i in 0..Self::LANES {
-            nexts.push(SpendingCounter::new(i, 0).unwrap());
-        }
+        let nexts = [
+            SpendingCounter::new(0, 0).unwrap(),
+            SpendingCounter::new(1, 0).unwrap(),
+            SpendingCounter::new(2, 0).unwrap(),
+            SpendingCounter::new(3, 0).unwrap(),
+            SpendingCounter::new(4, 0).unwrap(),
+            SpendingCounter::new(5, 0).unwrap(),
+            SpendingCounter::new(6, 0).unwrap(),
+            SpendingCounter::new(7, 0).unwrap(),
+        ];
         SpendingCounterIncreasing { nexts }
     }
 }
@@ -107,7 +113,7 @@ impl Default for SpendingCounterIncreasing {
     any(test, feature = "property-test-api"),
     derive(test_strategy::Arbitrary)
 )]
-pub struct SpendingCounter(pub(crate) u32);
+pub struct SpendingCounter(u32);
 
 impl SpendingCounter {
     // on 32 bits: 0x1fff_ffff;
@@ -254,25 +260,32 @@ mod tests {
 
     #[test]
     pub fn spending_counters_duplication() {
-        let counters = vec![SpendingCounter::zero(), SpendingCounter::zero()];
-        assert!(SpendingCounterIncreasing::new_from_counters(counters).is_none());
+        let counters = [
+            SpendingCounter::zero(),
+            SpendingCounter::zero(),
+            SpendingCounter::new(2, 0).unwrap(),
+            SpendingCounter::new(3, 0).unwrap(),
+            SpendingCounter::new(4, 0).unwrap(),
+            SpendingCounter::new(5, 0).unwrap(),
+            SpendingCounter::new(6, 0).unwrap(),
+            SpendingCounter::new(7, 0).unwrap(),
+        ];
+        assert!(SpendingCounterIncreasing::new_from_counters(counters).is_err());
     }
 
     #[test]
     pub fn spending_counters_incorrect_order() {
-        let counters = vec![
+        let counters = [
             SpendingCounter::new(1, 0).unwrap(),
             SpendingCounter::new(0, 0).unwrap(),
+            SpendingCounter::new(2, 0).unwrap(),
+            SpendingCounter::new(3, 0).unwrap(),
+            SpendingCounter::new(4, 0).unwrap(),
+            SpendingCounter::new(5, 0).unwrap(),
+            SpendingCounter::new(6, 0).unwrap(),
+            SpendingCounter::new(7, 0).unwrap(),
         ];
-        assert!(SpendingCounterIncreasing::new_from_counters(counters).is_none());
-    }
-
-    #[test]
-    pub fn spending_counters_too_many_sub_counters() {
-        let counters = std::iter::from_fn(|| Some(SpendingCounter::zero()))
-            .take(SpendingCounterIncreasing::LANES + 1)
-            .collect();
-        assert!(SpendingCounterIncreasing::new_from_counters(counters).is_none());
+        assert!(SpendingCounterIncreasing::new_from_counters(counters).is_err());
     }
 
     #[quickcheck_macros::quickcheck]
@@ -315,8 +328,8 @@ mod tests {
                     any::<SpendingCounter>()
                         .prop_map(|counter| Some(Self::new_from_counter(counter)))
                         .boxed(),
-                    any::<Vec<SpendingCounter>>()
-                        .prop_map(Self::new_from_counters)
+                    any::<[SpendingCounter; SpendingCounterIncreasing::LANES]>()
+                        .prop_map(|counters| Self::new_from_counters(counters).ok())
                         .boxed(),
                 ]
                 .prop_filter_map("must be valid spending counter set", |i| i)

--- a/src/chain-libs/chain-impl-mockchain/src/ledger/recovery.rs
+++ b/src/chain-libs/chain-impl-mockchain/src/ledger/recovery.rs
@@ -38,8 +38,7 @@
 use super::pots;
 use super::{Entry, EntryOwned};
 use crate::accounting::account::{
-    AccountState, DelegationRatio, DelegationType, LastRewards, SpendingCounter,
-    SpendingCounterIncreasing,
+    AccountState, DelegationRatio, DelegationType, LastRewards, SpendingCounterIncreasing,
 };
 use crate::certificate::{
     PoolId, PoolRegistration, Proposal, Proposals, UpdateProposal, UpdateProposalId, UpdateVoterId,
@@ -161,19 +160,18 @@ fn pack_spending_strategy<W: std::io::Write>(
 fn unpack_spending_strategy(
     codec: &mut Codec<&[u8]>,
 ) -> Result<SpendingCounterIncreasing, ReadError> {
-    let mut counters = Vec::new();
-    for _ in 0..SpendingCounterIncreasing::LANES {
-        let counter = SpendingCounter(codec.get_be_u32()?);
-        counters.push(counter);
-    }
-    let got_length = counters.len();
-    SpendingCounterIncreasing::new_from_counters(counters).ok_or_else(|| {
-        ReadError::InvalidData(format!(
-            "wrong numbers of lanes, expecting {} but got {}",
-            SpendingCounterIncreasing::LANES,
-            got_length,
-        ))
-    })
+    let counters = [
+        codec.get_be_u32()?.into(),
+        codec.get_be_u32()?.into(),
+        codec.get_be_u32()?.into(),
+        codec.get_be_u32()?.into(),
+        codec.get_be_u32()?.into(),
+        codec.get_be_u32()?.into(),
+        codec.get_be_u32()?.into(),
+        codec.get_be_u32()?.into(),
+    ];
+    SpendingCounterIncreasing::new_from_counters(counters)
+        .map_err(|e| ReadError::InvalidData(e.to_string()))
 }
 
 #[cfg(feature = "evm")]

--- a/src/chain-wallet-libs/bindings/wallet-core/src/wallet.rs
+++ b/src/chain-wallet-libs/bindings/wallet-core/src/wallet.rs
@@ -2,7 +2,7 @@ use crate::{Error, Proposal};
 use chain_core::property::Serialize as _;
 use chain_crypto::SecretKey;
 use chain_impl_mockchain::{
-    account::SpendingCounter,
+    account::SpendingCounterIncreasing,
     block::BlockDate,
     certificate::Certificate,
     fragment::{Fragment, FragmentId},
@@ -62,12 +62,18 @@ impl Wallet {
 
     /// get the current spending counter
     ///
-    pub fn spending_counter(&self) -> Vec<u32> {
-        self.account
-            .spending_counter()
-            .into_iter()
-            .map(SpendingCounter::into)
-            .collect()
+    pub fn spending_counter(&self) -> [u32; SpendingCounterIncreasing::LANES] {
+        let spending_counters = self.account.spending_counter();
+        [
+            spending_counters[0].into(),
+            spending_counters[1].into(),
+            spending_counters[2].into(),
+            spending_counters[3].into(),
+            spending_counters[4].into(),
+            spending_counters[5].into(),
+            spending_counters[6].into(),
+            spending_counters[7].into(),
+        ]
     }
 
     /// get the total value in the wallet
@@ -92,11 +98,24 @@ impl Wallet {
     /// before doing any transactions, otherwise future transactions may fail
     /// to be accepted by the blockchain nodes because of an invalid witness
     /// signature.
-    pub fn set_state(&mut self, value: Value, counters: Vec<u32>) -> Result<(), Error> {
+    pub fn set_state(
+        &mut self,
+        value: Value,
+        counters: [u32; SpendingCounterIncreasing::LANES],
+    ) -> Result<(), Error> {
         self.account
             .set_state(
                 value,
-                counters.into_iter().map(SpendingCounter::from).collect(),
+                [
+                    counters[0].into(),
+                    counters[1].into(),
+                    counters[2].into(),
+                    counters[3].into(),
+                    counters[4].into(),
+                    counters[5].into(),
+                    counters[6].into(),
+                    counters[7].into(),
+                ],
             )
             .map_err(|_| Error::invalid_spending_counters())
     }

--- a/src/chain-wallet-libs/wallet/src/account.rs
+++ b/src/chain-wallet-libs/wallet/src/account.rs
@@ -2,7 +2,7 @@ use super::transaction::AccountWitnessBuilder;
 use crate::scheme::{on_tx_input_and_witnesses, on_tx_output};
 use crate::states::States;
 use chain_crypto::{Ed25519, Ed25519Extended, PublicKey, SecretKey};
-use chain_impl_mockchain::accounting::account::SpendingCounterIncreasing;
+use chain_impl_mockchain::accounting::account::{spending, SpendingCounterIncreasing};
 use chain_impl_mockchain::{
     account::SpendingCounter,
     fragment::{Fragment, FragmentId},
@@ -41,6 +41,8 @@ pub enum Error {
     MalformedSpendingCounters,
     #[error("spending counter does not match current state")]
     NonMonotonicSpendingCounter,
+    #[error(transparent)]
+    SpendingCountersError(#[from] spending::Error),
 }
 
 pub enum EitherAccount {
@@ -109,16 +111,19 @@ impl Wallet {
     ///
     /// TODO: change to a constructor/initializator?, or just make it so it resets the state
     ///
-    pub fn set_state(&mut self, value: Value, counters: Vec<SpendingCounter>) -> Result<(), Error> {
-        let counters = SpendingCounterIncreasing::new_from_counters(counters)
-            .ok_or(Error::MalformedSpendingCounters)?;
+    pub fn set_state(
+        &mut self,
+        value: Value,
+        counters: [SpendingCounter; SpendingCounterIncreasing::LANES],
+    ) -> Result<(), Error> {
+        let counters = SpendingCounterIncreasing::new_from_counters(counters)?;
 
         self.state = States::new(FragmentId::zero_hash(), State { value, counters });
 
         Ok(())
     }
 
-    pub fn spending_counter(&self) -> Vec<SpendingCounter> {
+    pub fn spending_counter(&self) -> [SpendingCounter; SpendingCounterIncreasing::LANES] {
         self.state
             .last_state()
             .state()

--- a/src/chain-wallet-libs/wallet/src/account.rs
+++ b/src/chain-wallet-libs/wallet/src/account.rs
@@ -37,12 +37,10 @@ pub enum Error {
     NotEnoughFunds { current: Value, needed: Value },
     #[error("invalid lane for spending counter")]
     InvalidLane,
-    #[error("malformed spending counters")]
-    MalformedSpendingCounters,
     #[error("spending counter does not match current state")]
     NonMonotonicSpendingCounter,
     #[error(transparent)]
-    SpendingCountersError(#[from] spending::Error),
+    SpendingCounters(#[from] spending::Error),
 }
 
 pub enum EitherAccount {

--- a/src/chain-wallet-libs/wallet/tests/account.rs
+++ b/src/chain-wallet-libs/wallet/tests/account.rs
@@ -4,7 +4,6 @@ use self::utils::State;
 use chain_crypto::SecretKey;
 use chain_impl_mockchain::{
     account::SpendingCounter,
-    accounting::account::SpendingCounterIncreasing,
     certificate::VoteCast,
     fragment::Fragment,
     value::Value,
@@ -30,9 +29,16 @@ fn update_state_overrides_old() {
     account
         .set_state(
             Value(110),
-            (0..SpendingCounterIncreasing::LANES)
-                .map(|lane| SpendingCounter::new(lane, 1).unwrap())
-                .collect(),
+            [
+                SpendingCounter::new(0, 1).unwrap(),
+                SpendingCounter::new(1, 1).unwrap(),
+                SpendingCounter::new(2, 1).unwrap(),
+                SpendingCounter::new(3, 1).unwrap(),
+                SpendingCounter::new(4, 1).unwrap(),
+                SpendingCounter::new(5, 1).unwrap(),
+                SpendingCounter::new(6, 1).unwrap(),
+                SpendingCounter::new(7, 1).unwrap(),
+            ],
         )
         .unwrap();
 

--- a/src/jormungandr/jormungandr-lib/src/interfaces/account_state.rs
+++ b/src/jormungandr/jormungandr-lib/src/interfaces/account_state.rs
@@ -115,7 +115,7 @@ impl AccountState {
     ///
     #[inline]
     pub fn counters(&self) -> [u32; SpendingCounterIncreasing::LANES] {
-        self.counters.clone()
+        self.counters
     }
 
     /// the last rewards transfered to account

--- a/src/jormungandr/jormungandr-lib/src/interfaces/account_state.rs
+++ b/src/jormungandr/jormungandr-lib/src/interfaces/account_state.rs
@@ -1,6 +1,6 @@
 use super::mint_token::TokenIdentifier;
 use crate::{crypto::hash::Hash, interfaces::Value};
-use chain_impl_mockchain::{accounting::account, block::Epoch};
+use chain_impl_mockchain::{account::SpendingCounterIncreasing, accounting::account, block::Epoch};
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, convert::TryInto};
 
@@ -88,7 +88,7 @@ impl LastRewards {
 pub struct AccountState {
     delegation: DelegationType,
     value: Value,
-    counters: Vec<u32>,
+    counters: [u32; SpendingCounterIncreasing::LANES],
     tokens: BTreeMap<TokenIdentifier, Value>,
     last_rewards: LastRewards,
 }
@@ -114,7 +114,7 @@ impl AccountState {
     /// when adding a new account input to a transaction.
     ///
     #[inline]
-    pub fn counters(&self) -> Vec<u32> {
+    pub fn counters(&self) -> [u32; SpendingCounterIncreasing::LANES] {
         self.counters.clone()
     }
 
@@ -153,15 +153,20 @@ impl From<LastRewards> for account::LastRewards {
 
 impl<E> From<account::AccountState<E>> for AccountState {
     fn from(account: account::AccountState<E>) -> Self {
+        let counters = account.spending.get_valid_counters();
         AccountState {
             delegation: account.delegation().clone().into(),
             value: account.value().into(),
-            counters: account
-                .spending
-                .get_valid_counters()
-                .into_iter()
-                .map(Into::into)
-                .collect(),
+            counters: [
+                counters[0].into(),
+                counters[1].into(),
+                counters[2].into(),
+                counters[3].into(),
+                counters[4].into(),
+                counters[5].into(),
+                counters[6].into(),
+                counters[7].into(),
+            ],
             tokens: account
                 .tokens
                 .iter()
@@ -179,15 +184,20 @@ impl<E> From<account::AccountState<E>> for AccountState {
 
 impl<'a, E> From<&'a account::AccountState<E>> for AccountState {
     fn from(account: &'a account::AccountState<E>) -> Self {
+        let counters = account.spending.get_valid_counters();
         AccountState {
             delegation: account.delegation().clone().into(),
             value: account.value().into(),
-            counters: account
-                .spending
-                .get_valid_counters()
-                .into_iter()
-                .map(Into::into)
-                .collect(),
+            counters: [
+                counters[0].into(),
+                counters[1].into(),
+                counters[2].into(),
+                counters[3].into(),
+                counters[4].into(),
+                counters[5].into(),
+                counters[6].into(),
+                counters[7].into(),
+            ],
             tokens: account
                 .tokens
                 .iter()

--- a/src/jormungandr/testing/thor/src/cli/config.rs
+++ b/src/jormungandr/testing/thor/src/cli/config.rs
@@ -1,7 +1,7 @@
 use crate::wallet::discrimination::DiscriminationExtension;
 use chain_addr::{Address, AddressReadable, Discrimination, Kind};
 use chain_crypto::{bech32::Bech32, Ed25519, PublicKey};
-use chain_impl_mockchain::account::Identifier;
+use chain_impl_mockchain::account::{Identifier, SpendingCounterIncreasing};
 use jormungandr_automation::jormungandr::{JormungandrRest, RestSettings};
 use jormungandr_lib::crypto::hash::Hash;
 use serde::{Deserialize, Serialize};
@@ -77,7 +77,7 @@ pub struct Wallets {
 pub struct WalletState {
     pub pending_tx: Vec<Hash>,
     pub public_key: String,
-    pub spending_counters: Vec<u32>,
+    pub spending_counters: [u32; SpendingCounterIncreasing::LANES],
     //path to secret key in format of SecretKey struct
     pub secret_file: PathBuf,
     pub testing: bool,

--- a/src/jormungandr/testing/thor/src/cli/controller.rs
+++ b/src/jormungandr/testing/thor/src/cli/controller.rs
@@ -93,15 +93,16 @@ impl CliController {
         Ok(Wallet::Account(
             crate::wallet::account::Wallet::from_secret_key(
                 self.secret_key_for_wallet_state(password, &template)?,
-                SpendingCounterIncreasing::new_from_counters(
-                    template
-                        .spending_counters
-                        .iter()
-                        .cloned()
-                        .map(Into::into)
-                        .collect(),
-                )
-                .ok_or(Error::SpendingCounter)?,
+                SpendingCounterIncreasing::new_from_counters([
+                    template.spending_counters[0].into(),
+                    template.spending_counters[1].into(),
+                    template.spending_counters[2].into(),
+                    template.spending_counters[3].into(),
+                    template.spending_counters[4].into(),
+                    template.spending_counters[5].into(),
+                    template.spending_counters[6].into(),
+                    template.spending_counters[7].into(),
+                ])?,
                 template.discrimination(),
             ),
         ))
@@ -154,13 +155,17 @@ impl CliController {
                 VerifyExitStrategy::OnProcessed,
                 &node,
             )?;
-            self.wallets.wallet_mut()?.spending_counters = thor_wallet
-                .spending_counter()
-                .ok_or(Error::SpendingCounter)?
-                .get_valid_counters()
-                .into_iter()
-                .map(|x| x.into())
-                .collect();
+            let counters = thor_wallet.spending_counter()?.get_valid_counters();
+            self.wallets.wallet_mut()?.spending_counters = [
+                counters[0].into(),
+                counters[1].into(),
+                counters[2].into(),
+                counters[3].into(),
+                counters[4].into(),
+                counters[5].into(),
+                counters[6].into(),
+                counters[7].into(),
+            ];
         }
         Ok(check)
     }

--- a/src/jormungandr/testing/thor/src/cli/error.rs
+++ b/src/jormungandr/testing/thor/src/cli/error.rs
@@ -1,7 +1,7 @@
 use super::config::Alias;
 use crate::{FragmentSenderError, FragmentVerifierError};
 use chain_crypto::SecretKeyError;
-use chain_impl_mockchain::fragment::FragmentId;
+use chain_impl_mockchain::{accounting::account::spending, fragment::FragmentId};
 use jormungandr_automation::jormungandr::RestError;
 use jormungandr_lib::crypto::account::SigningKeyParseError;
 use thiserror::Error;
@@ -28,9 +28,8 @@ pub enum Error {
     Config(#[from] crate::cli::config::Error),
     #[error("cannot serialize secret key")]
     CannotrSerializeSecretKey,
-    #[error("cannot create spending counter")]
-    SpendingCounter,
-
+    #[error(transparent)]
+    SpendingCounterError(#[from] spending::Error),
     #[error("cannot read secret key")]
     CannotReadSecretKey,
     #[error("unknown alias: '{0}'")]

--- a/src/jormungandr/testing/thor/src/cli/wallet_controller.rs
+++ b/src/jormungandr/testing/thor/src/cli/wallet_controller.rs
@@ -135,7 +135,7 @@ impl WalletController {
                 secret_file,
                 pending_tx: Vec::new(),
                 testing,
-                spending_counters: vec![
+                spending_counters: [
                     0, 536870912, 1073741824, 1610612736, 2147483648, 2684354560, 3221225472,
                     3758096384,
                 ],

--- a/src/jormungandr/testing/thor/src/wallet/account.rs
+++ b/src/jormungandr/testing/thor/src/wallet/account.rs
@@ -108,7 +108,7 @@ impl Wallet {
         self.internal_counters.get_valid_counter()
     }
 
-    pub fn internal_counters(&self) -> Vec<SpendingCounter> {
+    pub fn internal_counters(&self) -> [SpendingCounter; SpendingCounterIncreasing::LANES] {
         self.internal_counters.get_valid_counters()
     }
 

--- a/src/jormungandr/testing/thor/src/wallet/mod.rs
+++ b/src/jormungandr/testing/thor/src/wallet/mod.rs
@@ -5,7 +5,8 @@ pub mod discrimination;
 pub mod utxo;
 
 use crate::{
-    wallet::discrimination::DiscriminationExtension, FragmentBuilder, FragmentBuilderError,
+    cli::Error, wallet::discrimination::DiscriminationExtension, FragmentBuilder,
+    FragmentBuilderError,
 };
 use chain_addr::{AddressReadable, Discrimination};
 use chain_crypto::{Ed25519, Ed25519Extended, PublicKey, SecretKey, Signature};
@@ -324,11 +325,11 @@ impl Wallet {
         }
     }
 
-    pub fn spending_counter(&self) -> Option<SpendingCounterIncreasing> {
+    pub fn spending_counter(&self) -> Result<SpendingCounterIncreasing, Error> {
         match self {
-            Wallet::Account(account) => {
-                SpendingCounterIncreasing::new_from_counters(account.internal_counters())
-            }
+            Wallet::Account(account) => Ok(SpendingCounterIncreasing::new_from_counters(
+                account.internal_counters(),
+            )?),
             _ => unimplemented!(),
         }
     }

--- a/src/vit-testing/iapyx/src/controller/mod.rs
+++ b/src/vit-testing/iapyx/src/controller/mod.rs
@@ -206,7 +206,7 @@ impl Controller {
             .into_iter()
             .map(|(p, c)| {
                 self.wallet
-                    .set_state((*account_state.value()).into(), counters.clone());
+                    .set_state((*account_state.value()).into(), counters);
                 let tx = self
                     .wallet
                     .vote(

--- a/src/vit-testing/iapyx/src/load/multi_controller.rs
+++ b/src/vit-testing/iapyx/src/load/multi_controller.rs
@@ -141,7 +141,7 @@ impl MultiController {
         let txs = votes_data
             .into_iter()
             .map(|(p, c)| {
-                wallet.set_state((*account_state.value()).into(), counters.clone());
+                wallet.set_state((*account_state.value()).into(), counters);
                 let tx = wallet
                     .vote(
                         settings.clone(),

--- a/src/vit-testing/iapyx/src/wallet.rs
+++ b/src/vit-testing/iapyx/src/wallet.rs
@@ -1,4 +1,5 @@
 use chain_addr::{AddressReadable, Discrimination};
+use chain_impl_mockchain::account::SpendingCounterIncreasing;
 use chain_impl_mockchain::{block::BlockDate, fragment::FragmentId};
 use hdkeygen::account::AccountId;
 use jormungandr_lib::interfaces::AccountIdentifier;
@@ -77,12 +78,12 @@ impl Wallet {
         self.inner.total_value()
     }
 
-    pub fn set_state(&mut self, value: Value, counter: Vec<u32>) {
+    pub fn set_state(&mut self, value: Value, counters: [u32; SpendingCounterIncreasing::LANES]) {
         //TODO map error instead of unwrapping
-        self.inner.set_state(value, counter).unwrap();
+        self.inner.set_state(value, counters).unwrap();
     }
 
-    pub fn spending_counter(&self) -> Vec<u32> {
+    pub fn spending_counter(&self) -> [u32; SpendingCounterIncreasing::LANES] {
         self.inner.spending_counter()
     }
 


### PR DESCRIPTION
# Description

Refactor SpendingCounter implementation. Replace Vec with an array usage.
At this place we are certanly know what is the size of SpendingCountersIncresing lanes, so it is better replace dynamic sized collection with the static sized collection.

## Type of change

- [x] Refactoring

## How Has This Been Tested?

Been fixed only existing tests,  no any new tests been added

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules