### PR TITLE
build: adds missing config setting for vit-ss

### DIFF
--- a/nix/vit-servicing-station/operables.nix
+++ b/nix/vit-servicing-station/operables.nix
@@ -33,6 +33,7 @@
       };
       address = "0.0.0.0:8080";
       service_version = "";
+      db_url = "";
     };
   in
     std.lib.ops.mkOperable {


### PR DESCRIPTION
The vit servicing station server exits silently if this configuration parameter is missing. We set it to an empty string here because it's passed as a flag during runtime. 