### PR TITLE
build: defaults vit-ss to use sqlite if pgsql url is absent

### DIFF
--- a/nix/vit-servicing-station/operables.nix
+++ b/nix/vit-servicing-station/operables.nix
@@ -51,15 +51,24 @@
           ''
             cp $configPath $out
           '';
-      in
-        std.lib.ops.mkOperableScript {
-          inherit package;
-          args = {
-            "--in-settings-file" = configFile;
-            "--service-version" = "$VERSION";
-            "--db-url" = "$DB_URL";
-          };
-        };
+      in ''
+        echo ">>> Entering entrypoint script..."
+
+        echo ">>> Using version: $VERSION"
+        echo ">>> Using config file: ${configFile}"
+
+        if [[ -z "''${DB_URL:=}" ]]; then
+          echo ">>> PostgreSQL database URL not set"
+          echo ">>> Using SQLite database at: ${artifacts'}/database.sqlite3"
+          DB_URL="${artifacts'}/database.sqlite3"
+        fi
+
+        echo ">>> Running servicing station..."
+        exec ${l.getExe package} \
+          --in-settings-file "${configFile}" \
+          --service-version "$VERSION" \
+          --db-url "$DB_URL"
+      '';
     };
 in
   {}


### PR DESCRIPTION
Since we're using SQLite for the next SVE, this allows us to use a local database file temporarily and still support testing with PostgreSQL. 