### PR TITLE
feat: Add 'ideascale-importer' script to ideascale_importer package

### DIFF
--- a/utilities/ideascale-importer/README.md
+++ b/utilities/ideascale-importer/README.md
@@ -15,13 +15,40 @@ Install [Poetry](https://python-poetry.org/docs/#installation). Then install dep
 
 ```sh
 poetry env use python
+```
+
+Initialize poetry's virtual environment.
+```sh
+poetry shell
+```
+
+Install the package.
+```sh
 poetry install
 ```
 
 To see the available commands:
 
 ```sh
-PYTHONPATH=$(pwd) poetry run python ideascale_importer --help
+poetry run python -m ideascale_importer --help
+```
+
+or
+
+```sh
+python -m ideascale_importer --help
+```
+
+or, use the executable script:
+
+```sh
+ideascale-importer --help
+```
+
+To leave the virtual environment, just type:
+
+```sh
+exit
 ```
 
 ## Documentation

--- a/utilities/ideascale-importer/ideascale_importer/__main__.py
+++ b/utilities/ideascale-importer/ideascale_importer/__main__.py
@@ -1,0 +1,3 @@
+from . import app
+
+app.app()

--- a/utilities/ideascale-importer/ideascale_importer/app.py
+++ b/utilities/ideascale-importer/ideascale_importer/app.py
@@ -3,10 +3,10 @@ import ideascale_importer.cli.db
 import ideascale_importer.cli.ideascale
 import ideascale_importer.cli.snapshot
 
-
 app = typer.Typer(add_completion=False)
 app.add_typer(ideascale_importer.cli.db.app, name="db", help="Postgres DB commands (e.g. seeding)")
 app.add_typer(ideascale_importer.cli.ideascale.app, name="ideascale", help="IdeaScale commands (e.g. importing data)")
 app.add_typer(ideascale_importer.cli.snapshot.app, name="snapshot", help="Snapshot commands (e.g. importing data)")
 
-app()
+if __name__ == "__main__":
+    app()

--- a/utilities/ideascale-importer/poetry.lock
+++ b/utilities/ideascale-importer/poetry.lock
@@ -223,14 +223,14 @@ tests-no-zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy 
 
 [[package]]
 name = "autopep8"
-version = "2.0.1"
+version = "2.0.2"
 description = "A tool that automatically formats Python code to conform to the PEP 8 style guide"
 category = "dev"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "autopep8-2.0.1-py2.py3-none-any.whl", hash = "sha256:be5bc98c33515b67475420b7b1feafc8d32c1a69862498eda4983b45bffd2687"},
-    {file = "autopep8-2.0.1.tar.gz", hash = "sha256:d27a8929d8dcd21c0f4b3859d2d07c6c25273727b98afc984c039df0f0d86566"},
+    {file = "autopep8-2.0.2-py2.py3-none-any.whl", hash = "sha256:86e9303b5e5c8160872b2f5ef611161b2893e9bfe8ccc7e2f76385947d57a2f1"},
+    {file = "autopep8-2.0.2.tar.gz", hash = "sha256:f9849cdd62108cb739dbcdbfb7fdcc9a30d1b63c4cc3e1c1f893b5360941b61c"},
 ]
 
 [package.dependencies]

--- a/utilities/ideascale-importer/pyproject.toml
+++ b/utilities/ideascale-importer/pyproject.toml
@@ -44,6 +44,9 @@ flake8 = "6.0.0"
 mypy = "0.991"
 mypy-extensions = "0.4.3"
 
+[tool.poetry.scripts]
+ideascale-importer = "ideascale_importer.app:app"
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Adds an executable script `ideascale-importer` to the `ideascale_importer` python package in `utilities/ideascale-importer`.