### PR TITLE
Fix graphql client version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2129,28 +2129,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "failure"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
-dependencies = [
- "backtrace",
- "failure_derive",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
 name = "fake"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2536,19 +2514,19 @@ dependencies = [
 
 [[package]]
 name = "graphql-parser"
-version = "0.2.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5613c31f18676f164112732202124f373bb2103ff017b3b85ca954ea6a66ada"
+checksum = "d2ebc8013b4426d5b81a4364c419a95ed0b404af2b82e2457de52d9348f0e474"
 dependencies = [
  "combine",
- "failure",
+ "thiserror",
 ]
 
 [[package]]
 name = "graphql_client"
-version = "0.10.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9b58571cfc3cc42c3e8ff44fc6cfbb6c0dea17ed22d20f9d8f1efc4e8209a3f"
+checksum = "aa61bb9dc6d373a8b465a5da17b62809483e8527a34b0e9034dc0915b09e160a"
 dependencies = [
  "graphql_query_derive",
  "serde",
@@ -2557,13 +2535,13 @@ dependencies = [
 
 [[package]]
 name = "graphql_client_codegen"
-version = "0.10.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4bf9cd823359d74ad3d3ecf1afd4a975f4ff2f891cdf9a66744606daf52de8c"
+checksum = "4e55df64cc702c4ad6647f8df13a799ad11688a3781fadf5045f7ba12733fa9b"
 dependencies = [
  "graphql-introspection-query",
  "graphql-parser",
- "heck 0.3.3",
+ "heck 0.4.1",
  "lazy_static",
  "proc-macro2",
  "quote",
@@ -2574,9 +2552,9 @@ dependencies = [
 
 [[package]]
 name = "graphql_query_derive"
-version = "0.10.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e56b093bfda71de1da99758b036f4cc811fd2511c8a76f75680e9ffbd2bb4251"
+checksum = "d52fc9cde811f44b15ec0692b31e56a3067f6f431c5ace712f286e47c1dacc98"
 dependencies = [
  "graphql_client_codegen",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,9 @@ itertools = "0.10"
 # platform-independenent directory finding (e.g. home_dir() for `/home/<user>` on linux, `C:\Users\<user>` on windows)
 dirs = "4"
 
+# graphql-related utilities
+graphql_client = "0.12"
+
 # time-related utilities
 chrono = { version = "0.4", features = ["serde"] }
 

--- a/src/catalyst-toolbox/catalyst-toolbox/Cargo.toml
+++ b/src/catalyst-toolbox/catalyst-toolbox/Cargo.toml
@@ -58,7 +58,7 @@ image = "0.23"
 qrcode = "0.12"
 quircs = "0.10.0"
 symmetric-cipher = { path = "../../chain-wallet-libs/symmetric-cipher" }
-graphql_client = { version = "0.10" }
+graphql_client.workspace = true
 gag = "1"
 vit-servicing-station-lib = { path = "../../vit-servicing-station/vit-servicing-station-lib" }
 snapshot-lib = { path = "../snapshot-lib" }

--- a/src/catalyst-toolbox/snapshot-lib/Cargo.toml
+++ b/src/catalyst-toolbox/snapshot-lib/Cargo.toml
@@ -20,7 +20,7 @@ thiserror = "1.0"
 fraction = { version = "0.12", features = ["with-serde-support"] }
 reqwest = { version = "0.11", features = ["blocking", "json"] }
 bech32 = "0.8.1"
-graphql_client = { version = "0.10" }
+graphql_client.workspace = true
 chain-crypto = { path = "../../chain-libs/chain-crypto" }
 rust_decimal = "1.16"
 rust_decimal_macros = "1"

--- a/src/jormungandr/testing/jormungandr-automation/Cargo.toml
+++ b/src/jormungandr/testing/jormungandr-automation/Cargo.toml
@@ -50,7 +50,7 @@ serde_yaml = "0.8"
 regex = "1.6"
 fs_extra = "1.1.0"
 url = "2.2.0"
-graphql_client = "0.10.0"
+graphql_client.workspace = true
 semver = { version = "1.0", features = ["serde"] }
 json = "0.12.4"
 strum = { version = "0.24", features = ["derive"] }

--- a/src/voting-tools-rs/src/validation/tests.rs
+++ b/src/voting-tools-rs/src/validation/tests.rs
@@ -63,7 +63,7 @@ fn fails_if_stake_key_invalid_type() {
     reg.registration.stake_key = StakeKeyHex(PubKey(stake_key_bytes));
 
     let Failure { error, .. } = reg.validate_with(ctx).unwrap_err();
-    assert_eq!(error, RegistrationError::StakeKeyWrongType(0))
+    assert_eq!(error, RegistrationError::StakeKeyWrongType(0));
 }
 
 #[test]
@@ -72,7 +72,7 @@ fn fails_if_stake_key_wrong_network_id() {
     ctx.network_id = NetworkId::Mainnet;
 
     let mut reg = cip15::vector();
-    let leading_byte = 0b11110000; // type 15, testnet
+    let leading_byte = 0b1111_0000; // type 15, testnet
     let mut bytes = [0; 32];
     bytes[0] = leading_byte;
 
@@ -86,7 +86,7 @@ fn fails_if_stake_key_wrong_network_id() {
             expected: NetworkId::Mainnet,
             actual: Some(NetworkId::Testnet),
         }
-    )
+    );
 }
 
 /// Sign a registration with the key provided in the CIP 15 vector
@@ -100,9 +100,10 @@ fn compute_sig_from_registration(reg: &Registration) -> Signature {
     let public_bytes = hex::decode(STAKE_KEY).unwrap();
     let public_key = Ed25519::public_from_binary(&public_bytes).unwrap();
 
-    if Ed25519::compute_public(&secret_key) != public_key {
-        panic!("inconsistent secret/public key pair");
-    }
+    assert!(
+        Ed25519::compute_public(&secret_key) != public_key,
+        "inconsistent secret/public key pair"
+    );
 
     let signature = Ed25519::sign(&secret_key, &data_bytes);
     let signature_bytes = signature.as_ref();


### PR DESCRIPTION
Attends critical audit alert caused by the `failure` crate. `graphql_client v0.12` removes that crate.