### PR TITLE
fix: Serde empty annotations bug 

### DIFF
--- a/src/vit-testing/vitup/src/mode/service/manager/file_lister.rs
+++ b/src/vit-testing/vitup/src/mode/service/manager/file_lister.rs
@@ -21,9 +21,7 @@ pub const NETWORK: &str = "network";
 #[derive(Serialize, Deserialize)]
 pub struct FolderDump {
     content: HashMap<String, Vec<String>>,
-    #[serde()]
     root: PathBuf,
-    #[serde()]
     blockchain_items: Vec<String>,
 }
 


### PR DESCRIPTION
Compilation fails with serde 1.0.157 https://github.com/serde-rs/serde/issues/2415
Removing empty serde annotation fixes the issue