### PR TITLE
Revert "Dedup 7"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,7 +58,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cipher 0.3.0",
  "cpufeatures",
  "opaque-debug",
@@ -399,7 +399,7 @@ checksum = "cab84319d616cfb654d03394f38ab7e6f0919e181b1b57e1fd15e7fb4077d9a7"
 dependencies = [
  "addr2line",
  "cc",
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "miniz_oxide 0.5.4",
  "object",
@@ -728,13 +728,13 @@ dependencies = [
 
 [[package]]
 name = "cardano-serialization-lib"
-version = "11.2.1"
+version = "11.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0850b05eab185a58c65e705b254074d47ac89e5dc54dd596a412753524397f5"
+checksum = "fcaa9ea0a848f7219becefb243acf75cd99880fb9199d8eabd96aebd93abde9d"
 dependencies = [
  "bech32 0.7.3",
  "cbor_event",
- "cfg-if",
+ "cfg-if 1.0.0",
  "clear_on_drop",
  "cryptoxide 0.4.2",
  "digest 0.9.0",
@@ -779,7 +779,7 @@ dependencies = [
  "chain-time",
  "chain-vote",
  "color-eyre",
- "csv 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "csv",
  "fraction",
  "futures",
  "gag",
@@ -844,6 +844,12 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -854,7 +860,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7fc89c7c5b9e7a02dfe45cd2367bae382f9ed31c61ca8debe5f827c420a2f08"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cipher 0.4.3",
  "cpufeatures",
 ]
@@ -1045,7 +1051,7 @@ dependencies = [
 name = "chain-vote"
 version = "0.1.0"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "chain-core",
  "chain-crypto",
  "const_format",
@@ -1317,7 +1323,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "wasm-bindgen",
 ]
 
@@ -1378,7 +1384,7 @@ version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1391,7 +1397,7 @@ dependencies = [
  "cast",
  "clap 2.34.0",
  "criterion-plot",
- "csv 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "csv",
  "futures",
  "itertools",
  "lazy_static",
@@ -1436,7 +1442,7 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
 ]
 
@@ -1446,7 +1452,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
@@ -1458,7 +1464,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
 dependencies = [
  "autocfg",
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
  "memoffset 0.7.1",
  "scopeguard",
@@ -1470,7 +1476,7 @@ version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1528,20 +1534,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
 dependencies = [
  "bstr 0.2.17",
- "csv-core 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "csv-core",
  "itoa 0.4.8",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "csv"
-version = "1.1.6"
-source = "git+https://github.com/BurntSushi/rust-csv#41c71ed353a71526c52633d854466c1619dacae4"
-dependencies = [
- "bstr 0.2.17",
- "csv-core 0.1.10 (git+https://github.com/BurntSushi/rust-csv)",
- "itoa 1.0.4",
  "ryu",
  "serde",
 ]
@@ -1551,14 +1545,6 @@ name = "csv-core"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.10"
-source = "git+https://github.com/BurntSushi/rust-csv#41c71ed353a71526c52633d854466c1619dacae4"
 dependencies = [
  "memchr",
 ]
@@ -1723,7 +1709,7 @@ version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "hashbrown 0.12.3",
  "lock_api",
  "once_cell",
@@ -1968,7 +1954,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "dirs-sys-next",
 ]
 
@@ -2094,7 +2080,7 @@ version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -2400,7 +2386,7 @@ version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b9663d381d07ae25dc88dbdf27df458faa83a9b25336bcac83d5e452b5fc9d3"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "redox_syscall",
  "windows-sys 0.42.0",
@@ -2652,7 +2638,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
@@ -2663,7 +2649,7 @@ version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
@@ -3202,7 +3188,7 @@ dependencies = [
  "cocoon",
  "console",
  "cryptoxide 0.4.2",
- "csv 1.1.6 (git+https://github.com/BurntSushi/rust-csv)",
+ "csv",
  "dialoguer",
  "dirs",
  "eccoxide 0.2.0",
@@ -3439,7 +3425,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -3449,14 +3435,14 @@ dependencies = [
  "assert_cmd",
  "assert_fs",
  "catalyst-toolbox",
- "cfg-if",
+ "cfg-if 1.0.0",
  "chain-addr",
  "chain-core",
  "chain-crypto",
  "chain-impl-mockchain",
  "chain-ser",
  "chrono",
- "csv 1.1.6 (git+https://github.com/BurntSushi/rust-csv)",
+ "csv",
  "fraction",
  "hersir",
  "hex",
@@ -3530,7 +3516,7 @@ checksum = "fbaf47fa129710ae041d5844a15b1365bdad8551673aee237449ba9dec6bcadc"
 dependencies = [
  "async-trait",
  "bytes",
- "cfg-if",
+ "cfg-if 1.0.0",
  "common-multipart-rfc7578",
  "dirs",
  "futures",
@@ -3633,7 +3619,7 @@ checksum = "854c3036c710866ee61a7e1cd7f39988dd077d0d97ce5dd23b0a1f64f3fffb42"
 dependencies = [
  "chrono",
  "cron",
- "uuid",
+ "uuid 1.2.2",
 ]
 
 [[package]]
@@ -3885,7 +3871,7 @@ dependencies = [
  "bech32 0.8.1",
  "bytesize",
  "console",
- "csv 1.1.6 (git+https://github.com/BurntSushi/rust-csv)",
+ "csv",
  "custom_debug",
  "dialoguer",
  "flate2",
@@ -4172,7 +4158,7 @@ version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "serde",
 ]
 
@@ -4273,7 +4259,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "uuid",
+ "uuid 1.2.2",
  "vit-servicing-station-lib",
  "vit-servicing-station-tests",
  "voting_tools_rs",
@@ -4631,7 +4617,7 @@ checksum = "e322c04a9e3440c327fca7b6c8a63e6890a32fa2ad689db972425f07e0d22abb"
 dependencies = [
  "autocfg",
  "bitflags",
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "memoffset 0.6.5",
  "pin-utils",
@@ -4868,7 +4854,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "020433887e44c27ff16365eaa2d380547a94544ad509aff6eb5b6e3e0b27b376"
 dependencies = [
  "bitflags",
- "cfg-if",
+ "cfg-if 1.0.0",
  "foreign-types",
  "libc",
  "once_cell",
@@ -5103,7 +5089,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "instant",
  "libc",
  "redox_syscall",
@@ -5117,7 +5103,7 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "redox_syscall",
  "smallvec",
@@ -5356,7 +5342,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8419d2b623c7c0896ff2d5d96e2cb4ede590fed28fcc34934f4c33c036e620a1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "opaque-debug",
  "universal-hash 0.4.1",
@@ -5479,7 +5465,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f375cb74c23b51d23937ffdeb48b1fbf5b6409d4b9979c1418c1de58bc8f801"
 dependencies = [
  "atty",
- "csv 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "csv",
  "encode_unicode 1.0.0",
  "lazy_static",
  "term",
@@ -5565,7 +5551,7 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "449811d15fbdf5ceb5c1144416066429cf82316e2ec8ce0c1f6f8a02e7bbcf8c"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "fnv",
  "lazy_static",
  "memchr",
@@ -6180,7 +6166,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d912f35156a3f99a66ee3e11ac2e0b3f34ac85a07e05263d05a7e2c8810d616f"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -6333,7 +6319,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88d8a765117b237ef233705cc2cc4c6a27fccd46eea6ef0c8c6dae5f3ef407f8"
 dependencies = [
  "bitvec",
- "cfg-if",
+ "cfg-if 1.0.0",
  "derive_more",
  "parity-scale-codec",
  "scale-info-derive",
@@ -6385,7 +6371,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
- "uuid",
+ "uuid 0.8.2",
  "walkdir",
  "warp",
 ]
@@ -6680,7 +6666,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug",
@@ -6692,7 +6678,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.10.6",
 ]
@@ -6703,7 +6689,7 @@ version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.10.6",
 ]
@@ -6715,7 +6701,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug",
@@ -6727,7 +6713,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.10.6",
 ]
@@ -6889,7 +6875,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
- "uuid",
+ "uuid 0.8.2",
  "voting_tools_rs",
  "walkdir",
  "warp",
@@ -7104,7 +7090,7 @@ version = "0.26.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29ddf41e393a9133c81d5f0974195366bd57082deac6e0eb02ed39b8341c2bb6"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "core-foundation-sys",
  "libc",
  "ntapi",
@@ -7146,7 +7132,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "fastrand",
  "libc",
  "redox_syscall",
@@ -7664,7 +7650,7 @@ version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "log",
  "pin-project-lite",
  "tracing-attributes",
@@ -8046,12 +8032,21 @@ checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom 0.2.8",
+ "serde",
+]
+
+[[package]]
+name = "uuid"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "422ee0de9031b5b948b97a8fc04e3aa35230001a722ddd27943e0be31564ce4c"
 dependencies = [
  "getrandom 0.2.8",
- "serde",
 ]
 
 [[package]]
@@ -8125,7 +8120,7 @@ name = "vit-servicing-station-cli"
 version = "0.3.4-dev"
 dependencies = [
  "base64",
- "csv 1.1.6 (git+https://github.com/BurntSushi/rust-csv)",
+ "csv",
  "diesel 1.4.8",
  "diesel_migrations 1.4.0",
  "r2d2",
@@ -8205,7 +8200,7 @@ dependencies = [
  "assert_cmd",
  "assert_fs",
  "base64",
- "cfg-if",
+ "cfg-if 0.1.10",
  "chain-addr",
  "chain-crypto",
  "chain-impl-mockchain",
@@ -8253,7 +8248,7 @@ dependencies = [
  "chain-time",
  "chain-vote",
  "console",
- "csv 1.1.6 (git+https://github.com/BurntSushi/rust-csv)",
+ "csv",
  "ctrlc",
  "custom_debug",
  "dialoguer",
@@ -8308,7 +8303,7 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "url",
- "uuid",
+ "uuid 0.8.2",
  "valgrind",
  "vit-servicing-station-lib",
  "vit-servicing-station-tests",
@@ -8530,7 +8525,7 @@ version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "wasm-bindgen-macro",
 ]
 
@@ -8555,7 +8550,7 @@ version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23639446165ca5a5de86ae1d8896b737ae80319560fbaa4c2887b7da6e7ebd7d"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "js-sys",
  "wasm-bindgen",
  "web-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,10 +55,6 @@ members = [
 
 [workspace.dependencies]
 proptest = { git = "https://github.com/input-output-hk/proptest.git" }
-uuid = { version = "1", features = ["v4", "serde"] }
-# we use this branch because it uses v1 of `itoa`, but the latest crates.io release doesn't
-csv = { git = "https://github.com/BurntSushi/rust-csv" }
-cfg-if = "1"
 
 # Observability tools to instrument, generate, collect, and export telemetry data. 
 opentelemetry = { version = "0.18", features = ["rt-tokio"] }

--- a/src/chain-libs/chain-vote/Cargo.toml
+++ b/src/chain-libs/chain-vote/Cargo.toml
@@ -20,7 +20,7 @@ smoke = "^0.2.1"
 criterion = "0.3"
 
 [build-dependencies]
-cfg-if = { workspace = true }
+cfg-if = "*"
 
 
 [[bench]]

--- a/src/jortestkit/Cargo.toml
+++ b/src/jortestkit/Cargo.toml
@@ -35,7 +35,7 @@ fs_extra = "1.1.0"
 console = "0.15"
 dialoguer = "0.10"
 semver = "1.0"
-csv = { workspace = true }
+csv = "1.1.3"
 warp = "0.3"
 base64 = "0.13.0"
 rayon = "1"

--- a/src/vit-servicing-station/vit-servicing-station-cli/Cargo.toml
+++ b/src/vit-servicing-station/vit-servicing-station-cli/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 base64 = "0.13"
 time = "0.3"
-csv = { workspace = true }
+csv = "1.1"
 diesel = "1.4"
 rand = "0.7.3"
 r2d2 = "0.8"

--- a/src/vit-servicing-station/vit-servicing-station-tests/Cargo.toml
+++ b/src/vit-servicing-station/vit-servicing-station-tests/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 base64 = "0.13"
-cfg-if = { workspace = true }
+cfg-if = "0.1"
 time = { version = "0.3", features = ["formatting", "parsing", "macros"] }
 diesel = { version = "1.4.4", features = ["sqlite", "r2d2"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/src/vit-testing/iapyx/Cargo.toml
+++ b/src/vit-testing/iapyx/Cargo.toml
@@ -44,7 +44,7 @@ regex = "*"
 dialoguer = "0.10"
 structopt = "0.3"
 console = "0.15"
-csv = { workspace = true }
+csv = "1.1"
 warp = { version = "0.3", features = ["tls"] }
 warp-reverse-proxy = "0.3.2"
 tokio = { version = "^1.4.0", features = ["macros", "signal", "rt", "fs", "sync"] }

--- a/src/vit-testing/integration-tests/Cargo.toml
+++ b/src/vit-testing/integration-tests/Cargo.toml
@@ -38,13 +38,13 @@ rand = "0.8"
 hex = "0.4.3"
 lazy_static = "1"
 libmath = "0.2.1"
-cfg-if = { workspace = true }
+cfg-if = "1.0.0"
 assert_fs = "1.0"
 assert_cmd = "2"
 chrono = "0.4.19"
 serde_json = "1.0.53"
 serde = "1.0.53"
-csv = { workspace = true }
+csv = "1.1"
 fraction = "0.12"
 
 [features]

--- a/src/vit-testing/mainnet-tools/Cargo.toml
+++ b/src/vit-testing/mainnet-tools/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-uuid = { workspace = true }
+uuid = "1.2.2"
 hex = "0.4"
 bech32 = "0.8.1"
 structopt = "0.3"

--- a/src/vit-testing/scheduler-service-lib/Cargo.toml
+++ b/src/vit-testing/scheduler-service-lib/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 structopt = "0.3.26"
 serde_json = "1.0.86"
 serde = { version = "1", features = ["derive"] }
-uuid = { workspace = true }
+uuid = { version = "0.8", features = ["serde","v4"] }
 chrono = { version = "0.4", features = ["serde"] }
 thiserror = "1.0"
 walkdir = "2.3.1"

--- a/src/vit-testing/snapshot-trigger-service/Cargo.toml
+++ b/src/vit-testing/snapshot-trigger-service/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-uuid = { workspace = true }
+uuid = { version = "0.8", features = ["serde","v4"] }
 chrono = { version = "0.4", features = ["serde"] }
 walkdir = "2.3.1"
 structopt = "0.3"

--- a/src/vit-testing/vitup/Cargo.toml
+++ b/src/vit-testing/vitup/Cargo.toml
@@ -16,7 +16,7 @@ assert_fs = "1.0"
 glob = "0.3.0"
 ctrlc = "3.2.1"
 walkdir = "2.3.1"
-csv = { workspace = true}
+csv = "1.1"
 itertools = "0.10.3"
 chain-core           = { path = "../../chain-libs/chain-core" }
 chain-crypto         = { path = "../../chain-libs/chain-crypto", features = [ "property-test-api" ] }
@@ -69,7 +69,7 @@ tokio = { version = "1.4", features = ["macros","rt","rt-multi-thread"] }
 json = "0.12.4"
 image = "0.23"
 base64 = "0.13"
-uuid = { workspace = true }
+uuid = { version = "0.8", features = ["serde", "v4"] }
 tracing-subscriber = { workspace = true, features= ["std", "env-filter"] }
 tracing.workspace = true
 tracing-appender.workspace = true

--- a/src/voting-tools-rs/src/model/mod.rs
+++ b/src/voting-tools-rs/src/model/mod.rs
@@ -110,9 +110,7 @@ impl RewardsAddr {
 pub fn network_info(testnet_magic: Option<TestnetMagic>) -> NetworkInfo {
     match testnet_magic {
         None => NetworkInfo::mainnet(),
-        Some(TestnetMagic(magic)) => {
-            NetworkInfo::new(NetworkInfo::testnet_preview().network_id(), magic)
-        }
+        Some(TestnetMagic(magic)) => NetworkInfo::new(NetworkInfo::testnet().network_id(), magic),
     }
 }
 


### PR DESCRIPTION
Reverts input-output-hk/catalyst-core#212

Fixes nix builds. Will troubleshoot why it broke them at a later time. 