### PR TITLE
Fix wallet-js publishing

### DIFF
--- a/.github/workflows/js_wallet_publish.yml
+++ b/.github/workflows/js_wallet_publish.yml
@@ -39,8 +39,8 @@ jobs:
       fail-fast: false
       matrix:
         target: [
-                nodejs, 
-                # web,
+                # nodejs, 
+                web,
                 # bundler
                 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8428,7 +8428,7 @@ dependencies = [
 
 [[package]]
 name = "wallet-wasm-js"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "bech32 0.7.3",
  "chain-core",

--- a/src/chain-wallet-libs/bindings/wallet-wasm-js/Cargo.toml
+++ b/src/chain-wallet-libs/bindings/wallet-wasm-js/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 name = "wallet-wasm-js"
 repository = "https://github.com/input-output-hk/catalyst-core"
-version = "0.8.3"
+version = "0.8.4"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/src/chain-wallet-libs/bindings/wallet-wasm-js/js/index.js
+++ b/src/chain-wallet-libs/bindings/wallet-wasm-js/js/index.js
@@ -1,14 +1,13 @@
-const wasm = require("wallet-wasm-js");
+import wasm from "wallet-wasm-js";
 
-class BlockDate {
+export class BlockDate {
   constructor(epoch, slot) {
     this.epoch = epoch;
     this.slot = slot;
   }
 }
-module.exports.BlockDate = BlockDate;
 
-class Settings {
+export class Settings {
   constructor(json) {
     this.settings = wasm.Settings.from_json(json);
   }
@@ -17,9 +16,8 @@ class Settings {
     return this.settings.to_json();
   }
 }
-module.exports.Settings = Settings;
 
-class Proposal {
+export class Proposal {
   constructor(votePlan, voteOptions, proposalIndex, voteEncKey) {
     this.votePlan = votePlan;
     this.voteOptions = voteOptions;
@@ -27,9 +25,8 @@ class Proposal {
     this.voteEncKey = voteEncKey;
   }
 }
-module.exports.Proposal = Proposal;
 
-class Vote {
+export class Vote {
   constructor(
     proposal,
     choice,
@@ -44,9 +41,8 @@ class Vote {
     this.spendingCounterLane = spendingCounterLane;
   }
 }
-module.exports.Vote = Vote;
 
-function signVotes(votes, settings, accountId, privateKey) {
+export function signVotes(votes, settings, accountId, privateKey) {
   let tx_builders = [];
   for (let i = 0; i < votes.length; i++) {
     let vote = votes[i];
@@ -93,4 +89,3 @@ function signVotes(votes, settings, accountId, privateKey) {
   }
   return tx_builders;
 }
-module.exports.signVotes = signVotes;

--- a/src/chain-wallet-libs/bindings/wallet-wasm-js/js/package.json
+++ b/src/chain-wallet-libs/bindings/wallet-wasm-js/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@catalyst-core/wallet-js",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Jormungandr wallet capabilities for Javascript",
   "main": "index.js",
   "types": "index.d.ts",
@@ -9,7 +9,8 @@
     "url": "https://github.com/input-output-hk/catalyst-core"
   },
   "license": "MIT",
+  "type": "module",
   "dependencies": {
-    "@catalyst-core/wallet-wasm-js": "0.8.3"
+    "@catalyst-core/wallet-wasm-js": "0.8.4"
   }
 }

--- a/src/chain-wallet-libs/bindings/wallet-wasm-js/js/package_test.json
+++ b/src/chain-wallet-libs/bindings/wallet-wasm-js/js/package_test.json
@@ -1,6 +1,6 @@
 {
   "name": "wallet-js",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Jormungandr wallet capabilities for Javascript",
   "main": "index.js",
   "repository": {
@@ -8,6 +8,7 @@
     "url": "https://github.com/input-output-hk/catalyst-core"
   },
   "license": "MIT",
+  "type": "module",
   "devDependencies": {
     "wallet-wasm-js": "file:../pkg"
   }


### PR DESCRIPTION
Update wallet-js package publishing, change wasm target from `nodejs` to `web`. Modify modules managing approach from `CommonJs` to `ES` standard.