### PR TITLE
move tracing and opentelemetry crates to workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,5 +56,18 @@ members = [
 [workspace.dependencies]
 proptest = { git = "https://github.com/input-output-hk/proptest.git" }
 
+# Observability tools to instrument, generate, collect, and export telemetry data. 
+opentelemetry = { version = "0.18", features = ["rt-tokio"] }
+opentelemetry-otlp = "0.11.0"
+opentelemetry-semantic-conventions = "0.10.0"
+
+# Framework for instrumenting Rust programs to collect structured, event-based diagnostic information.
+tracing = "0.1.37"
+tracing-appender = "0.2.2"
+tracing-futures = "0.2.5"
+tracing-subscriber = "0.3.16"
+tracing-opentelemetry = "0.18.0"
+tracing-test = "0.2.3"
+
 [patch.crates-io]
 cryptoxide = { git = "https://github.com/typed-io/cryptoxide.git" }

--- a/src/catalyst-toolbox/catalyst-toolbox/Cargo.toml
+++ b/src/catalyst-toolbox/catalyst-toolbox/Cargo.toml
@@ -62,8 +62,8 @@ gag = "1"
 vit-servicing-station-lib = { path = "../../vit-servicing-station/vit-servicing-station-lib" }
 snapshot-lib = { path = "../snapshot-lib" }
 fraction = "0.12"
-tracing = "0.1"
-tracing-subscriber = "0.3"
+tracing.workspace = true
+tracing-subscriber.workspace = true
 
 [dev-dependencies]
 rand_chacha = "0.3"

--- a/src/jormungandr/explorer/Cargo.toml
+++ b/src/jormungandr/explorer/Cargo.toml
@@ -24,14 +24,14 @@ thiserror = "1.0.20"
 anyhow = "1.0.56"
 url = { version = "2.1.1", features = ["serde"] }
 warp = {version = "0.3.1", features = ["tls"]}
-tracing = "0.1"
-tracing-futures = "0.2"
-tracing-subscriber = { version = "0.3", features = ["fmt", "json"] }
-tracing-appender = "0.2"
-tracing-opentelemetry = "0.18.0"
-opentelemetry = { version = "0.18.0", features = ["rt-tokio"] }
-opentelemetry-otlp = "0.11.0"
-opentelemetry-semantic-conventions = "0.10.0"
+tracing.workspace = true
+tracing-futures.workspace = true
+tracing-subscriber = { workspace = true, features = ["fmt", "json"] }
+tracing-appender.workspace = true
+tracing-opentelemetry.workspace = true
+opentelemetry.workspace = true
+opentelemetry-otlp.workspace = true
+opentelemetry-semantic-conventions.workspace = true
 tokio = { version = "^1.4", features = ["rt-multi-thread", "time", "sync", "rt", "signal", "test-util"] }
 tokio-stream = { version = "0.1.4", features = ["sync"] }
 tokio-util = { version = "0.6.0", features = ["time"] }

--- a/src/jormungandr/jormungandr/Cargo.toml
+++ b/src/jormungandr/jormungandr/Cargo.toml
@@ -34,9 +34,9 @@ jormungandr-lib = { path = "../jormungandr-lib" }
 keynesis = "1.1"
 lazy_static = "1.4"
 linked-hash-map = "0.5"
-opentelemetry = { version = "0.18", features = ["rt-tokio"] }
-opentelemetry-otlp = "0.11.0"
-opentelemetry-semantic-conventions = "0.10.0"
+opentelemetry.workspace = true
+opentelemetry-otlp.workspace = true
+opentelemetry-semantic-conventions.workspace = true
 poldercast = "1.2"
 multiaddr = { package = "parity-multiaddr", version = "0.11" }
 rand = "0.8"
@@ -48,14 +48,14 @@ serde_yaml = "0.8"
 structopt = "^0.3"
 time = { version = "0.3", features = ["macros"] }
 thiserror = "1.0.30"
-tracing = "0.1"
-tracing-futures = "0.2"
+tracing.workspace = true
+tracing-futures.workspace = true
 tracing-gelf = { version = "0.6", optional = true }
 # TODO unpin this when cross for ARM targets is fixed: https://github.com/cross-rs/cross/pull/591
 tracing-journald = { version = "=0.2.0", optional = true }
-tracing-opentelemetry = "0.18.0"
-tracing-subscriber = { version = "0.3", features = ["fmt", "json", "time"] }
-tracing-appender = "0.2"
+tracing-opentelemetry.workspace = true
+tracing-subscriber = { workspace = true, features = ["fmt", "json", "time"] }
+tracing-appender.workspace = true
 tokio = { version = "^1.15", features = ["rt-multi-thread", "time", "sync", "rt", "signal", "test-util"] }
 tokio-stream = { version = "0.1.4", features = ["sync"] }
 tokio-util = { version = "0.6.0", features = ["time"] }

--- a/src/jormungandr/testing/jormungandr-automation/Cargo.toml
+++ b/src/jormungandr/testing/jormungandr-automation/Cargo.toml
@@ -55,7 +55,7 @@ graphql_client = "0.10.0"
 semver = { version = "1.0", features = ["serde"] }
 json = "0.12.4"
 strum = { version = "0.24", features = ["derive"] }
-tracing = "0.1"
+tracing.workspace = true
 log = { version = "0.4", features = ["serde"] }
 netstat2 = "0.9"
 multiaddr = { package = "parity-multiaddr", version = "0.11" }
@@ -71,7 +71,7 @@ default-features = false
 features = ["blocking", "json", "rustls-tls"]
 
 [dependencies.tracing-subscriber]
-version = "0.3"
+workspace = true
 default-features = false
 features = ["json","fmt"]
 

--- a/src/jormungandr/testing/jormungandr-integration-tests/Cargo.toml
+++ b/src/jormungandr/testing/jormungandr-integration-tests/Cargo.toml
@@ -47,7 +47,7 @@ tempfile = "3"
 json = "0.12.4"
 multiaddr = { package = "parity-multiaddr", version = "0.11" }
 rstest = "0.12.0"
-tracing = "0.1"
+tracing.workspace = true
 
 [dependencies.reqwest]
 version = "0.11"

--- a/src/vit-servicing-station/vit-servicing-station-lib/Cargo.toml
+++ b/src/vit-servicing-station/vit-servicing-station-lib/Cargo.toml
@@ -26,9 +26,9 @@ structopt = "0.3.14"
 r2d2 = "0.8.10"
 thiserror = "1.0.30"
 tokio = { version = "1.18.0", features = ["macros", "signal", "rt", "fs", "sync"] }
-tracing = "0.1.34"
-tracing-futures = "0.2.4"
-tracing-subscriber = "0.3"
+tracing.workspace = true
+tracing-futures.workspace = true
+tracing-subscriber.workspace = true
 warp = { version = "0.3.2", features = ["tls"] }
 snapshot-lib = { path = "../../catalyst-toolbox/snapshot-lib" }
 chain-ser = { path = "../../chain-libs/chain-ser" }

--- a/src/vit-servicing-station/vit-servicing-station-server/Cargo.toml
+++ b/src/vit-servicing-station/vit-servicing-station-server/Cargo.toml
@@ -8,16 +8,16 @@ edition = "2018"
 
 [dependencies]
 log = "0.4.11"
-opentelemetry = { version = "0.18", features = ["rt-tokio"] }
-opentelemetry-otlp = "0.11.0"
-opentelemetry-semantic-conventions = "0.10.0"
+opentelemetry.workspace = true
+opentelemetry-otlp.workspace = true
+opentelemetry-semantic-conventions.workspace = true
 structopt = "0.3.14"
 thiserror = "1.0.37"
 tokio = { version = "^1.0", features = ["macros", "rt-multi-thread"] }
-tracing = "0.1.21"
-tracing-futures = "0.2.4"
-tracing-subscriber = { version = "0.3", features=["fmt"] }
-tracing-appender = "0.2"
-tracing-opentelemetry = "0.18.0"
+tracing.workspace = true
+tracing-futures.workspace = true
+tracing-subscriber = { workspace = true, features=["fmt"] }
+tracing-appender.workspace = true
+tracing-opentelemetry.workspace = true
 url = "2"
 vit-servicing-station-lib = { path = "../vit-servicing-station-lib" }

--- a/src/vit-testing/db-sync-explorer/Cargo.toml
+++ b/src/vit-testing/db-sync-explorer/Cargo.toml
@@ -12,7 +12,7 @@ microtype = { version = "0.7.5", features = ["serde"] } # defining secrecy and d
 diesel =  { version = "2", features = ["postgres", "64-column-tables", "numeric", "serde_json", "r2d2"]} # connector lib
 diesel-derive-enum = "2.0.0-rc.0" #extension to diesel
 chrono = "0.4.23"
-tracing = "0.1"
+tracing.workspace = true
 bigdecimal = "0.3.0"
 warp = { version = "0.3.2", features = ["tls"] }
 vit-servicing-station-lib  = { path = "../../vit-servicing-station/vit-servicing-station-lib" }
@@ -21,8 +21,7 @@ thiserror = "1.0.37"
 http-zipkin = "0.3.0"
 jortestkit = { path = "../../jortestkit" }
 tokio = { version = "1.18.0", features = ["macros", "signal", "rt", "fs", "sync"] }
-tracing-subscriber = "0.3"
+tracing-subscriber.workspace = true
 clap = { version = "3.2", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-

--- a/src/vit-testing/mainnet-tools/Cargo.toml
+++ b/src/vit-testing/mainnet-tools/Cargo.toml
@@ -36,8 +36,8 @@ job_scheduler_ng = "*"
 snapshot-lib = { path = "../../catalyst-toolbox/snapshot-lib", features=["proptest"] }
 snapshot-trigger-service = { path = "../snapshot-trigger-service" }
 clap = { version = "4", features = ["derive"] }
-tracing = "0.1"
-tracing-subscriber = "0.3"
+tracing.workspace = true
+tracing-subscriber.workspace = true
 warp = "0.3.3"
 futures-util = "0.3.25"
 

--- a/src/vit-testing/scheduler-service-lib/Cargo.toml
+++ b/src/vit-testing/scheduler-service-lib/Cargo.toml
@@ -18,7 +18,7 @@ futures = "0.3.8"
 tokio = { version = "1.2", features = ["macros","rt","process"] }
 jortestkit = { path = "../../jortestkit" }
 serde_yaml = "0.8"
-tracing = "0.1"
+tracing.workspace = true
 
 [dependencies.reqwest]
 version = "0.11"

--- a/src/vit-testing/snapshot-trigger-service/Cargo.toml
+++ b/src/vit-testing/snapshot-trigger-service/Cargo.toml
@@ -28,7 +28,7 @@ tokio = { version = "1.2", features = ["macros","rt","process"] }
 serde_json = "1.0"
 serde_yaml = "0.8"
 signals-handler = { path = "../signals-handler" }
-tracing = "0.1"
+tracing.workspace = true
 
 [dependencies.reqwest]
 version = "0.11"

--- a/src/vit-testing/vitup/Cargo.toml
+++ b/src/vit-testing/vitup/Cargo.toml
@@ -70,9 +70,9 @@ json = "0.12.4"
 image = "0.23"
 base64 = "0.13"
 uuid = { version = "0.8", features = ["serde", "v4"] }
-tracing-subscriber = { version = "0.3", features= ["std", "env-filter"] }
-tracing = "0.1"
-tracing-appender = "0.2"
+tracing-subscriber = { workspace = true, features= ["std", "env-filter"] }
+tracing.workspace = true
+tracing-appender.workspace = true
 hyper = { version = "0.14.17", features = ["server"] }
 rustls = "0.20.4"
 rustls-pemfile = "1"

--- a/src/voting-tools-rs/Cargo.toml
+++ b/src/voting-tools-rs/Cargo.toml
@@ -23,8 +23,8 @@ bigdecimal = { version = "0.3", features = ["serde"] }
 
 hex = "0.4"
 
-tracing = "0.1"
-tracing-subscriber = "0.3"
+tracing.workspace = true
+tracing-subscriber.workspace = true
 rust_decimal = { version = "1.26", features = ["serde", "db-postgres"] }
 
 mainnet-lib = { path = "../vit-testing/mainnet-lib"}
@@ -36,7 +36,7 @@ test-strategy = "0.2"
 serial_test = "0.9"
 assert_fs = "1.0.7"
 tempdir = "0.3"
-tracing-test = "0.2"
+tracing-test.workspace = true
 insta = { version = "1", features = ["json"] }
 postgres = "0.19"  # just to create the reference db in case it doesn't already exist
 diesel_migrations="2"


### PR DESCRIPTION
adjust member manifests.