### PR TITLE
build: adds migration support to servicing-station

### DIFF
--- a/nix/lib/lib.nix
+++ b/nix/lib/lib.nix
@@ -69,7 +69,8 @@ in rec {
     pkgPath,
     cargoOptions ? [],
     nativeBuildInputs ? [],
-  }: let
+    ...
+  } @ args: let
     rootPkgCargo = readTOML (inputs.self + "/Cargo.toml");
     pkgCargo = readTOML (inputs.self + "/src/" + pkgPath + "/Cargo.toml");
     inherit (pkgCargo.package) name version;
@@ -90,31 +91,32 @@ in rec {
       ]
       ++ nativeBuildInputs;
   in
-    naersk.buildPackage {
-      inherit name version;
+    naersk.buildPackage ({
+        inherit name version;
 
-      # We have to invoke cargo from within the member's directory
-      preBuild = "cd src/${pkgPath}";
+        # We have to invoke cargo from within the member's directory
+        preBuild = "cd src/${pkgPath}";
 
-      # The output artifacts are stored in the workspace root, failing to change
-      # back will result in naesrk failing to find the artifacts.
-      postBuild = "cd -";
+        # The output artifacts are stored in the workspace root, failing to change
+        # back will result in naesrk failing to find the artifacts.
+        postBuild = "cd -";
 
-      root = inputs.self;
-      src = mkDummySrc rootPkgCargo.workspace.members filteredSrc;
+        root = inputs.self;
+        src = mkDummySrc rootPkgCargo.workspace.members filteredSrc;
 
-      nativeBuildInputs = nativeBuildInputs';
+        nativeBuildInputs = nativeBuildInputs';
 
-      cargoBuildOptions = x: x ++ cargoOptions;
-      cargoTestOptions = x: x ++ cargoOptions;
+        cargoBuildOptions = x: x ++ cargoOptions;
+        cargoTestOptions = x: x ++ cargoOptions;
 
-      PROTOC = "${nixpkgs.protobuf}/bin/protoc";
-      PROTOC_INCLUDE = "${nixpkgs.protobuf}/include";
+        PROTOC = "${nixpkgs.protobuf}/bin/protoc";
+        PROTOC_INCLUDE = "${nixpkgs.protobuf}/include";
 
-      buildInputs = with nixpkgs; [
-        openssl
-      ];
-    };
+        buildInputs = with nixpkgs; [
+          openssl
+        ];
+      }
+      // args);
 
   # Maps a function to all possible namespaces, returning results of the
   # function calls as an attribute set where the key is `{service}-{namespace}`

--- a/nix/lib/lib.nix
+++ b/nix/lib/lib.nix
@@ -71,6 +71,7 @@ in rec {
     nativeBuildInputs ? [],
     ...
   } @ args: let
+    args' = builtins.removeAttrs args ["pkgPath" "cargoOptions" "nativeBuildInputs"];
     rootPkgCargo = readTOML (inputs.self + "/Cargo.toml");
     pkgCargo = readTOML (inputs.self + "/src/" + pkgPath + "/Cargo.toml");
     inherit (pkgCargo.package) name version;
@@ -116,7 +117,7 @@ in rec {
           openssl
         ];
       }
-      // args);
+      // args');
 
   # Maps a function to all possible namespaces, returning results of the
   # function calls as an attribute set where the key is `{service}-{namespace}`

--- a/nix/vit-servicing-station/operables.nix
+++ b/nix/vit-servicing-station/operables.nix
@@ -38,8 +38,9 @@
   in
     std.lib.ops.mkOperable {
       inherit package;
-      runtimeInputs = [
+      runtimeInputs = with nixpkgs; [
         artifacts'
+        diesel-cli
       ];
       runtimeScript = let
         configFile =
@@ -51,15 +52,21 @@
           ''
             cp $configPath $out
           '';
-      in
-        std.lib.ops.mkOperableScript {
-          inherit package;
-          args = {
-            "--in-settings-file" = configFile;
-            "--service-version" = "$VERSION";
-            "--db-url" = "$DB_URL";
-          };
-        };
+      in ''
+        echo ">>> Entering entrypoint script..."
+
+        if [[ -n "$MIGRATE" ]]; then
+          echo ">>> Running migrations..."
+          export DATABASE_URL="$DB_URL"
+          diesel migration run --migration-dir "${package}/migrations"
+        fi
+
+        echo ">>> Running servicing station..."
+        exec ${l.getExe package} \
+          --in-settings-file "${configFile}" \
+          --service-version "$VERSION" \
+          --db-url "$DB_URL"
+      '';
     };
 in
   {}

--- a/nix/vit-servicing-station/operables.nix
+++ b/nix/vit-servicing-station/operables.nix
@@ -35,10 +35,15 @@
       service_version = "";
       db_url = "";
     };
+
+    diesel-cli = nixpkgs.diesel-cli.override {
+      sqliteSupport = false;
+      mysqlSupport = false;
+    };
   in
     std.lib.ops.mkOperable {
       inherit package;
-      runtimeInputs = with nixpkgs; [
+      runtimeInputs = [
         artifacts'
         diesel-cli
       ];

--- a/nix/vit-servicing-station/packages.nix
+++ b/nix/vit-servicing-station/packages.nix
@@ -10,5 +10,10 @@
   mkSimplePkg = subPkg: lib.mkPackage {pkgPath = "${name}/${subPkg}";};
 in {
   vit-servicing-station-cli = mkSimplePkg "vit-servicing-station-cli";
-  vit-servicing-station-server = mkSimplePkg "vit-servicing-station-server";
+  vit-servicing-station-server = lib.mkPackage {
+    pkgPath = "${name}/vit-servicing-station-server";
+    postInstall = ''
+      cp -r src/vit-servicing-station/vit-servicing-station-lib/migrations/postgres $out/migrations
+    '';
+  };
 }


### PR DESCRIPTION
Allows the servicing station container to automatically run database migrations by setting the `MIGRATION` environment variable.