### PR TITLE
build: adds scripts for pushing images

### DIFF
--- a/nix/jormungandr/containers.nix
+++ b/nix/jormungandr/containers.nix
@@ -7,18 +7,19 @@
   l = nixpkgs.lib // builtins;
 
   mkOCI = namespace: let
-    # TODO: fix git rev
     rev =
       if (inputs.self.rev != "not-a-commit")
       then inputs.self.rev
-      else "dirty";
+      else "";
   in
-    std.lib.ops.mkStandardOCI {
-      name = "${constants.registry}/jormungandr";
-      tag = "${rev}-${namespace}";
-      operable = cell.operables."jormungandr-${namespace}";
-      debug = true;
-    };
+    std.lib.ops.mkStandardOCI ({
+        name = "${constants.registry}/jormungandr";
+        tag = "${rev}-${namespace}";
+        operable = cell.operables."jormungandr-${namespace}";
+        debug = true;
+      }
+      # Default to using output hash as the tag if the repo is dirty
+      // l.optionalAttrs (rev != "") {tag = "${rev}-${namespace}";});
 in
   {}
   // lib.mapToNamespaces "jormungandr" mkOCI

--- a/nix/vit-servicing-station/containers.nix
+++ b/nix/vit-servicing-station/containers.nix
@@ -7,18 +7,18 @@
   l = nixpkgs.lib // builtins;
 
   mkOCI = namespace: let
-    # TODO: fix git rev
     rev =
       if (inputs.self.rev != "not-a-commit")
       then inputs.self.rev
-      else "dirty";
+      else "";
   in
-    std.lib.ops.mkStandardOCI {
-      name = "${constants.registry}/vit-servicing-station-server";
-      tag = "${rev}-${namespace}";
-      operable = cell.operables."vit-servicing-station-server-${namespace}";
-      debug = true;
-    };
+    std.lib.ops.mkStandardOCI ({
+        name = "${constants.registry}/vit-servicing-station-server";
+        operable = cell.operables."vit-servicing-station-server-${namespace}";
+        debug = true;
+      }
+      # Default to using output hash as the tag if the repo is dirty
+      // l.optionalAttrs (rev != "") {tag = "${rev}-${namespace}";});
 in
   {}
   // lib.mapToNamespaces "vit-servicing-station-server" mkOCI

--- a/scripts/login-ecr.sh
+++ b/scripts/login-ecr.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -o errexit -o pipefail -o noclobber -o nounset
+
+ECR_REGISTRY="432820653916.dkr.ecr.eu-central-1.amazonaws.com"
+
+echo "Clearing existing login sessions..."
+docker logout "$ECR_REGISTRY"
+
+echo "Logging into ECR registry..."
+aws ecr get-login-password --region eu-central-1 | docker login --username AWS --password-stdin "$ECR_REGISTRY"

--- a/scripts/push-image.sh
+++ b/scripts/push-image.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+set -o errexit -o pipefail -o noclobber -o nounset
+
+help() {
+    echo "Usage: $(basename "$0") [-hl] image_name"
+    echo
+    echo "   -h           show this help message"
+    echo "   -l           list all image names"
+}
+
+list_images() {
+    system="$(nix eval --raw --impure --expr 'builtins.currentSystem')"
+    nix eval --json ".#containers.$system" --apply builtins.attrNames | jq -r '.[]'
+}
+
+push_image() {
+    system="$(nix eval --raw --impure --expr 'builtins.currentSystem')"
+    nix run ".#containers.$system.$1.copyToRegistry"
+}
+
+while getopts ':hl' option; do
+    case "$option" in
+    h)
+        help
+        exit
+        ;;
+    l)
+        list_images
+        exit
+        ;;
+    \?)
+        printf "illegal option: -%s\n" "$OPTARG" >&2
+        help
+        exit 1
+        ;;
+    esac
+done
+
+shift $((OPTIND - 1))
+
+if [[ $# -ne 1 ]]; then
+    help
+    exit 1
+fi
+
+push_image "$1"


### PR DESCRIPTION
Dirty git repositories now resort to using the output hash as the tag (to prevent overriding someone else's testing), and two scripts have been added for pushing images:

- `scripts/login-ecr.sh`: Authenticates to ECR
- `scripts/push-image.sh`: Pushes an image to ECR (use `-l` to view a list of all image names)

Appropriate AWS accounts will need to be set up to use this. 