### PR TITLE
logically seperate p2p config

### DIFF
--- a/src/jormungandr/jormungandr-lib/src/interfaces/config/mod.rs
+++ b/src/jormungandr/jormungandr-lib/src/interfaces/config/mod.rs
@@ -6,7 +6,7 @@ mod secret;
 pub use log::{Log, LogEntry, LogOutput};
 pub use mempool::{LogMaxEntries, Mempool, PersistentLog, PoolMaxEntries};
 pub use node::{
-    Cors, CorsOrigin, JRpc, LayersConfig, NodeConfig, NodeId, P2p, Policy, PreferredListConfig,
-    Rest, Tls, TopicsOfInterest, TrustedPeer,
+    Bootstrap, Connection, Cors, CorsOrigin, JRpc, LayersConfig, NodeConfig, NodeId, P2p, Policy,
+    PreferredListConfig, Rest, Tls, TopicsOfInterest, TrustedPeer,
 };
 pub use secret::{Bft, GenesisPraos, NodeSecret};

--- a/src/jormungandr/jormungandr-lib/src/interfaces/config/node.rs
+++ b/src/jormungandr/jormungandr-lib/src/interfaces/config/node.rs
@@ -188,16 +188,36 @@ impl Serialize for HttpMethod {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct P2p {
-    /// The public address to which other peers may connect to
-    pub public_address: Multiaddr,
+    pub bootstrap: Bootstrap,
+
+    pub connection: Connection,
+
+    pub policy: Option<Policy>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub layers: Option<LayersConfig>,
+}
+
+/// Bootstrap contains meta data for initial startup
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Bootstrap {
+    /// the rendezvous points for the peer to connect to in order to initiate
+    /// the p2p discovery from.
+    pub trusted_peers: Vec<TrustedPeer>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_bootstrap_attempts: Option<usize>,
 
     /// File with the secret key used to advertise and authenticate the node
     #[serde(skip_serializing_if = "Option::is_none")]
     pub node_key_file: Option<PathBuf>,
+}
 
-    /// the rendezvous points for the peer to connect to in order to initiate
-    /// the p2p discovery from.
-    pub trusted_peers: Vec<TrustedPeer>,
+/// Miscellaneous network configuration
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Connection {
+    /// The public address to which other peers may connect to
+    pub public_address: Multiaddr,
 
     /// Listen address.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -209,21 +229,17 @@ pub struct P2p {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_inbound_connections: Option<u32>,
 
+    /// Whether to allow non-public IP addresses in gossip
     pub allow_private_addresses: bool,
 
+    /// contains addrs of nodes which we can accept fragments from
     pub whitelist: Option<Vec<SocketAddr>>,
 
-    pub policy: Option<Policy>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub layers: Option<LayersConfig>,
-
+    /// interval to start gossiping with new nodes, changing the value will affect the bandwidth.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub gossip_interval: Option<Duration>,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub max_bootstrap_attempts: Option<usize>,
-
+    /// If no gossip has been received in the last interval, try to connect to nodes that were previously known to this node
     #[serde(skip_serializing_if = "Option::is_none")]
     pub network_stuck_check: Option<Duration>,
 }
@@ -234,6 +250,7 @@ pub struct TopicsOfInterest {
     pub blocks: String,
 }
 
+/// policy module
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Policy {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -242,6 +259,7 @@ pub struct Policy {
     pub quarantine_whitelist: Option<Vec<Multiaddr>>,
 }
 
+/// Jörmungandr provides multiple additional layers to the poldercast default ones: the preferred list or the bottle in the sea.
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct LayersConfig {
@@ -308,7 +326,8 @@ pub struct NodeConfig {
 
 impl P2p {
     pub fn get_listen_addr(&self) -> Option<SocketAddr> {
-        self.listen
-            .or_else(|| multiaddr_utils::to_tcp_socket_addr(&self.public_address))
+        self.connection
+            .listen
+            .or_else(|| multiaddr_utils::to_tcp_socket_addr(&self.connection.public_address))
     }
 }

--- a/src/jormungandr/jormungandr/src/settings/start/config.rs
+++ b/src/jormungandr/jormungandr/src/settings/start/config.rs
@@ -66,6 +66,46 @@ pub struct ConfigLogSettings {
 #[derive(Debug, Clone, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
 pub struct P2pConfig {
+    pub bootstrap: Bootstrap,
+
+    pub connection: Connection,
+
+    /// setting for the policy
+    #[serde(default)]
+    pub policy: QuarantineConfig,
+
+    /// settings for the different custom layers
+    #[serde(default)]
+    pub layers: LayersConfig,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct Bootstrap {
+    /// File with the secret key used to advertise and authenticate the node
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub node_key_file: Option<PathBuf>,
+
+    /// the rendezvous points for the peer to connect to in order to initiate
+    /// the p2p discovery from.
+    pub trusted_peers: Option<Vec<TrustedPeer>>,
+
+    /// The number of times to retry bootstrapping from trusted peers. The default
+    /// value of None will result in the bootstrap process retrying indefinitely. A
+    /// value of zero will skip bootstrap all together -- even if trusted peers are
+    /// defined. If the node fails to bootstrap from any of the trusted peers and the
+    /// number of bootstrap retry attempts is exceeded, then the node will continue to
+    /// run without completing the bootstrap process. This will allow the node to act
+    /// as the first node in the p2p network (i.e. genesis node), or immediately begin
+    /// gossip with the trusted peers if any are defined.
+    #[serde(default)]
+    pub max_bootstrap_attempts: Option<usize>,
+}
+
+/// Start up connection configuration
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct Connection {
     /// The public address to which other peers may connect to
     pub public_address: Option<Multiaddr>,
 
@@ -74,14 +114,6 @@ pub struct P2pConfig {
     /// The IP address can be specified as 0.0.0.0 or :: to listen on
     /// all network interfaces.
     pub listen: Option<Address>,
-
-    /// File with the secret key used to advertise and authenticate the node
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub node_key_file: Option<PathBuf>,
-
-    /// the rendezvous points for the peer to connect to in order to initiate
-    /// the p2p discovery from.
-    pub trusted_peers: Option<Vec<TrustedPeer>>,
 
     /// Limit on the number of simultaneous connections.
     /// If not specified, an internal default limit is used.
@@ -99,15 +131,8 @@ pub struct P2pConfig {
     #[serde(default)]
     pub allow_private_addresses: bool,
 
+    /// contains addrs of nodes which we can accept fragments from
     pub whitelist: Option<Vec<SocketAddr>>,
-
-    /// setting for the policy
-    #[serde(default)]
-    pub policy: QuarantineConfig,
-
-    /// settings for the different custom layers
-    #[serde(default)]
-    pub layers: LayersConfig,
 
     /// interval to start gossiping with new nodes, changing the value will
     /// affect the bandwidth. The more often the node will gossip the more
@@ -124,17 +149,6 @@ pub struct P2pConfig {
     /// The default value is 5 min.
     #[serde(default)]
     pub network_stuck_check: Option<Duration>,
-
-    /// The number of times to retry bootstrapping from trusted peers. The default
-    /// value of None will result in the bootstrap process retrying indefinitely. A
-    /// value of zero will skip bootstrap all together -- even if trusted peers are
-    /// defined. If the node fails to bootstrap from any of the trusted peers and the
-    /// number of bootstrap retry attempts is exceeded, then the node will continue to
-    /// run without completing the bootstrap process. This will allow the node to act
-    /// as the first node in the p2p network (i.e. genesis node), or immediately begin
-    /// gossip with the trusted peers if any are defined.
-    #[serde(default)]
-    pub max_bootstrap_attempts: Option<usize>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]

--- a/src/jormungandr/jormungandr/src/settings/start/mod.rs
+++ b/src/jormungandr/jormungandr/src/settings/start/mod.rs
@@ -287,8 +287,6 @@ fn generate_network(
         .transpose()?
         .unwrap_or_default();
 
-    // TODO: do we want to check that we end up with a valid address?
-    // Is it possible for a node to specify no public address?
     let config_addr = p2p.connection.public_address;
     let public_address = command_arguments
         .public_address

--- a/src/jormungandr/jormungandr/src/settings/start/mod.rs
+++ b/src/jormungandr/jormungandr/src/settings/start/mod.rs
@@ -260,15 +260,16 @@ fn generate_network(
             (config::P2pConfig::default(), Vec::new(), false, false)
         };
 
-    if p2p.trusted_peers.is_some() {
-        if let Some(peers) = p2p.trusted_peers.as_mut() {
+    if p2p.bootstrap.trusted_peers.is_some() {
+        if let Some(peers) = p2p.bootstrap.trusted_peers.as_mut() {
             peers.extend(command_arguments.trusted_peer.clone())
         }
     } else if !command_arguments.trusted_peer.is_empty() {
-        p2p.trusted_peers = Some(command_arguments.trusted_peer.clone())
+        p2p.bootstrap.trusted_peers = Some(command_arguments.trusted_peer.clone())
     }
 
     let trusted_peers = p2p
+        .bootstrap
         .trusted_peers
         .as_ref()
         .map_or_else(Vec::new, |peers| resolve_trusted_peers(peers));
@@ -288,21 +289,21 @@ fn generate_network(
 
     // TODO: do we want to check that we end up with a valid address?
     // Is it possible for a node to specify no public address?
-    let config_addr = p2p.public_address;
+    let config_addr = p2p.connection.public_address;
     let public_address = command_arguments
         .public_address
         .clone()
         .or(config_addr)
         .and_then(|addr| multiaddr::to_tcp_socket_addr(&addr));
 
-    let node_key = match p2p.node_key_file {
+    let node_key = match p2p.bootstrap.node_key_file {
         Some(node_key_file) => {
             <SigningKey<Ed25519>>::from_bech32_str(&std::fs::read_to_string(&node_key_file)?)?
         }
         None => SigningKey::generate(rand::thread_rng()),
     };
 
-    let p2p_listen_address = p2p.listen.as_ref();
+    let p2p_listen_address = p2p.connection.listen.as_ref();
     let listen_address = command_arguments
         .listen_address
         .as_ref()
@@ -321,23 +322,27 @@ fn generate_network(
             rings,
         },
         max_connections: p2p
+            .connection
             .max_connections
             .unwrap_or(network::DEFAULT_MAX_CONNECTIONS),
         max_client_connections: p2p
+            .connection
             .max_client_connections
             .unwrap_or(network::DEFAULT_MAX_CLIENT_CONNECTIONS),
         timeout: std::time::Duration::from_secs(15),
-        allow_private_addresses: p2p.allow_private_addresses,
-        whitelist: p2p.whitelist,
+        allow_private_addresses: p2p.connection.allow_private_addresses,
+        whitelist: p2p.connection.whitelist,
         gossip_interval: p2p
+            .connection
             .gossip_interval
             .map(|d| d.into())
             .unwrap_or_else(|| std::time::Duration::from_secs(10)),
         network_stuck_check: p2p
+            .connection
             .network_stuck_check
             .map(Into::into)
             .unwrap_or(crate::topology::DEFAULT_NETWORK_STUCK_INTERVAL),
-        max_bootstrap_attempts: p2p.max_bootstrap_attempts,
+        max_bootstrap_attempts: p2p.bootstrap.max_bootstrap_attempts,
         http_fetch_block0_service,
         bootstrap_from_trusted_peers,
         skip_bootstrap,

--- a/src/jormungandr/testing/hersir/src/builder/explorer.rs
+++ b/src/jormungandr/testing/hersir/src/builder/explorer.rs
@@ -16,7 +16,13 @@ pub fn generate_explorer(
     Ok(ExplorerConfiguration {
         explorer_port: get_available_port(),
         explorer_listen_address: "127.0.0.1".to_string(),
-        node_address: settings.config.p2p.public_address.clone().to_http_addr(),
+        node_address: settings
+            .config
+            .p2p
+            .connection
+            .public_address
+            .clone()
+            .to_http_addr(),
         logs_dir: Some(Path::new("C:\\work\\iohk\\logs.txt").to_path_buf()),
         storage_dir: None,
         params: explorer_template.to_explorer_params(),

--- a/src/jormungandr/testing/hersir/src/builder/settings/mod.rs
+++ b/src/jormungandr/testing/hersir/src/builder/settings/mod.rs
@@ -178,14 +178,14 @@ impl Settings {
                         .to_public(),
                 );
                 trusted_peers.push(TrustedPeer {
-                    address: trusted_peer.config.p2p.public_address.clone(),
+                    address: trusted_peer.config.p2p.connection.public_address.clone(),
                     id: Some(id),
                 })
             }
 
             node.config.skip_bootstrap = Some(trusted_peers.is_empty());
             node.config.bootstrap_from_trusted_peers = Some(!trusted_peers.is_empty());
-            node.config.p2p.trusted_peers = trusted_peers;
+            node.config.p2p.bootstrap.trusted_peers = trusted_peers;
         }
     }
 

--- a/src/jormungandr/testing/hersir/src/config/spawn_params.rs
+++ b/src/jormungandr/testing/hersir/src/config/spawn_params.rs
@@ -281,31 +281,31 @@ impl SpawnParams {
         }
 
         if let Some(public_address) = &self.public_address {
-            node_config.p2p.public_address = public_address.clone();
+            node_config.p2p.connection.public_address = public_address.clone();
         }
 
         if let Some(max_inbound_connections) = &self.max_inbound_connections {
-            node_config.p2p.max_inbound_connections = Some(*max_inbound_connections);
+            node_config.p2p.connection.max_inbound_connections = Some(*max_inbound_connections);
         }
 
         if let Some(allow_private_addresses) = &self.allow_private_addresses {
-            node_config.p2p.allow_private_addresses = *allow_private_addresses;
+            node_config.p2p.connection.allow_private_addresses = *allow_private_addresses;
         }
 
         if let Some(whitelist) = &self.whitelist {
-            node_config.p2p.whitelist = Some(whitelist.clone());
+            node_config.p2p.connection.whitelist = Some(whitelist.clone());
         }
 
         if let Some(max_connections) = &self.max_connections {
-            node_config.p2p.max_connections = Some(*max_connections);
+            node_config.p2p.connection.max_connections = Some(*max_connections);
         }
 
         if let Some(listen_address_option) = &self.listen_address {
-            node_config.p2p.listen = *listen_address_option;
+            node_config.p2p.connection.listen = *listen_address_option;
         }
 
         if let Some(trusted_peers) = &self.trusted_peers {
-            node_config.p2p.trusted_peers = trusted_peers.clone();
+            node_config.p2p.bootstrap.trusted_peers = trusted_peers.clone();
         }
 
         if let Some(preferred_layer) = &self.preferred_layer {
@@ -328,19 +328,19 @@ impl SpawnParams {
         }
 
         if let Some(node_key_file) = &self.node_key_file {
-            node_config.p2p.node_key_file = Some(node_key_file.clone());
+            node_config.p2p.bootstrap.node_key_file = Some(node_key_file.clone());
         }
 
         if self.gossip_interval.is_some() {
-            node_config.p2p.gossip_interval = self.gossip_interval;
+            node_config.p2p.connection.gossip_interval = self.gossip_interval;
         }
 
         if let Some(max_bootstrap_attempts) = self.max_bootstrap_attempts {
-            node_config.p2p.max_bootstrap_attempts = Some(max_bootstrap_attempts);
+            node_config.p2p.bootstrap.max_bootstrap_attempts = Some(max_bootstrap_attempts);
         }
 
         if let Some(network_stuck_check) = self.network_stuck_check {
-            node_config.p2p.network_stuck_check = Some(network_stuck_check);
+            node_config.p2p.connection.network_stuck_check = Some(network_stuck_check);
         }
         node_config.mempool.as_mut().unwrap().persistent_log = self
             .persistent_fragment_log

--- a/src/jormungandr/testing/hersir/src/controller/mod.rs
+++ b/src/jormungandr/testing/hersir/src/controller/mod.rs
@@ -254,7 +254,7 @@ impl Controller {
 
         spawn_params.override_settings(&mut config);
 
-        for peer in config.p2p.trusted_peers.iter_mut() {
+        for peer in config.p2p.bootstrap.trusted_peers.iter_mut() {
             peer.id = None;
         }
 

--- a/src/jormungandr/testing/jormungandr-automation/src/jormungandr/configuration/node/manager.rs
+++ b/src/jormungandr/testing/jormungandr-automation/src/jormungandr/configuration/node/manager.rs
@@ -45,19 +45,19 @@ impl ConfigurableNodeConfig for NodeConfigManager {
     }
 
     fn p2p_listen_address(&self) -> SocketAddr {
-        if let Some(address) = &self.node_config.p2p.listen {
+        if let Some(address) = &self.node_config.p2p.connection.listen {
             *address
         } else {
-            to_tcp_socket_addr(&self.node_config.p2p.public_address).unwrap()
+            to_tcp_socket_addr(&self.node_config.p2p.connection.public_address).unwrap()
         }
     }
 
     fn p2p_public_address(&self) -> Multiaddr {
-        self.node_config.p2p.public_address.clone()
+        self.node_config.p2p.connection.public_address.clone()
     }
 
     fn set_p2p_public_address(&mut self, address: Multiaddr) {
-        self.node_config.p2p.public_address = address;
+        self.node_config.p2p.connection.public_address = address;
     }
 
     fn rest_socket_addr(&self) -> SocketAddr {

--- a/src/jormungandr/testing/jormungandr-automation/src/jormungandr/configuration/node/node_config_builder.rs
+++ b/src/jormungandr/testing/jormungandr-automation/src/jormungandr/configuration/node/node_config_builder.rs
@@ -3,8 +3,8 @@
 use crate::jormungandr::get_available_port;
 use jormungandr_lib::{
     interfaces::{
-        Cors, JRpc, LayersConfig, Log, LogEntry, LogOutput, Mempool, NodeConfig, P2p, Policy, Rest,
-        Tls, TopicsOfInterest, TrustedPeer,
+        Bootstrap, Connection, Cors, JRpc, LayersConfig, Log, LogEntry, LogOutput, Mempool,
+        NodeConfig, P2p, Policy, Rest, Tls, TopicsOfInterest, TrustedPeer,
     },
     time::Duration,
 };
@@ -61,13 +61,22 @@ impl Default for NodeConfigBuilder {
                 listen: format!("{}:{}", DEFAULT_HOST, jrpc_port).parse().unwrap(),
             },
             p2p: P2p {
-                node_key_file: None,
-                trusted_peers: vec![],
-                public_address: grpc_public_address,
-                listen: None,
-                max_inbound_connections: None,
-                max_connections: None,
-                allow_private_addresses: true,
+                bootstrap: Bootstrap {
+                    max_bootstrap_attempts: None,
+                    trusted_peers: vec![],
+                    node_key_file: None,
+                },
+                connection: Connection {
+                    public_address: grpc_public_address,
+                    listen: None,
+                    max_inbound_connections: None,
+                    max_connections: None,
+                    allow_private_addresses: true,
+                    gossip_interval: None,
+                    network_stuck_check: None,
+                    whitelist: None,
+                },
+
                 policy: Some(Policy {
                     quarantine_duration: Some(Duration::new(1, 0)),
                     quarantine_whitelist: None,
@@ -79,10 +88,6 @@ impl Default for NodeConfigBuilder {
                         blocks: String::from("high"),
                     }),
                 }),
-                gossip_interval: None,
-                max_bootstrap_attempts: None,
-                network_stuck_check: None,
-                whitelist: None,
             },
             mempool: Some(Mempool::default()),
         }
@@ -106,17 +111,17 @@ impl NodeConfigBuilder {
     }
 
     pub fn with_trusted_peers(mut self, trusted_peers: Vec<TrustedPeer>) -> Self {
-        self.p2p.trusted_peers = trusted_peers;
+        self.p2p.bootstrap.trusted_peers = trusted_peers;
         self
     }
 
     pub fn with_public_address(mut self, public_address: String) -> Self {
-        self.p2p.public_address = public_address.parse().unwrap();
+        self.p2p.connection.public_address = public_address.parse().unwrap();
         self
     }
 
     pub fn with_listen_address(mut self, listen_address: String) -> Self {
-        self.p2p.listen = Some(listen_address.parse().unwrap());
+        self.p2p.connection.listen = Some(listen_address.parse().unwrap());
         self
     }
 
@@ -142,13 +147,13 @@ impl NodeConfigBuilder {
 
     pub fn build(mut self) -> NodeConfig {
         //remove id from trusted peers
-        for trusted_peer in self.p2p.trusted_peers.iter_mut() {
+        for trusted_peer in self.p2p.bootstrap.trusted_peers.iter_mut() {
             trusted_peer.id = None;
         }
 
         NodeConfig {
-            bootstrap_from_trusted_peers: Some(!self.p2p.trusted_peers.is_empty()),
-            skip_bootstrap: Some(self.p2p.trusted_peers.is_empty()),
+            bootstrap_from_trusted_peers: Some(!self.p2p.bootstrap.trusted_peers.is_empty()),
+            skip_bootstrap: Some(self.p2p.bootstrap.trusted_peers.is_empty()),
             storage: self.storage,
             log: self.log,
             rest: self.rest,

--- a/src/jormungandr/testing/jormungandr-automation/src/jormungandr/legacy/config/node/mod.rs
+++ b/src/jormungandr/testing/jormungandr-automation/src/jormungandr/legacy/config/node/mod.rs
@@ -38,7 +38,7 @@ pub struct LegacyNodeConfigBuilder {
 
 impl LegacyNodeConfigBuilder {
     pub fn with_trusted_peers(mut self, trusted_peer: Vec<NewestTrustedPeer>) -> Self {
-        self.config.p2p.trusted_peers = trusted_peer;
+        self.config.p2p.bootstrap.trusted_peers = trusted_peer;
         self
     }
 }
@@ -105,6 +105,7 @@ impl LegacyNodeConfigConverter {
 
         let trusted_peers: Vec<TrustedPeer> = source
             .p2p
+            .bootstrap
             .trusted_peers
             .iter()
             .map(|peer| {
@@ -131,16 +132,16 @@ impl LegacyNodeConfigConverter {
             jrpc: source.jrpc.clone(),
             p2p: P2p {
                 trusted_peers,
-                public_address: source.p2p.public_address.clone(),
+                public_address: source.p2p.connection.public_address.clone(),
                 listen: None,
                 max_inbound_connections: None,
                 max_connections: None,
                 topics_of_interest: None,
-                allow_private_addresses: source.p2p.allow_private_addresses,
+                allow_private_addresses: source.p2p.connection.allow_private_addresses,
                 policy: source.p2p.policy.clone(),
                 layers: source.p2p.layers.clone(),
                 public_id: None,
-                whitelist: source.p2p.whitelist.clone(),
+                whitelist: source.p2p.connection.whitelist.clone(),
             },
             mempool: source.mempool.clone(),
             bootstrap_from_trusted_peers: source.bootstrap_from_trusted_peers,
@@ -151,6 +152,7 @@ impl LegacyNodeConfigConverter {
     fn build_node_config_after_0_12_0(&self, source: &NodeConfig) -> LegacyNodeConfig {
         let trusted_peers: Vec<TrustedPeer> = source
             .p2p
+            .bootstrap
             .trusted_peers
             .iter()
             .map(|peer| TrustedPeer {
@@ -171,16 +173,16 @@ impl LegacyNodeConfigConverter {
             jrpc: source.jrpc.clone(),
             p2p: P2p {
                 trusted_peers,
-                public_address: source.p2p.public_address.clone(),
+                public_address: source.p2p.connection.public_address.clone(),
                 listen: None,
                 max_inbound_connections: None,
                 max_connections: None,
                 topics_of_interest: None,
-                allow_private_addresses: source.p2p.allow_private_addresses,
+                allow_private_addresses: source.p2p.connection.allow_private_addresses,
                 policy: source.p2p.policy.clone(),
                 layers: source.p2p.layers.clone(),
                 public_id: None,
-                whitelist: source.p2p.whitelist.clone(),
+                whitelist: source.p2p.connection.whitelist.clone(),
             },
             mempool: source.mempool.clone(),
             bootstrap_from_trusted_peers: source.bootstrap_from_trusted_peers,
@@ -198,6 +200,7 @@ impl LegacyNodeConfigConverter {
         let mut rng = OsRng;
         let trusted_peers: Vec<TrustedPeer> = source
             .p2p
+            .bootstrap
             .trusted_peers
             .iter()
             .map(|peer| {
@@ -227,7 +230,7 @@ impl LegacyNodeConfigConverter {
             jrpc: source.jrpc.clone(),
             p2p: P2p {
                 trusted_peers,
-                public_address: source.p2p.public_address.clone(),
+                public_address: source.p2p.connection.public_address.clone(),
                 listen: None,
                 max_inbound_connections: None,
                 max_connections: None,
@@ -236,11 +239,11 @@ impl LegacyNodeConfigConverter {
                     .layers
                     .as_ref()
                     .and_then(|c| c.topics_of_interest.clone()),
-                allow_private_addresses: source.p2p.allow_private_addresses,
+                allow_private_addresses: source.p2p.connection.allow_private_addresses,
                 policy: source.p2p.policy.clone(),
                 layers: None,
                 public_id: None,
-                whitelist: source.p2p.whitelist.clone(),
+                whitelist: source.p2p.connection.whitelist.clone(),
             },
             mempool: source.mempool.clone(),
             bootstrap_from_trusted_peers: source.bootstrap_from_trusted_peers,

--- a/src/jormungandr/testing/jormungandr-integration-tests/src/networking/p2p/connections.rs
+++ b/src/jormungandr/testing/jormungandr-integration-tests/src/networking/p2p/connections.rs
@@ -97,7 +97,7 @@ pub fn node_trust_itself() {
     let config = network_controller.node_config(CLIENT).unwrap().p2p;
 
     let peer = TrustedPeer {
-        address: config.public_address,
+        address: config.connection.public_address,
         id: None,
     };
     network_controller

--- a/src/jormungandr/testing/jormungandr-integration-tests/src/networking/p2p/public_traffic.rs
+++ b/src/jormungandr/testing/jormungandr-integration-tests/src/networking/p2p/public_traffic.rs
@@ -20,8 +20,8 @@ const INTERNAL_NODE_2: &str = "INTERNAL_2";
 const ALICE: &str = "ALICE";
 const BOB: &str = "BOB";
 
-#[ignore]
 #[test]
+#[ignore]
 fn public_gossip_rejection() {
     const SERVER_GOSSIP_INTERVAL_SECS: u64 = 10;
 
@@ -94,8 +94,8 @@ fn public_gossip_rejection() {
     assert!(gossip_dropped);
 }
 
-#[ignore]
 #[test]
+#[ignore]
 pub fn test_public_node_cannot_publish() {
     let mut network_controller = NetworkBuilder::default()
         .topology(
@@ -154,19 +154,19 @@ pub fn test_public_node_cannot_publish() {
     // add whitelists to nodes config
     let mut internal_node_config = network_controller.node_config(INTERNAL_NODE).unwrap();
 
-    internal_node_config.p2p.whitelist = Some(whitelist.clone());
+    internal_node_config.p2p.connection.whitelist = Some(whitelist.clone());
 
     let mut internal_node_2_config = network_controller.node_config(INTERNAL_NODE_2).unwrap();
 
-    internal_node_2_config.p2p.whitelist = Some(whitelist.clone());
+    internal_node_2_config.p2p.connection.whitelist = Some(whitelist.clone());
 
     let mut gateway_node_config = network_controller.node_config(GATEWAY).unwrap();
 
-    gateway_node_config.p2p.whitelist = Some(whitelist.clone());
+    gateway_node_config.p2p.connection.whitelist = Some(whitelist.clone());
 
     let mut public_node_config = network_controller.node_config(PUBLIC_NODE).unwrap();
 
-    public_node_config.p2p.whitelist = Some(whitelist.clone());
+    public_node_config.p2p.connection.whitelist = Some(whitelist.clone());
 
     //
     //
@@ -241,8 +241,8 @@ pub fn test_public_node_cannot_publish() {
     };
 }
 
-#[ignore]
 #[test]
+#[ignore]
 pub fn test_public_node_synced_with_internal() {
     let mut network_controller = NetworkBuilder::default()
         .topology(
@@ -301,19 +301,19 @@ pub fn test_public_node_synced_with_internal() {
     // add whitelists to nodes config
     let mut internal_node_config = network_controller.node_config(INTERNAL_NODE).unwrap();
 
-    internal_node_config.p2p.whitelist = Some(whitelist.clone());
+    internal_node_config.p2p.connection.whitelist = Some(whitelist.clone());
 
     let mut internal_node_2_config = network_controller.node_config(INTERNAL_NODE_2).unwrap();
 
-    internal_node_2_config.p2p.whitelist = Some(whitelist.clone());
+    internal_node_2_config.p2p.connection.whitelist = Some(whitelist.clone());
 
     let mut gateway_node_config = network_controller.node_config(GATEWAY).unwrap();
 
-    gateway_node_config.p2p.whitelist = Some(whitelist.clone());
+    gateway_node_config.p2p.connection.whitelist = Some(whitelist.clone());
 
     let mut public_node_config = network_controller.node_config(PUBLIC_NODE).unwrap();
 
-    public_node_config.p2p.whitelist = Some(whitelist.clone());
+    public_node_config.p2p.connection.whitelist = Some(whitelist.clone());
 
     //
     //

--- a/src/jormungandr/testing/jormungandr-integration-tests/src/networking/p2p/public_traffic.rs
+++ b/src/jormungandr/testing/jormungandr-integration-tests/src/networking/p2p/public_traffic.rs
@@ -121,8 +121,6 @@ pub fn test_public_node_cannot_publish() {
         .build()
         .unwrap();
 
-    //
-    //
     // Get addresses of nodes for whitelisting
     let internal_node_addr = network_controller
         .node_config(INTERNAL_NODE)
@@ -149,8 +147,6 @@ pub fn test_public_node_cannot_publish() {
 
     println!("whitelist {:?}", whitelist);
 
-    //
-    //
     // add whitelists to nodes config
     let mut internal_node_config = network_controller.node_config(INTERNAL_NODE).unwrap();
 
@@ -168,8 +164,6 @@ pub fn test_public_node_cannot_publish() {
 
     public_node_config.p2p.connection.whitelist = Some(whitelist.clone());
 
-    //
-    //
     // spin up internal nodes
     let params = SpawnParams::new(INTERNAL_NODE)
         .gossip_interval(Duration::new(1, 0))
@@ -189,8 +183,6 @@ pub fn test_public_node_cannot_publish() {
 
     let _client_internal_2 = network_controller.spawn(params).unwrap();
 
-    //
-    //
     // node from internal network exposed to public
 
     let params = SpawnParams::new(GATEWAY)
@@ -202,8 +194,6 @@ pub fn test_public_node_cannot_publish() {
 
     let _gateway = network_controller.spawn(params).unwrap();
 
-    //
-    //
     // simulate node in the wild
     let address: Multiaddr = "/ip4/80.9.12.3/tcp/0".parse().unwrap();
 
@@ -217,8 +207,6 @@ pub fn test_public_node_cannot_publish() {
 
     let _client_public = network_controller.spawn(params).unwrap();
 
-    //
-    //
     // public node sends fragments to network
     // it should fail as they public node is not whitelisted
     let mut alice = network_controller.controlled_wallet(ALICE).unwrap();
@@ -268,8 +256,6 @@ pub fn test_public_node_synced_with_internal() {
         .build()
         .unwrap();
 
-    //
-    //
     // Get addresses of nodes for whitelisting
     let internal_node_addr = network_controller
         .node_config(INTERNAL_NODE)
@@ -296,8 +282,6 @@ pub fn test_public_node_synced_with_internal() {
 
     println!("whitelist {:?}", whitelist);
 
-    //
-    //
     // add whitelists to nodes config
     let mut internal_node_config = network_controller.node_config(INTERNAL_NODE).unwrap();
 
@@ -315,8 +299,6 @@ pub fn test_public_node_synced_with_internal() {
 
     public_node_config.p2p.connection.whitelist = Some(whitelist.clone());
 
-    //
-    //
     // spin up internal nodes
     let params = SpawnParams::new(INTERNAL_NODE)
         .gossip_interval(Duration::new(1, 0))
@@ -336,8 +318,6 @@ pub fn test_public_node_synced_with_internal() {
 
     let _client_internal_2 = network_controller.spawn(params).unwrap();
 
-    //
-    //
     // node from internal network exposed to public
 
     let params = SpawnParams::new(GATEWAY)
@@ -349,8 +329,6 @@ pub fn test_public_node_synced_with_internal() {
 
     let _gateway = network_controller.spawn(params).unwrap();
 
-    //
-    //
     // simulate node in the wild
     let address: Multiaddr = "/ip4/80.9.12.3/tcp/0".parse().unwrap();
 
@@ -364,8 +342,6 @@ pub fn test_public_node_synced_with_internal() {
 
     let _client_public = network_controller.spawn(params).unwrap();
 
-    //
-    //
     // internal node sends fragments to network
     // fragments should be propagated to the publish node (which can consume but not publish)
     let mut alice = network_controller.controlled_wallet(ALICE).unwrap();
@@ -386,8 +362,6 @@ pub fn test_public_node_synced_with_internal() {
 
     utils::wait(10);
 
-    //
-    //
     // account states should be the same
 
     let public_state_a = _client_internal_2

--- a/src/jormungandr/testing/jormungandr-integration-tests/src/networking/p2p/quarantine.rs
+++ b/src/jormungandr/testing/jormungandr-integration-tests/src/networking/p2p/quarantine.rs
@@ -45,6 +45,7 @@ pub fn node_whitelist_itself() {
         .node_config(CLIENT)
         .unwrap()
         .p2p
+        .connection
         .public_address;
     let policy = Policy {
         quarantine_duration: Some(Duration::new(1, 0)),


### PR DESCRIPTION
Currently the p2p config has become cluttered with multiple behaviours; i.e internode relations, bootstrap info and other things. PR adds extra sub settings to logically separate the functionality for clarity and context.