### PR TITLE
Update wallet js tx building process, refactor WitnessBuilder

### DIFF
--- a/src/catalyst-toolbox/catalyst-toolbox/src/recovery/tally.rs
+++ b/src/catalyst-toolbox/catalyst-toolbox/src/recovery/tally.rs
@@ -513,6 +513,7 @@ impl FragmentReplayer {
             .get_mut(&address)
             .ok_or_else(|| ReplayError::NonVotingAccount(address.to_string()))?;
 
+        let secret_key = wallet.secret_key();
         // unwrap checked in the validation step
         let builder_help = wallet
             .new_transaction(tx.total_input().unwrap(), 0)
@@ -520,7 +521,7 @@ impl FragmentReplayer {
         let mut builder =
             TransactionBuilder::new(self.settings.clone(), vote_cast, tx.valid_until());
         builder.add_input(builder_help.input(), builder_help.witness_builder());
-        let res = Fragment::VoteCast(builder.finalize_tx(()).unwrap());
+        let res = Fragment::VoteCast(builder.finalize_tx((), vec![secret_key]).unwrap());
 
         debug!("replaying vote cast transaction from {}", address);
         self.pending_requests.insert(res.id(), address);
@@ -564,6 +565,7 @@ impl FragmentReplayer {
         };
 
         warn!("replaying a plain transaction from {} to {:?} with value {}, this is not coming from the app, might want to look into this", identifier, output_address, output.value);
+        let secret_key = wallet.secret_key();
         // unwrap checked in the validation step
         let builder_help = wallet
             .new_transaction(tx.total_input().unwrap(), 0)
@@ -571,7 +573,7 @@ impl FragmentReplayer {
         let mut builder = TransactionBuilder::new(self.settings.clone(), NoExtra, tx.valid_until());
         builder.add_input(builder_help.input(), builder_help.witness_builder());
         builder.add_output(Output::from_address(output_address, output.value));
-        let res = Fragment::Transaction(builder.finalize_tx(()).unwrap());
+        let res = Fragment::Transaction(builder.finalize_tx((), vec![secret_key]).unwrap());
         self.pending_requests.insert(res.id(), address);
         Ok(res)
     }

--- a/src/catalyst-toolbox/catalyst-toolbox/src/recovery/tally.rs
+++ b/src/catalyst-toolbox/catalyst-toolbox/src/recovery/tally.rs
@@ -30,7 +30,7 @@ use std::collections::{HashMap, HashSet};
 use std::ops::{Add, Range};
 use std::time::{Duration, SystemTime};
 use tracing::{debug, error, trace, warn};
-use wallet::{Settings, TransactionBuilder, Wallet};
+use wallet::{transaction::WitnessInput, Settings, TransactionBuilder, Wallet};
 
 #[allow(clippy::large_enum_variant)]
 #[derive(thiserror::Error, Debug)]
@@ -521,7 +521,11 @@ impl FragmentReplayer {
         let mut builder =
             TransactionBuilder::new(self.settings.clone(), vote_cast, tx.valid_until());
         builder.add_input(builder_help.input(), builder_help.witness_builder());
-        let res = Fragment::VoteCast(builder.finalize_tx((), vec![secret_key]).unwrap());
+        let res = Fragment::VoteCast(
+            builder
+                .finalize_tx((), vec![WitnessInput::SecretKey(secret_key)])
+                .unwrap(),
+        );
 
         debug!("replaying vote cast transaction from {}", address);
         self.pending_requests.insert(res.id(), address);
@@ -573,7 +577,11 @@ impl FragmentReplayer {
         let mut builder = TransactionBuilder::new(self.settings.clone(), NoExtra, tx.valid_until());
         builder.add_input(builder_help.input(), builder_help.witness_builder());
         builder.add_output(Output::from_address(output_address, output.value));
-        let res = Fragment::Transaction(builder.finalize_tx((), vec![secret_key]).unwrap());
+        let res = Fragment::Transaction(
+            builder
+                .finalize_tx((), vec![WitnessInput::SecretKey(secret_key)])
+                .unwrap(),
+        );
         self.pending_requests.insert(res.id(), address);
         Ok(res)
     }

--- a/src/chain-libs/chain-impl-mockchain/src/transaction/witness.rs
+++ b/src/chain-libs/chain-impl-mockchain/src/transaction/witness.rs
@@ -143,12 +143,27 @@ impl AsRef<[u8]> for WitnessMultisigData {
 
 impl Witness {
     /// Creates new `Witness` value.
+
+    pub fn new_utxo_data(
+        block0: &HeaderId,
+        sign_data_hash: &TransactionSignDataHash,
+    ) -> WitnessUtxoData {
+        WitnessUtxoData::new(block0, sign_data_hash, WitnessUtxoVersion::Normal)
+    }
+
     pub fn new_utxo<F>(block0: &HeaderId, sign_data_hash: &TransactionSignDataHash, sign: F) -> Self
     where
         F: FnOnce(&WitnessUtxoData) -> Signature<WitnessUtxoData, Ed25519>,
     {
         let wud = WitnessUtxoData::new(block0, sign_data_hash, WitnessUtxoVersion::Normal);
         Witness::Utxo(sign(&wud))
+    }
+
+    pub fn new_old_utxo_data(
+        block0: &HeaderId,
+        sign_data_hash: &TransactionSignDataHash,
+    ) -> WitnessUtxoData {
+        WitnessUtxoData::new(block0, sign_data_hash, WitnessUtxoVersion::Legacy)
     }
 
     pub fn new_old_utxo<F>(
@@ -163,6 +178,14 @@ impl Witness {
         let wud = WitnessUtxoData::new(block0, sign_data_hash, WitnessUtxoVersion::Legacy);
         let (pk, sig) = sign(&wud);
         Witness::OldUtxo(pk, *some_bytes, sig)
+    }
+
+    pub fn new_account_data(
+        block0: &HeaderId,
+        sign_data_hash: &TransactionSignDataHash,
+        spending_counter: account::SpendingCounter,
+    ) -> WitnessAccountData {
+        WitnessAccountData::new(block0, sign_data_hash, spending_counter)
     }
 
     pub fn new_account<F>(

--- a/src/chain-wallet-libs/bindings/wallet-core/src/tx_builder.rs
+++ b/src/chain-wallet-libs/bindings/wallet-core/src/tx_builder.rs
@@ -1,19 +1,20 @@
 use chain_crypto::SecretKey;
 use chain_impl_mockchain::{
-    account::SpendingCounter,
+    account::{self, SpendingCounter},
     fragment::Fragment,
     header::BlockDate,
     transaction::{Input, Payload, Transaction, WitnessAccountData},
 };
-use std::{str::FromStr};
+use std::str::FromStr;
 use wallet::{
-    transaction::AccountSecretKey, AccountId, AccountWitnessBuilder, EitherAccount, Settings,
+    transaction::{AccountSecretKey, WitnessInput},
+    AccountId, AccountWitnessBuilder, EitherAccount, Settings,
 };
 
 use crate::Error;
 
 pub struct TxBuilder<P: Payload> {
-    builder: wallet::TransactionBuilder<P, AccountSecretKey, WitnessAccountData>,
+    builder: wallet::TransactionBuilder<P, AccountSecretKey, WitnessAccountData, account::Witness>,
 }
 
 impl<P: Payload> TxBuilder<P> {
@@ -52,7 +53,10 @@ impl<P: Payload> TxBuilder<P> {
 
         Ok(fragment_build_fn(
             self.builder
-                .finalize_tx(auth, vec![account.secret_key(); inputs_size])
+                .finalize_tx(
+                    auth,
+                    vec![WitnessInput::SecretKey(account.secret_key()); inputs_size],
+                )
                 .map_err(|e| Error::wallet_transaction().with(e))?,
         ))
     }

--- a/src/chain-wallet-libs/bindings/wallet-core/src/tx_builder.rs
+++ b/src/chain-wallet-libs/bindings/wallet-core/src/tx_builder.rs
@@ -45,7 +45,7 @@ impl<P: Payload> TxBuilder<P> {
             .get_sign_data()
             .map_err(|e| Error::wallet_transaction().with(e))?;
         // as inside build_tx() function has been inserted only 1 input, valid tx should contains only first witness sign data
-        data.into_iter().next().ok_or(Error::invalid_fragment())
+        data.into_iter().next().ok_or_else(Error::invalid_fragment)
     }
 
     pub fn build_tx(

--- a/src/chain-wallet-libs/bindings/wallet-core/src/wallet.rs
+++ b/src/chain-wallet-libs/bindings/wallet-core/src/wallet.rs
@@ -8,7 +8,7 @@ use chain_impl_mockchain::{
     value::Value,
     vote::Choice,
 };
-use wallet::{AccountId, Settings};
+use wallet::{transaction::WitnessInput, AccountId, Settings};
 
 /// the wallet
 ///
@@ -163,7 +163,7 @@ impl Wallet {
         builder.add_input(input, witness_builder);
 
         let tx = builder
-            .finalize_tx((), vec![secret_key])
+            .finalize_tx((), vec![WitnessInput::SecretKey(secret_key)])
             .map_err(|e| Error::wallet_transaction().with(e))?;
 
         let fragment = Fragment::VoteCast(tx);

--- a/src/chain-wallet-libs/bindings/wallet-wasm-js/js-test/test/vote_cast.js
+++ b/src/chain-wallet-libs/bindings/wallet-wasm-js/js-test/test/vote_cast.js
@@ -75,9 +75,9 @@ describe("Postponed signing vote cast certificate tests", function () {
     let tx_builders = wallet.signVotes([vote], settings, account_id);
     assert(tx_builders.length == 1);
     // get fragemnts
-    fragments = tx_builders.map((tx_builder) =>
-      tx_builder.sign_tx(private_key)
-    );
+    let signature =
+      "2195c6eca3e6901696e3c376cb01d27bca47ad13fe63d153e1883fef08921948960cb843fd3e8383a0cc3d15a47451cc9e3e1695fe0ebf0165a58a9d930c9d00";
+    fragments = tx_builders.map((tx_builder) => tx_builder.build_tx(signature));
   });
 
   it("private", async function () {
@@ -94,8 +94,8 @@ describe("Postponed signing vote cast certificate tests", function () {
     let tx_builders = wallet.signVotes([vote], settings, account_id);
     assert(tx_builders.length == 1);
     // get fragemnts
-    fragments = tx_builders.map((tx_builder) =>
-      tx_builder.sign_tx(private_key)
-    );
+    let signature =
+      "a33524b702ff2371ee214981433d543a39fc4c08958ef58d29d1890ad611b4deca9b11d0fad5bc076a1e68b87d97410907337dbc94286b0819464092674e0508";
+    fragments = tx_builders.map((tx_builder) => tx_builder.build_tx(signature));
   });
 });

--- a/src/chain-wallet-libs/bindings/wallet-wasm-js/js-test/test/vote_cast.js
+++ b/src/chain-wallet-libs/bindings/wallet-wasm-js/js-test/test/vote_cast.js
@@ -33,15 +33,12 @@ describe("Inplace signing vote cast certificate tests", function () {
       8
     );
     let vote = new wallet.Vote(proposal, 0);
-    let tx_builders = wallet.signVotes(
-      [vote],
-      settings,
-      account_id,
-      private_key
-    );
+    let tx_builders = wallet.signVotes([vote], settings, account_id);
     assert(tx_builders.length == 1);
     // get fragemnts
-    fragments = tx_builders.map((tx_builder) => tx_builder.finalize_tx());
+    fragments = tx_builders.map((tx_builder) =>
+      tx_builder.finalize_tx(private_key)
+    );
   });
 
   it("private", async function () {
@@ -55,15 +52,12 @@ describe("Inplace signing vote cast certificate tests", function () {
       "bed88887abe0a84f64691fe0bdfa3daf1a6cd697a13f07ae07588910ce39c927"
     );
     let vote = new wallet.Vote(proposal, 0);
-    let tx_builders = wallet.signVotes(
-      [vote],
-      settings,
-      account_id,
-      private_key
-    );
+    let tx_builders = wallet.signVotes([vote], settings, account_id);
     assert(tx_builders.length == 1);
     // get fragemnts
-    fragments = tx_builders.map((tx_builder) => tx_builder.finalize_tx());
+    fragments = tx_builders.map((tx_builder) =>
+      tx_builder.finalize_tx(private_key)
+    );
   });
 });
 
@@ -82,7 +76,7 @@ describe("Postponed signing vote cast certificate tests", function () {
     assert(tx_builders.length == 1);
     // get fragemnts
     fragments = tx_builders.map((tx_builder) =>
-      tx_builder.sign_tx(private_key).finalize_tx()
+      tx_builder.finalize_tx(private_key)
     );
   });
 
@@ -101,7 +95,7 @@ describe("Postponed signing vote cast certificate tests", function () {
     assert(tx_builders.length == 1);
     // get fragemnts
     fragments = tx_builders.map((tx_builder) =>
-      tx_builder.sign_tx(private_key).finalize_tx()
+      tx_builder.finalize_tx(private_key)
     );
   });
 });

--- a/src/chain-wallet-libs/bindings/wallet-wasm-js/js-test/test/vote_cast.js
+++ b/src/chain-wallet-libs/bindings/wallet-wasm-js/js-test/test/vote_cast.js
@@ -37,7 +37,7 @@ describe("Inplace signing vote cast certificate tests", function () {
     assert(tx_builders.length == 1);
     // get fragemnts
     fragments = tx_builders.map((tx_builder) =>
-      tx_builder.finalize_tx(private_key)
+      tx_builder.sign_tx(private_key)
     );
   });
 
@@ -56,7 +56,7 @@ describe("Inplace signing vote cast certificate tests", function () {
     assert(tx_builders.length == 1);
     // get fragemnts
     fragments = tx_builders.map((tx_builder) =>
-      tx_builder.finalize_tx(private_key)
+      tx_builder.sign_tx(private_key)
     );
   });
 });
@@ -76,7 +76,7 @@ describe("Postponed signing vote cast certificate tests", function () {
     assert(tx_builders.length == 1);
     // get fragemnts
     fragments = tx_builders.map((tx_builder) =>
-      tx_builder.finalize_tx(private_key)
+      tx_builder.sign_tx(private_key)
     );
   });
 
@@ -95,7 +95,7 @@ describe("Postponed signing vote cast certificate tests", function () {
     assert(tx_builders.length == 1);
     // get fragemnts
     fragments = tx_builders.map((tx_builder) =>
-      tx_builder.finalize_tx(private_key)
+      tx_builder.sign_tx(private_key)
     );
   });
 });

--- a/src/chain-wallet-libs/bindings/wallet-wasm-js/js-test/test/vote_cast.js
+++ b/src/chain-wallet-libs/bindings/wallet-wasm-js/js-test/test/vote_cast.js
@@ -35,10 +35,8 @@ describe("Inplace signing vote cast certificate tests", function () {
     let vote = new wallet.Vote(proposal, 0);
     let tx_builders = wallet.signVotes([vote], settings, account_id);
     assert(tx_builders.length == 1);
-    // get fragemnts
-    fragments = tx_builders.map((tx_builder) =>
-      tx_builder.sign_tx(private_key)
-    );
+    // complete transaction
+    fragment = tx_builders[0].sign_tx(private_key);
   });
 
   it("private", async function () {
@@ -54,10 +52,8 @@ describe("Inplace signing vote cast certificate tests", function () {
     let vote = new wallet.Vote(proposal, 0);
     let tx_builders = wallet.signVotes([vote], settings, account_id);
     assert(tx_builders.length == 1);
-    // get fragemnts
-    fragments = tx_builders.map((tx_builder) =>
-      tx_builder.sign_tx(private_key)
-    );
+    // complete transaction
+    fragment = tx_builders[0].sign_tx(private_key);
   });
 });
 
@@ -74,10 +70,12 @@ describe("Postponed signing vote cast certificate tests", function () {
     let vote = new wallet.Vote(proposal, 0);
     let tx_builders = wallet.signVotes([vote], settings, account_id);
     assert(tx_builders.length == 1);
-    // get fragemnts
+    // get sign data
+    let data = tx_builders[0].get_sign_data();
+    // complete transaction
     let signature =
       "2195c6eca3e6901696e3c376cb01d27bca47ad13fe63d153e1883fef08921948960cb843fd3e8383a0cc3d15a47451cc9e3e1695fe0ebf0165a58a9d930c9d00";
-    fragments = tx_builders.map((tx_builder) => tx_builder.build_tx(signature));
+    fragment = tx_builders[0].build_tx(signature);
   });
 
   it("private", async function () {
@@ -93,9 +91,11 @@ describe("Postponed signing vote cast certificate tests", function () {
     let vote = new wallet.Vote(proposal, 0);
     let tx_builders = wallet.signVotes([vote], settings, account_id);
     assert(tx_builders.length == 1);
-    // get fragemnts
+    // get sign data
+    let data = tx_builders[0].get_sign_data();
+    // complete transaction
     let signature =
       "a33524b702ff2371ee214981433d543a39fc4c08958ef58d29d1890ad611b4deca9b11d0fad5bc076a1e68b87d97410907337dbc94286b0819464092674e0508";
-    fragments = tx_builders.map((tx_builder) => tx_builder.build_tx(signature));
+    fragment = tx_builders[0].build_tx(signature);
   });
 });

--- a/src/chain-wallet-libs/bindings/wallet-wasm-js/js/index.d.ts
+++ b/src/chain-wallet-libs/bindings/wallet-wasm-js/js/index.d.ts
@@ -91,15 +91,15 @@ export class Vote {
 /**
  * Signes provided votes and returns a completly generated transaction list
  *
- * @param {Vote[]} votes list of votes
- * @param {Settings} settings wallet Settings
- * @param {string} accountId user's account id hex representation
- * @param {string} privateKey user's private key hex representation
+ * @param {Vote[]} votes List of votes
+ * @param {Settings} settings Wallet Settings
+ * @param {string} accountId User's account id hex representation
+ * @param {string} privateKey Deprecated field, you can pass anything.
  * @returns {wallet_wasm.Fragment[]}
  */
 function signVotes(
   votes: Vote[],
   settings: Settings,
   accountId: string,
-  privateKey: string
+  privateKey?: string
 ): wallet_wasm.VoteCastTxBuilder[];

--- a/src/chain-wallet-libs/bindings/wallet-wasm-js/js/index.js
+++ b/src/chain-wallet-libs/bindings/wallet-wasm-js/js/index.js
@@ -59,7 +59,7 @@ export function signVotes(votes, settings, accountId, privateKey) {
     );
 
     let builder = wasm.VoteCastTxBuilder.new(settings.settings, voteCast);
-    let tx_builder = builder.build_tx(accountId);
+    let tx_builder = builder.prepare_tx(accountId);
     tx_builders.push(tx_builder);
   }
   return tx_builders;

--- a/src/chain-wallet-libs/bindings/wallet-wasm-js/js/index.js
+++ b/src/chain-wallet-libs/bindings/wallet-wasm-js/js/index.js
@@ -60,9 +60,6 @@ export function signVotes(votes, settings, accountId, privateKey) {
 
     let builder = wasm.VoteCastTxBuilder.new(settings.settings, voteCast);
     let tx_builder = builder.build_tx(accountId);
-    if (privateKey != undefined) {
-      tx_builder = tx_builder.sign_tx(privateKey);
-    }
     tx_builders.push(tx_builder);
   }
   return tx_builders;

--- a/src/chain-wallet-libs/bindings/wallet-wasm-js/src/lib.rs
+++ b/src/chain-wallet-libs/bindings/wallet-wasm-js/src/lib.rs
@@ -56,22 +56,16 @@ impl VoteCastTxBuilder {
         Ok(self)
     }
 
-    pub fn sign_tx(mut self, hex_account: String) -> Result<VoteCastTxBuilder, JsValue> {
-        self.0 = self
-            .0
-            .sign_tx(
+    /// Finish step of signing and building VoteCast fragment
+    pub fn finalize_tx(self, hex_account: String) -> Result<Fragment, JsValue> {
+        self.0
+            .finalize_tx(
+                (),
                 hex::decode(hex_account)
                     .map_err(|e| JsValue::from(e.to_string()))?
                     .as_slice(),
+                FragmentLib::VoteCast,
             )
-            .map_err(|e| JsValue::from(e.to_string()))?;
-        Ok(self)
-    }
-
-    /// Finish step of building VoteCast fragment
-    pub fn finalize_tx(self) -> Result<Fragment, JsValue> {
-        self.0
-            .finalize_tx((), FragmentLib::VoteCast)
             .map_err(|e| JsValue::from(e.to_string()))
             .map(Fragment)
     }

--- a/src/chain-wallet-libs/bindings/wallet-wasm-js/src/lib.rs
+++ b/src/chain-wallet-libs/bindings/wallet-wasm-js/src/lib.rs
@@ -2,7 +2,7 @@
 
 pub use certificates::Certificate;
 pub use certificates::{
-    vote_cast::{Payload, VoteCast},
+    vote_cast::{ElectionPublicKey, Payload, VoteCast},
     vote_plan::VotePlanId,
 };
 use chain_impl_mockchain::account::SpendingCounter;

--- a/src/chain-wallet-libs/bindings/wallet-wasm-js/src/lib.rs
+++ b/src/chain-wallet-libs/bindings/wallet-wasm-js/src/lib.rs
@@ -48,18 +48,40 @@ impl VoteCastTxBuilder {
     ///
     /// The `account` parameter gives the Ed25519Extended private key
     /// of the account.
-    pub fn build_tx(mut self, hex_account_id: String) -> Result<VoteCastTxBuilder, JsValue> {
+    pub fn prepare_tx(mut self, hex_account_id: String) -> Result<VoteCastTxBuilder, JsValue> {
         self.0 = self
             .0
-            .build_tx(hex_account_id, SpendingCounter::zero())
+            .prepare_tx(hex_account_id, SpendingCounter::zero())
             .map_err(|e| JsValue::from(e.to_string()))?;
         Ok(self)
     }
 
-    /// Finish step of signing and building VoteCast fragment
-    pub fn finalize_tx(self, hex_account: String) -> Result<Fragment, JsValue> {
+    /// Get a transaction signing data
+    pub fn get_sign_data(&self) -> Result<Box<[u8]>, JsValue> {
         self.0
-            .finalize_tx(
+            .get_sign_data()
+            .map(|data| data.as_ref().into())
+            .map_err(|e| JsValue::from(e.to_string()))
+    }
+
+    /// Finish step of building VoteCast fragment with passing an already signed transaction data
+    pub fn build_tx(self, hex_signature: String) -> Result<Fragment, JsValue> {
+        self.0
+            .build_tx(
+                (),
+                hex::decode(hex_signature)
+                    .map_err(|e| JsValue::from(e.to_string()))?
+                    .as_slice(),
+                FragmentLib::VoteCast,
+            )
+            .map_err(|e| JsValue::from(e.to_string()))
+            .map(Fragment)
+    }
+
+    /// Finish step of signing and building VoteCast fragment
+    pub fn sign_tx(self, hex_account: String) -> Result<Fragment, JsValue> {
+        self.0
+            .sign_tx(
                 (),
                 hex::decode(hex_account)
                     .map_err(|e| JsValue::from(e.to_string()))?

--- a/src/chain-wallet-libs/bindings/wallet-wasm-js/tests/certificates/vote_cast.rs
+++ b/src/chain-wallet-libs/bindings/wallet-wasm-js/tests/certificates/vote_cast.rs
@@ -1,62 +1,105 @@
-use crate::{generate_settings, generate_wallet};
-use wallet_js::*;
+use crate::{ACCOUNT_ID, PRIVATE_KEY, SETTINGS};
+use wallet_wasm_js::*;
 use wasm_bindgen_test::*;
 
 #[wasm_bindgen_test]
 fn vote_cast_public_test() {
-    let mut wallet = generate_wallet().unwrap();
+    let settings = Settings::from_json(SETTINGS.to_string()).unwrap();
 
-    let settings = generate_settings().unwrap();
+    let payload = Payload::new_public(0);
 
-    let vote_plan =
-        VotePlanId::from_bytes(core::array::from_fn::<u8, 32, _>(|i| i as u8).as_slice()).unwrap();
-
-    let vote_cast = VoteCast::new(vote_plan, 8, Payload::new_public(0));
-
-    let fragment = wallet
-        .sign_transaction(
-            &settings,
-            BlockDate::new(0, 1),
-            0,
-            Certificate::vote_cast(vote_cast),
+    let vote_cast = VoteCast::new(
+        VotePlanId::from_hex(
+            "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f".to_string(),
         )
-        .unwrap();
+        .unwrap(),
+        2,
+        payload,
+    );
+    let mut builder = VoteCastTxBuilder::new(settings, vote_cast);
+    builder = builder.prepare_tx(ACCOUNT_ID.to_string()).unwrap();
+    let _fragment = builder.sign_tx(PRIVATE_KEY.to_string()).unwrap();
+}
 
-    wallet.confirm_transaction(&fragment.id());
+#[wasm_bindgen_test]
+fn vote_cast_public_test2() {
+    let settings = Settings::from_json(SETTINGS.to_string()).unwrap();
+
+    let payload = Payload::new_public(0);
+
+    let vote_cast = VoteCast::new(
+        VotePlanId::from_hex(
+            "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f".to_string(),
+        )
+        .unwrap(),
+        2,
+        payload,
+    );
+    let mut builder = VoteCastTxBuilder::new(settings, vote_cast);
+    builder = builder.prepare_tx(ACCOUNT_ID.to_string()).unwrap();
+    let signature = "2195c6eca3e6901696e3c376cb01d27bca47ad13fe63d153e1883fef08921948960cb843fd3e8383a0cc3d15a47451cc9e3e1695fe0ebf0165a58a9d930c9d00";
+    let _fragment = builder.build_tx(signature.to_string()).unwrap();
 }
 
 #[wasm_bindgen_test]
 fn vote_cast_private_test() {
-    let mut wallet = generate_wallet().unwrap();
+    let settings = Settings::from_json(SETTINGS.to_string()).unwrap();
 
-    let settings = generate_settings().unwrap();
-
-    let vote_plan =
-        VotePlanId::from_bytes(core::array::from_fn::<u8, 32, _>(|i| i as u8).as_slice()).unwrap();
-
-    let vote_cast = VoteCast::new(
-        vote_plan.clone(),
-        8,
-        Payload::new_private(
-            vote_plan,
-            4,
-            0,
-            &[
-                190, 216, 136, 135, 171, 224, 168, 79, 100, 105, 31, 224, 189, 250, 61, 175, 26,
-                108, 214, 151, 161, 63, 7, 174, 7, 88, 137, 16, 206, 57, 201, 39,
-            ],
+    let payload = Payload::new_private(
+        &VotePlanId::from_hex(
+            "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f".to_string(),
         )
         .unwrap(),
-    );
-
-    let fragment = wallet
-        .sign_transaction(
-            &settings,
-            BlockDate::new(0, 1),
-            0,
-            Certificate::vote_cast(vote_cast),
+        8,
+        0,
+        &ElectionPublicKey::from_hex(
+            "bed88887abe0a84f64691fe0bdfa3daf1a6cd697a13f07ae07588910ce39c927".to_string(),
         )
-        .unwrap();
+        .unwrap(),
+    )
+    .unwrap();
 
-    wallet.confirm_transaction(&fragment.id());
+    let vote_cast = VoteCast::new(
+        VotePlanId::from_hex(
+            "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f".to_string(),
+        )
+        .unwrap(),
+        4,
+        payload,
+    );
+    let mut builder = VoteCastTxBuilder::new(settings, vote_cast);
+    builder = builder.prepare_tx(ACCOUNT_ID.to_string()).unwrap();
+    let _fragment = builder.sign_tx(PRIVATE_KEY.to_string()).unwrap();
+}
+
+#[wasm_bindgen_test]
+fn vote_cast_private_test2() {
+    let settings = Settings::from_json(SETTINGS.to_string()).unwrap();
+
+    let payload = Payload::new_private(
+        &VotePlanId::from_hex(
+            "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f".to_string(),
+        )
+        .unwrap(),
+        8,
+        0,
+        &ElectionPublicKey::from_hex(
+            "bed88887abe0a84f64691fe0bdfa3daf1a6cd697a13f07ae07588910ce39c927".to_string(),
+        )
+        .unwrap(),
+    )
+    .unwrap();
+
+    let vote_cast = VoteCast::new(
+        VotePlanId::from_hex(
+            "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f".to_string(),
+        )
+        .unwrap(),
+        4,
+        payload,
+    );
+    let mut builder = VoteCastTxBuilder::new(settings, vote_cast);
+    builder = builder.prepare_tx(ACCOUNT_ID.to_string()).unwrap();
+    let signature = "a33524b702ff2371ee214981433d543a39fc4c08958ef58d29d1890ad611b4deca9b11d0fad5bc076a1e68b87d97410907337dbc94286b0819464092674e0508";
+    let _fragment = builder.build_tx(signature.to_string()).unwrap();
 }

--- a/src/chain-wallet-libs/bindings/wallet-wasm-js/tests/certificates/vote_plan.rs
+++ b/src/chain-wallet-libs/bindings/wallet-wasm-js/tests/certificates/vote_plan.rs
@@ -1,4 +1,4 @@
-use wallet_js::*;
+use wallet_wasm_js::*;
 use wasm_bindgen_test::*;
 
 #[wasm_bindgen_test]

--- a/src/chain-wallet-libs/bindings/wallet-wasm-js/tests/lib.rs
+++ b/src/chain-wallet-libs/bindings/wallet-wasm-js/tests/lib.rs
@@ -2,39 +2,12 @@
 
 #![cfg(target_arch = "wasm32")]
 
-use std::assert_eq;
-
-use chain_impl_mockchain::accounting::account::SpendingCounterIncreasing;
-use wallet_js::{SpendingCounter, *};
-use wasm_bindgen::JsValue;
 use wasm_bindgen_test::*;
 
 mod certificates;
 
 wasm_bindgen_test_configure!(run_in_browser);
 
-const ACCOUNT_KEY: &str = include_str!("../../../test-vectors/free_keys/key1.prv");
-const BLOCK0: &[u8] = include_bytes!("../../../test-vectors/block0");
-
-pub fn generate_wallet() -> Result<Wallet, JsValue> {
-    let mut wallet = Wallet::import_keys(
-        hex::decode(String::from(ACCOUNT_KEY).trim())
-            .unwrap()
-            .as_ref(),
-    )?;
-
-    wallet.set_state(
-        1_000,
-        (0..SpendingCounterIncreasing::LANES)
-            .map(|lane| SpendingCounter::new(lane, 1))
-            .collect::<Vec<SpendingCounter>>()
-            .into(),
-    )?;
-
-    assert_eq!(wallet.total_value(), 1_000);
-    Ok(wallet)
-}
-
-pub fn generate_settings() -> Result<Settings, JsValue> {
-    Settings::new(BLOCK0)
-}
+const PRIVATE_KEY: &str = "c86596c2d1208885db1fe3658406aa0f7cc7b8e13c362fe46a6db277fc5064583e487588c98a6c36e2e7445c0add36f83f171cb5ccfd815509d19cd38ecb0af3";
+const ACCOUNT_ID: &str = "a6a3c0447aeb9cc54cf6422ba32b294e5e1c3ef6d782f2acff4a70694c4d1663";
+const SETTINGS: &str = r#"{"fees":{"constant":10,"coefficient":2,"certificate":100},"discrimination":"production","block0_initial_hash":{"hash":"baf6b54817cf2a3e865f432c3922d28ac5be641e66662c66d445f141e409183e"},"block0_date":1586637936,"slot_duration":20,"time_era":{"epoch_start":0,"slot_start":0,"slots_per_epoch":180},"transaction_max_expiry_epochs":1}"#;

--- a/src/chain-wallet-libs/wallet/src/transaction/mod.rs
+++ b/src/chain-wallet-libs/wallet/src/transaction/mod.rs
@@ -5,5 +5,5 @@ mod witness_builder;
 pub use self::{
     builder::{AddInputStatus, TransactionBuilder},
     strategy::{InputStrategy, OutputStrategy, Strategy, StrategyBuilder, DEFAULT_STRATEGIES},
-    witness_builder::AccountWitnessBuilder,
+    witness_builder::{AccountSecretKey, AccountWitnessBuilder},
 };

--- a/src/chain-wallet-libs/wallet/src/transaction/mod.rs
+++ b/src/chain-wallet-libs/wallet/src/transaction/mod.rs
@@ -3,7 +3,7 @@ mod strategy;
 mod witness_builder;
 
 pub use self::{
-    builder::{AddInputStatus, TransactionBuilder},
+    builder::{AddInputStatus, TransactionBuilder, WitnessInput},
     strategy::{InputStrategy, OutputStrategy, Strategy, StrategyBuilder, DEFAULT_STRATEGIES},
     witness_builder::{AccountSecretKey, AccountWitnessBuilder},
 };

--- a/src/chain-wallet-libs/wallet/src/transaction/witness_builder.rs
+++ b/src/chain-wallet-libs/wallet/src/transaction/witness_builder.rs
@@ -29,6 +29,7 @@ pub trait WitnessBuilder<SecretKey, WitnessData: AsRef<[u8]>> {
 
 pub struct UtxoWitnessBuilder;
 
+#[derive(Clone)]
 pub enum AccountSecretKey {
     Ed25519(SecretKey<Ed25519>),
     Ed25519Extended(SecretKey<Ed25519Extended>),

--- a/src/chain-wallet-libs/wallet/src/transaction/witness_builder.rs
+++ b/src/chain-wallet-libs/wallet/src/transaction/witness_builder.rs
@@ -2,53 +2,95 @@ use chain_crypto::{Ed25519, Ed25519Extended, SecretKey, Signature};
 use chain_impl_mockchain::{
     accounting::account::SpendingCounter,
     block::HeaderId,
-    transaction::{TransactionSignDataHash, Witness, WitnessUtxoData},
+    transaction::{TransactionSignDataHash, Witness, WitnessAccountData, WitnessUtxoData},
 };
 use ed25519_bip32::XPrv;
 
 use hdkeygen::Key;
 
-pub trait WitnessBuilder {
-    fn build(&self, block0: &HeaderId, sign_data_hash: &TransactionSignDataHash) -> Witness;
-}
+pub trait WitnessBuilder<SecretKey, WitnessData: AsRef<[u8]>> {
+    fn build_sign_data(
+        &self,
+        block0: &HeaderId,
+        sign_data_hash: &TransactionSignDataHash,
+    ) -> WitnessData;
 
-pub struct UtxoWitnessBuilder<K>(pub K);
-pub enum AccountWitnessBuilder {
-    Ed25519(SecretKey<Ed25519>, SpendingCounter),
-    Ed25519Extended(SecretKey<Ed25519Extended>, SpendingCounter),
-}
+    fn sign(&self, witness_data: WitnessData, secret_key: SecretKey) -> Witness;
 
-impl<D> WitnessBuilder for UtxoWitnessBuilder<Key<XPrv, D>> {
-    fn build(&self, block0: &HeaderId, sign_data_hash: &TransactionSignDataHash) -> Witness {
-        let xprv = &self.0;
-        Witness::new_utxo(block0, sign_data_hash, |data| {
-            Signature::from_binary(xprv.sign::<WitnessUtxoData, &[u8]>(data.as_ref()).as_ref())
-                .unwrap()
-        })
+    fn build(
+        &self,
+        block0: &HeaderId,
+        sign_data_hash: &TransactionSignDataHash,
+        secret_key: SecretKey,
+    ) -> Witness {
+        self.sign(self.build_sign_data(block0, sign_data_hash), secret_key)
     }
 }
 
-impl WitnessBuilder for UtxoWitnessBuilder<SecretKey<Ed25519Extended>> {
-    fn build(&self, block0: &HeaderId, sign_data_hash: &TransactionSignDataHash) -> Witness {
-        let key = &self.0;
-        Witness::new_utxo(block0, sign_data_hash, |data| {
-            Signature::from_binary(key.sign(data).as_ref()).unwrap()
-        })
+pub struct UtxoWitnessBuilder;
+
+pub enum AccountSecretKey {
+    Ed25519(SecretKey<Ed25519>),
+    Ed25519Extended(SecretKey<Ed25519Extended>),
+}
+
+pub struct AccountWitnessBuilder(pub SpendingCounter);
+
+impl<D> WitnessBuilder<Key<XPrv, D>, WitnessUtxoData> for UtxoWitnessBuilder {
+    fn build_sign_data(
+        &self,
+        block0: &HeaderId,
+        sign_data_hash: &TransactionSignDataHash,
+    ) -> WitnessUtxoData {
+        Witness::new_utxo_data(block0, sign_data_hash)
+    }
+
+    fn sign(&self, witness_data: WitnessUtxoData, secret_key: Key<XPrv, D>) -> Witness {
+        Witness::Utxo(
+            Signature::from_binary(
+                secret_key
+                    .sign::<WitnessUtxoData, &[u8]>(witness_data.as_ref())
+                    .as_ref(),
+            )
+            .unwrap(),
+        )
     }
 }
 
-impl WitnessBuilder for AccountWitnessBuilder {
-    fn build(&self, block0: &HeaderId, sign_data_hash: &TransactionSignDataHash) -> Witness {
-        match self {
-            AccountWitnessBuilder::Ed25519(key, spending_counter) => {
-                Witness::new_account(block0, sign_data_hash, *spending_counter, |data| {
-                    key.sign(data)
-                })
+impl WitnessBuilder<SecretKey<Ed25519Extended>, WitnessUtxoData> for UtxoWitnessBuilder {
+    fn build_sign_data(
+        &self,
+        block0: &HeaderId,
+        sign_data_hash: &TransactionSignDataHash,
+    ) -> WitnessUtxoData {
+        Witness::new_utxo_data(block0, sign_data_hash)
+    }
+
+    fn sign(
+        &self,
+        witness_data: WitnessUtxoData,
+        secret_key: SecretKey<Ed25519Extended>,
+    ) -> Witness {
+        Witness::Utxo(secret_key.sign(&witness_data))
+    }
+}
+
+impl WitnessBuilder<AccountSecretKey, WitnessAccountData> for AccountWitnessBuilder {
+    fn build_sign_data(
+        &self,
+        block0: &HeaderId,
+        sign_data_hash: &TransactionSignDataHash,
+    ) -> WitnessAccountData {
+        Witness::new_account_data(block0, sign_data_hash, self.0)
+    }
+
+    fn sign(&self, witness_data: WitnessAccountData, secret_key: AccountSecretKey) -> Witness {
+        match secret_key {
+            AccountSecretKey::Ed25519(secret_key) => {
+                Witness::Account(self.0, secret_key.sign(&witness_data))
             }
-            AccountWitnessBuilder::Ed25519Extended(key, spending_counter) => {
-                Witness::new_account(block0, sign_data_hash, *spending_counter, |data| {
-                    key.sign(data)
-                })
+            AccountSecretKey::Ed25519Extended(secret_key) => {
+                Witness::Account(self.0, secret_key.sign(&witness_data))
             }
         }
     }

--- a/src/chain-wallet-libs/wallet/tests/account.rs
+++ b/src/chain-wallet-libs/wallet/tests/account.rs
@@ -9,6 +9,7 @@ use chain_impl_mockchain::{
     value::Value,
     vote::{Choice, Payload},
 };
+use wallet::transaction::WitnessInput;
 
 const BLOCK0: &[u8] = include_bytes!("../../test-vectors/block0");
 const ACCOUNT_KEY: &str = include_str!("../../test-vectors/free_keys/key1.prv");
@@ -90,7 +91,9 @@ fn cast_vote() {
 
         builder.add_input(input, witness_builder);
 
-        let tx = builder.finalize_tx((), vec![secret_key]).unwrap();
+        let tx = builder
+            .finalize_tx((), vec![WitnessInput::SecretKey(secret_key)])
+            .unwrap();
 
         let fragment = Fragment::VoteCast(tx);
         let id = fragment.hash();

--- a/src/chain-wallet-libs/wallet/tests/account.rs
+++ b/src/chain-wallet-libs/wallet/tests/account.rs
@@ -83,13 +83,14 @@ fn cast_vote() {
 
         let value = builder.estimate_fee_with(1, 0);
 
+        let secret_key = account.secret_key();
         let account_tx_builder = account.new_transaction(value, i % 8).unwrap();
         let input = account_tx_builder.input();
         let witness_builder = account_tx_builder.witness_builder();
 
         builder.add_input(input, witness_builder);
 
-        let tx = builder.finalize_tx(()).unwrap();
+        let tx = builder.finalize_tx((), vec![secret_key]).unwrap();
 
         let fragment = Fragment::VoteCast(tx);
         let id = fragment.hash();


### PR DESCRIPTION
Fixes this issue https://github.com/input-output-hk/catalyst-core/issues/225. 
Provide a capability for the wallet js to sign transaction by its own without using our api.