### PR TITLE
docs: fixed reference in VIT-SS API docs

### DIFF
--- a/book/src/core-vitss-doc/api/v0.yaml
+++ b/book/src/core-vitss-doc/api/v0.yaml
@@ -357,7 +357,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/VotersInfo"
+                $ref: "#/components/schemas/DelegatorInfo"
         "400":
           description: Not found
 


### PR DESCRIPTION
## Change
[/snapshot/delegator/](https://github.com/input-output-hk/catalyst-core/blob/3f64ee55fa0055eb8e45a27b136290b129578094/book/src/core-vitss-doc/api/v0.yaml#L336) should $ref [DelegatorInfo](https://github.com/input-output-hk/catalyst-core/blob/3f64ee55fa0055eb8e45a27b136290b129578094/book/src/core-vitss-doc/api/v0.yaml#L1170) not [VotersInfo](https://github.com/input-output-hk/catalyst-core/blob/3f64ee55fa0055eb8e45a27b136290b129578094/book/src/core-vitss-doc/api/v0.yaml#L1016), 

I think VotersInfo was just copied from /snapshot/voter/ endpoint.

cc: @stevenj 