### PR TITLE
feat: NPG-5790, NPG-5815 add new event's endpoint and db queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -804,6 +804,7 @@ dependencies = [
  "chrono",
  "clap 4.1.4",
  "event-db",
+ "rust_decimal",
  "serde",
  "serde_json",
  "thiserror",
@@ -2134,6 +2135,7 @@ dependencies = [
  "bb8-postgres",
  "chrono",
  "dotenvy",
+ "rust_decimal",
  "serde",
  "serde_json",
  "thiserror",
@@ -6016,9 +6018,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.28.1"
+version = "1.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13cf35f7140155d02ba4ec3294373d513a3c7baa8364c162b030e33c61520a8"
+checksum = "26bd36b60561ee1fb5ec2817f198b6fd09fa571c897a5e86d1487cfc2b096dfc"
 dependencies = [
  "arrayvec",
  "borsh",
@@ -6031,6 +6033,7 @@ dependencies = [
  "rkyv",
  "serde",
  "serde_json",
+ "tokio-postgres",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,5 +107,7 @@ clap_complete = "4"  # shell autocomplete for CLIs
 # async traits
 async-trait = "0.1.64"
 
+rust_decimal = { version = "1.29" }
+
 [patch.crates-io]
 cryptoxide = { git = "https://github.com/typed-io/cryptoxide.git" }

--- a/Makefiles/db.toml
+++ b/Makefiles/db.toml
@@ -40,6 +40,7 @@ psql -U catalyst-event-dev -d CatalystEventDev -f test_data/event_table.sql ${@}
 psql -U catalyst-event-dev -d CatalystEventDev -f test_data/snapshot_table.sql ${@}
 psql -U catalyst-event-dev -d CatalystEventDev -f test_data/voter_table.sql ${@}
 psql -U catalyst-event-dev -d CatalystEventDev -f test_data/contribution_table.sql ${@}
+psql -U catalyst-event-dev -d CatalystEventDev -f test_data/goal_table.sql ${@}
 '''
 
 # Setup the local database ready to run the migrations.

--- a/Makefiles/db.toml
+++ b/Makefiles/db.toml
@@ -41,6 +41,7 @@ psql -U catalyst-event-dev -d CatalystEventDev -f test_data/snapshot_table.sql $
 psql -U catalyst-event-dev -d CatalystEventDev -f test_data/voter_table.sql ${@}
 psql -U catalyst-event-dev -d CatalystEventDev -f test_data/contribution_table.sql ${@}
 psql -U catalyst-event-dev -d CatalystEventDev -f test_data/goal_table.sql ${@}
+psql -U catalyst-event-dev -d CatalystEventDev -f test_data/voting_group_table.sql ${@}
 '''
 
 # Setup the local database ready to run the migrations.

--- a/book/src/07_web_api/openapi/core_backend_api.yaml
+++ b/book/src/07_web_api/openapi/core_backend_api.yaml
@@ -442,12 +442,12 @@ components:
         ends:
           $ref: '#/components/schemas/DateTime'
           description: Date-Time when the Voting Event is expected to finish.
-        finalized:
+        final:
           type: boolean
           description: True if the event is finished and no changes can be made to it.<br>Does not Including payment of rewards or funding of projects.
         reg_checked:
           $ref: '#/components/schemas/DateTime'
-          description: 'Last time registrations and Voting power were checed.If not present, no registration or voting power records exist for this event.'
+          description: 'Last time registrations and Voting power were checked. If not present, no registration or voting power records exist for this event.'
       required:
         - id
         - name

--- a/book/src/07_web_api/openapi/core_backend_api.yaml
+++ b/book/src/07_web_api/openapi/core_backend_api.yaml
@@ -451,6 +451,7 @@ components:
       required:
         - id
         - name
+        - final
       description: A Summary of an individual Voting Event
     VotingPowerSettings:
       title: Voting Power Settings
@@ -587,10 +588,6 @@ components:
         tallying_end:
           $ref: '#/components/schemas/DateTime'
           description: Date-Time when Tallying Ends.
-      required:
-        - voting
-        - tallying
-        - tallying_end
       x-stoplight:
         id: c1q1b5jtfd4ue
     ObjectiveId:

--- a/src/cat-data-service/Cargo.toml
+++ b/src/cat-data-service/Cargo.toml
@@ -22,3 +22,5 @@ axum = { version = "0.6.9" }
 serde_json = { version = "1.0" }
 tower = { version = "0.4", features = ["util"] }
 chrono = { workspace = true }
+rust_decimal = {  workspace = true }
+

--- a/src/cat-data-service/src/service/v1/event.rs
+++ b/src/cat-data-service/src/service/v1/event.rs
@@ -7,7 +7,7 @@ use axum::{
     routing::get,
     Router,
 };
-use event_db::types::event::{EventId, EventSummary};
+use event_db::types::event::{Event, EventId, EventSummary};
 use serde::Deserialize;
 use std::sync::Arc;
 
@@ -29,7 +29,7 @@ pub fn event(state: Arc<State>) -> Router {
         )
 }
 
-async fn event_exec(Path(event): Path<EventId>, state: Arc<State>) -> Result<EventSummary, Error> {
+async fn event_exec(Path(event): Path<EventId>, state: Arc<State>) -> Result<Event, Error> {
     tracing::debug!("event_exec, event: {0}", event.0);
 
     let event = state.event_db.get_event(event).await?;

--- a/src/cat-data-service/src/service/v1/event.rs
+++ b/src/cat-data-service/src/service/v1/event.rs
@@ -1,0 +1,124 @@
+use crate::{
+    service::{handle_result, Error},
+    state::State,
+};
+use axum::{routing::get, Router};
+use event_db::types::event::EventSummary;
+use std::sync::Arc;
+
+pub fn event(state: Arc<State>) -> Router {
+    Router::new().route(
+        "/events",
+        get({
+            let state = state.clone();
+            move || async { handle_result(events_exec(state).await).await }
+        }),
+    )
+}
+
+async fn events_exec(state: Arc<State>) -> Result<Vec<EventSummary>, Error> {
+    tracing::debug!("events_exec");
+
+    let events = state.event_db.get_events(None).await?;
+    Ok(events)
+}
+
+/// Need to setup and run a test event db instance
+/// To do it you can use `cargo make local-event-db-setup`
+/// Also need establish `EVENT_DB_URL` env variable with the following value
+/// ```
+/// EVENT_DB_URL="postgres://catalyst-event-dev:CHANGE_ME@localhost/CatalystEventDev"
+/// ```
+/// https://github.com/input-output-hk/catalyst-core/tree/main/src/event-db/Readme.md
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::service::app;
+    use axum::{
+        body::{Body, HttpBody},
+        http::{Request, StatusCode},
+    };
+    use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
+    use event_db::types::event::EventId;
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn events_test() {
+        let state = Arc::new(State::new(None).await.unwrap());
+        let app = app(state);
+
+        let request = Request::builder()
+            .uri(format!("/api/v1/events"))
+            .body(Body::empty())
+            .unwrap();
+        let response = app.clone().oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                .unwrap(),
+            serde_json::to_string(&vec![
+                EventSummary {
+                    id: EventId(1),
+                    name: "Test Fund 1".to_string(),
+                    starts: DateTime::<Utc>::from_utc(
+                        NaiveDateTime::new(
+                            NaiveDate::from_ymd_opt(2020, 5, 1).unwrap(),
+                            NaiveTime::from_hms_opt(12, 0, 0).unwrap()
+                        ),
+                        Utc
+                    ),
+                    ends: DateTime::<Utc>::from_utc(
+                        NaiveDateTime::new(
+                            NaiveDate::from_ymd_opt(2020, 6, 1).unwrap(),
+                            NaiveTime::from_hms_opt(12, 0, 0).unwrap()
+                        ),
+                        Utc
+                    ),
+                    is_final: true,
+                    reg_checked: None,
+                },
+                EventSummary {
+                    id: EventId(2),
+                    name: "Test Fund 2".to_string(),
+                    starts: DateTime::<Utc>::from_utc(
+                        NaiveDateTime::new(
+                            NaiveDate::from_ymd_opt(2021, 5, 1).unwrap(),
+                            NaiveTime::from_hms_opt(12, 0, 0).unwrap()
+                        ),
+                        Utc
+                    ),
+                    ends: DateTime::<Utc>::from_utc(
+                        NaiveDateTime::new(
+                            NaiveDate::from_ymd_opt(2021, 6, 1).unwrap(),
+                            NaiveTime::from_hms_opt(12, 0, 0).unwrap()
+                        ),
+                        Utc
+                    ),
+                    is_final: true,
+                    reg_checked: None,
+                },
+                EventSummary {
+                    id: EventId(3),
+                    name: "Test Fund 3".to_string(),
+                    starts: DateTime::<Utc>::from_utc(
+                        NaiveDateTime::new(
+                            NaiveDate::from_ymd_opt(2022, 5, 1).unwrap(),
+                            NaiveTime::from_hms_opt(12, 0, 0).unwrap()
+                        ),
+                        Utc
+                    ),
+                    ends: DateTime::<Utc>::from_utc(
+                        NaiveDateTime::new(
+                            NaiveDate::from_ymd_opt(2022, 6, 1).unwrap(),
+                            NaiveTime::from_hms_opt(12, 0, 0).unwrap()
+                        ),
+                        Utc
+                    ),
+                    is_final: true,
+                    reg_checked: None,
+                }
+            ])
+            .unwrap()
+        );
+    }
+}

--- a/src/cat-data-service/src/service/v1/event.rs
+++ b/src/cat-data-service/src/service/v1/event.rs
@@ -2,24 +2,63 @@ use crate::{
     service::{handle_result, Error},
     state::State,
 };
-use axum::{routing::get, Router};
+use axum::{extract::Path, routing::get, Router};
 use event_db::types::event::EventSummary;
 use std::sync::Arc;
 
 pub fn event(state: Arc<State>) -> Router {
-    Router::new().route(
-        "/events",
-        get({
-            let state = state.clone();
-            move || async { handle_result(events_exec(state).await).await }
-        }),
-    )
+    Router::new()
+        .route(
+            "/events",
+            get({
+                let state = state.clone();
+                move || async { handle_result(events_exec(state).await).await }
+            }),
+        )
+        .route(
+            "/events/:offset",
+            get({
+                let state = state.clone();
+                move |path| async {
+                    handle_result(events_with_offset_exec(path, state).await).await
+                }
+            }),
+        )
+        .route(
+            "/events/:offset/:limit",
+            get({
+                let state = state.clone();
+                move |path| async {
+                    handle_result(events_with_offset_and_limit_exec(path, state).await).await
+                }
+            }),
+        )
 }
 
 async fn events_exec(state: Arc<State>) -> Result<Vec<EventSummary>, Error> {
     tracing::debug!("events_exec");
 
     let events = state.event_db.get_events(None, None).await?;
+    Ok(events)
+}
+
+async fn events_with_offset_exec(
+    Path(offset): Path<i64>,
+    state: Arc<State>,
+) -> Result<Vec<EventSummary>, Error> {
+    tracing::debug!("events_with_offset_exec, offset: {offset}");
+
+    let events = state.event_db.get_events(None, Some(offset)).await?;
+    Ok(events)
+}
+
+async fn events_with_offset_and_limit_exec(
+    Path((limit, offset)): Path<(i64, i64)>,
+    state: Arc<State>,
+) -> Result<Vec<EventSummary>, Error> {
+    tracing::debug!("events_with_offset_and_limit_exec, offset: {offset}, limit: {limit}");
+
+    let events = state.event_db.get_events(Some(limit), Some(offset)).await?;
     Ok(events)
 }
 
@@ -118,6 +157,104 @@ mod tests {
                     reg_checked: None,
                 }
             ])
+            .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn events_with_offset_test() {
+        let state = Arc::new(State::new(None).await.unwrap());
+        let app = app(state);
+
+        let request = Request::builder()
+            .uri(format!("/api/v1/events/1"))
+            .body(Body::empty())
+            .unwrap();
+        let response = app.clone().oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                .unwrap(),
+            serde_json::to_string(&vec![
+                EventSummary {
+                    id: EventId(2),
+                    name: "Test Fund 2".to_string(),
+                    starts: DateTime::<Utc>::from_utc(
+                        NaiveDateTime::new(
+                            NaiveDate::from_ymd_opt(2021, 5, 1).unwrap(),
+                            NaiveTime::from_hms_opt(12, 0, 0).unwrap()
+                        ),
+                        Utc
+                    ),
+                    ends: DateTime::<Utc>::from_utc(
+                        NaiveDateTime::new(
+                            NaiveDate::from_ymd_opt(2021, 6, 1).unwrap(),
+                            NaiveTime::from_hms_opt(12, 0, 0).unwrap()
+                        ),
+                        Utc
+                    ),
+                    is_final: true,
+                    reg_checked: None,
+                },
+                EventSummary {
+                    id: EventId(3),
+                    name: "Test Fund 3".to_string(),
+                    starts: DateTime::<Utc>::from_utc(
+                        NaiveDateTime::new(
+                            NaiveDate::from_ymd_opt(2022, 5, 1).unwrap(),
+                            NaiveTime::from_hms_opt(12, 0, 0).unwrap()
+                        ),
+                        Utc
+                    ),
+                    ends: DateTime::<Utc>::from_utc(
+                        NaiveDateTime::new(
+                            NaiveDate::from_ymd_opt(2022, 6, 1).unwrap(),
+                            NaiveTime::from_hms_opt(12, 0, 0).unwrap()
+                        ),
+                        Utc
+                    ),
+                    is_final: true,
+                    reg_checked: None,
+                }
+            ])
+            .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn events_with_offset_and_limit_test() {
+        let state = Arc::new(State::new(None).await.unwrap());
+        let app = app(state);
+
+        let request = Request::builder()
+            .uri(format!("/api/v1/events/1/1"))
+            .body(Body::empty())
+            .unwrap();
+        let response = app.clone().oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                .unwrap(),
+            serde_json::to_string(&vec![EventSummary {
+                id: EventId(2),
+                name: "Test Fund 2".to_string(),
+                starts: DateTime::<Utc>::from_utc(
+                    NaiveDateTime::new(
+                        NaiveDate::from_ymd_opt(2021, 5, 1).unwrap(),
+                        NaiveTime::from_hms_opt(12, 0, 0).unwrap()
+                    ),
+                    Utc
+                ),
+                ends: DateTime::<Utc>::from_utc(
+                    NaiveDateTime::new(
+                        NaiveDate::from_ymd_opt(2021, 6, 1).unwrap(),
+                        NaiveTime::from_hms_opt(12, 0, 0).unwrap()
+                    ),
+                    Utc
+                ),
+                is_final: true,
+                reg_checked: None,
+            },])
             .unwrap()
         );
     }

--- a/src/cat-data-service/src/service/v1/event.rs
+++ b/src/cat-data-service/src/service/v1/event.rs
@@ -325,44 +325,10 @@ mod tests {
             .body(Body::empty())
             .unwrap();
         let response = app.clone().oneshot(request).await.unwrap();
-        assert_eq!(response.status(), StatusCode::NOT_FOUND);
-    }
-
-    #[tokio::test]
-    async fn events_with_offset_and_limit_test() {
-        let state = Arc::new(State::new(None).await.unwrap());
-        let app = app(state);
-
-        let request = Request::builder()
-            .uri(format!("/api/v1/events/{0}/{1}", 1, 1))
-            .body(Body::empty())
-            .unwrap();
-        let response = app.clone().oneshot(request).await.unwrap();
-        assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
             String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
                 .unwrap(),
-            serde_json::to_string(&vec![EventSummary {
-                id: EventId(2),
-                name: "Test Fund 2".to_string(),
-                starts: DateTime::<Utc>::from_utc(
-                    NaiveDateTime::new(
-                        NaiveDate::from_ymd_opt(2021, 5, 1).unwrap(),
-                        NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                    ),
-                    Utc
-                ),
-                ends: DateTime::<Utc>::from_utc(
-                    NaiveDateTime::new(
-                        NaiveDate::from_ymd_opt(2021, 6, 1).unwrap(),
-                        NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                    ),
-                    Utc
-                ),
-                is_final: true,
-                reg_checked: None,
-            },])
-            .unwrap()
+            serde_json::to_string(&Vec::<EventSummary>::new()).unwrap()
         );
     }
 }

--- a/src/cat-data-service/src/service/v1/event.rs
+++ b/src/cat-data-service/src/service/v1/event.rs
@@ -34,7 +34,6 @@ pub fn event(state: Arc<State>) -> Router {
         .route(
             "/events/:offset/:limit",
             get({
-                let state = state.clone();
                 move |path| async {
                     handle_result(events_with_offset_and_limit_exec(path, state).await).await
                 }

--- a/src/cat-data-service/src/service/v1/event.rs
+++ b/src/cat-data-service/src/service/v1/event.rs
@@ -2,8 +2,13 @@ use crate::{
     service::{handle_result, Error},
     state::State,
 };
-use axum::{extract::Path, routing::get, Router};
+use axum::{
+    extract::{Path, Query},
+    routing::get,
+    Router,
+};
 use event_db::types::event::{EventId, EventSummary};
+use serde::Deserialize;
 use std::sync::Arc;
 
 pub fn event(state: Arc<State>) -> Router {
@@ -19,24 +24,7 @@ pub fn event(state: Arc<State>) -> Router {
             "/events",
             get({
                 let state = state.clone();
-                move || async { handle_result(events_exec(state).await).await }
-            }),
-        )
-        .route(
-            "/events/:offset",
-            get({
-                let state = state.clone();
-                move |path| async {
-                    handle_result(events_with_offset_exec(path, state).await).await
-                }
-            }),
-        )
-        .route(
-            "/events/:offset/:limit",
-            get({
-                move |path| async {
-                    handle_result(events_with_offset_and_limit_exec(path, state).await).await
-                }
+                move |query| async { handle_result(events_exec(query, state).await).await }
             }),
         )
 }
@@ -48,30 +36,26 @@ async fn event_exec(Path(event): Path<EventId>, state: Arc<State>) -> Result<Eve
     Ok(event)
 }
 
-async fn events_exec(state: Arc<State>) -> Result<Vec<EventSummary>, Error> {
-    tracing::debug!("events_exec");
-
-    let events = state.event_db.get_events(None, None).await?;
-    Ok(events)
+#[derive(Deserialize)]
+struct EventsQuery {
+    limit: Option<i64>,
+    offset: Option<i64>,
 }
 
-async fn events_with_offset_exec(
-    Path(offset): Path<i64>,
+async fn events_exec(
+    events_query: Query<EventsQuery>,
     state: Arc<State>,
 ) -> Result<Vec<EventSummary>, Error> {
-    tracing::debug!("events_with_offset_exec, offset: {offset}");
+    tracing::debug!(
+        "events_exec, limit: {0:?}, offset: {1:?}",
+        events_query.limit,
+        events_query.offset
+    );
 
-    let events = state.event_db.get_events(None, Some(offset)).await?;
-    Ok(events)
-}
-
-async fn events_with_offset_and_limit_exec(
-    Path((limit, offset)): Path<(i64, i64)>,
-    state: Arc<State>,
-) -> Result<Vec<EventSummary>, Error> {
-    tracing::debug!("events_with_offset_and_limit_exec, offset: {offset}, limit: {limit}");
-
-    let events = state.event_db.get_events(Some(limit), Some(offset)).await?;
+    let events = state
+        .event_db
+        .get_events(events_query.limit, events_query.offset)
+        .await?;
     Ok(events)
 }
 
@@ -130,6 +114,13 @@ mod tests {
             },)
             .unwrap()
         );
+
+        let request = Request::builder()
+            .uri(format!("/api/v1/event/{0}", 10))
+            .body(Body::empty())
+            .unwrap();
+        let response = app.clone().oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
     }
 
     #[tokio::test]
@@ -212,20 +203,7 @@ mod tests {
         );
 
         let request = Request::builder()
-            .uri(format!("/api/v1/event/{0}", 10))
-            .body(Body::empty())
-            .unwrap();
-        let response = app.clone().oneshot(request).await.unwrap();
-        assert_eq!(response.status(), StatusCode::NOT_FOUND);
-    }
-
-    #[tokio::test]
-    async fn events_with_offset_test() {
-        let state = Arc::new(State::new(None).await.unwrap());
-        let app = app(state);
-
-        let request = Request::builder()
-            .uri(format!("/api/v1/events/{0}", 1))
+            .uri(format!("/api/v1/events?offset={0}", 1))
             .body(Body::empty())
             .unwrap();
         let response = app.clone().oneshot(request).await.unwrap();
@@ -279,7 +257,71 @@ mod tests {
         );
 
         let request = Request::builder()
-            .uri(format!("/api/v1/events/{0}", 10))
+            .uri(format!("/api/v1/events?limit={0}", 1))
+            .body(Body::empty())
+            .unwrap();
+        let response = app.clone().oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                .unwrap(),
+            serde_json::to_string(&vec![EventSummary {
+                id: EventId(1),
+                name: "Test Fund 1".to_string(),
+                starts: DateTime::<Utc>::from_utc(
+                    NaiveDateTime::new(
+                        NaiveDate::from_ymd_opt(2020, 5, 1).unwrap(),
+                        NaiveTime::from_hms_opt(12, 0, 0).unwrap()
+                    ),
+                    Utc
+                ),
+                ends: DateTime::<Utc>::from_utc(
+                    NaiveDateTime::new(
+                        NaiveDate::from_ymd_opt(2020, 6, 1).unwrap(),
+                        NaiveTime::from_hms_opt(12, 0, 0).unwrap()
+                    ),
+                    Utc
+                ),
+                is_final: true,
+                reg_checked: None,
+            },])
+            .unwrap()
+        );
+
+        let request = Request::builder()
+            .uri(format!("/api/v1/events?limit={0}&offset={1}", 1, 1))
+            .body(Body::empty())
+            .unwrap();
+        let response = app.clone().oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                .unwrap(),
+            serde_json::to_string(&vec![EventSummary {
+                id: EventId(2),
+                name: "Test Fund 2".to_string(),
+                starts: DateTime::<Utc>::from_utc(
+                    NaiveDateTime::new(
+                        NaiveDate::from_ymd_opt(2021, 5, 1).unwrap(),
+                        NaiveTime::from_hms_opt(12, 0, 0).unwrap()
+                    ),
+                    Utc
+                ),
+                ends: DateTime::<Utc>::from_utc(
+                    NaiveDateTime::new(
+                        NaiveDate::from_ymd_opt(2021, 6, 1).unwrap(),
+                        NaiveTime::from_hms_opt(12, 0, 0).unwrap()
+                    ),
+                    Utc
+                ),
+                is_final: true,
+                reg_checked: None,
+            },])
+            .unwrap()
+        );
+
+        let request = Request::builder()
+            .uri(format!("/api/v1/events?offset={0}", 10))
             .body(Body::empty())
             .unwrap();
         let response = app.clone().oneshot(request).await.unwrap();

--- a/src/cat-data-service/src/service/v1/event.rs
+++ b/src/cat-data-service/src/service/v1/event.rs
@@ -73,7 +73,8 @@ mod tests {
     };
     use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
     use event_db::types::event::{
-        EventDetails, EventGoal, EventId, EventSchedule, VotingPowerAlgorithm, VotingPowerSettings,
+        EventDetails, EventGoal, EventId, EventSchedule, VoterGroup, VotingPowerAlgorithm,
+        VotingPowerSettings,
     };
     use rust_decimal::Decimal;
     use tower::ServiceExt;
@@ -209,7 +210,16 @@ mod tests {
                             name: "goal 4".to_string(),
                         }
                     ],
-                    groups: vec![]
+                    groups: vec![
+                        VoterGroup {
+                            id: "rep".to_string(),
+                            voting_token: "rep token".to_string()
+                        },
+                        VoterGroup {
+                            id: "direct".to_string(),
+                            voting_token: "direct token".to_string()
+                        }
+                    ]
                 },
             },)
             .unwrap()

--- a/src/cat-data-service/src/service/v1/event.rs
+++ b/src/cat-data-service/src/service/v1/event.rs
@@ -73,7 +73,7 @@ mod tests {
     };
     use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
     use event_db::types::event::{
-        EventDetails, EventId, EventSchedule, VotingPowerAlgorithm, VotingPowerSettings,
+        EventDetails, EventGoal, EventId, EventSchedule, VotingPowerAlgorithm, VotingPowerSettings,
     };
     use rust_decimal::Decimal;
     use tower::ServiceExt;
@@ -191,7 +191,24 @@ mod tests {
                             Utc
                         )),
                     },
-                    goals: vec![],
+                    goals: vec![
+                        EventGoal {
+                            idx: 1,
+                            name: "goal 1".to_string(),
+                        },
+                        EventGoal {
+                            idx: 2,
+                            name: "goal 2".to_string(),
+                        },
+                        EventGoal {
+                            idx: 3,
+                            name: "goal 3".to_string(),
+                        },
+                        EventGoal {
+                            idx: 4,
+                            name: "goal 4".to_string(),
+                        }
+                    ],
                     groups: vec![]
                 },
             },)

--- a/src/cat-data-service/src/service/v1/event.rs
+++ b/src/cat-data-service/src/service/v1/event.rs
@@ -3,11 +3,18 @@ use crate::{
     state::State,
 };
 use axum::{extract::Path, routing::get, Router};
-use event_db::types::event::EventSummary;
+use event_db::types::event::{EventId, EventSummary};
 use std::sync::Arc;
 
 pub fn event(state: Arc<State>) -> Router {
     Router::new()
+        .route(
+            "/event/:event",
+            get({
+                let state = state.clone();
+                move |path| async { handle_result(event_exec(path, state).await).await }
+            }),
+        )
         .route(
             "/events",
             get({
@@ -33,6 +40,13 @@ pub fn event(state: Arc<State>) -> Router {
                 }
             }),
         )
+}
+
+async fn event_exec(Path(event): Path<EventId>, state: Arc<State>) -> Result<EventSummary, Error> {
+    tracing::debug!("event_exec, event: {0}", event.0);
+
+    let event = state.event_db.get_event(event).await?;
+    Ok(event)
 }
 
 async fn events_exec(state: Arc<State>) -> Result<Vec<EventSummary>, Error> {
@@ -80,6 +94,44 @@ mod tests {
     use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
     use event_db::types::event::EventId;
     use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn event_test() {
+        let state = Arc::new(State::new(None).await.unwrap());
+        let app = app(state);
+
+        let request = Request::builder()
+            .uri(format!("/api/v1/event/{0}", 1))
+            .body(Body::empty())
+            .unwrap();
+        let response = app.clone().oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                .unwrap(),
+            serde_json::to_string(&EventSummary {
+                id: EventId(1),
+                name: "Test Fund 1".to_string(),
+                starts: DateTime::<Utc>::from_utc(
+                    NaiveDateTime::new(
+                        NaiveDate::from_ymd_opt(2020, 5, 1).unwrap(),
+                        NaiveTime::from_hms_opt(12, 0, 0).unwrap()
+                    ),
+                    Utc
+                ),
+                ends: DateTime::<Utc>::from_utc(
+                    NaiveDateTime::new(
+                        NaiveDate::from_ymd_opt(2020, 6, 1).unwrap(),
+                        NaiveTime::from_hms_opt(12, 0, 0).unwrap()
+                    ),
+                    Utc
+                ),
+                is_final: true,
+                reg_checked: None,
+            },)
+            .unwrap()
+        );
+    }
 
     #[tokio::test]
     async fn events_test() {
@@ -159,6 +211,13 @@ mod tests {
             ])
             .unwrap()
         );
+
+        let request = Request::builder()
+            .uri(format!("/api/v1/event/{0}", 10))
+            .body(Body::empty())
+            .unwrap();
+        let response = app.clone().oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
     }
 
     #[tokio::test]
@@ -167,7 +226,7 @@ mod tests {
         let app = app(state);
 
         let request = Request::builder()
-            .uri(format!("/api/v1/events/1"))
+            .uri(format!("/api/v1/events/{0}", 1))
             .body(Body::empty())
             .unwrap();
         let response = app.clone().oneshot(request).await.unwrap();
@@ -219,6 +278,13 @@ mod tests {
             ])
             .unwrap()
         );
+
+        let request = Request::builder()
+            .uri(format!("/api/v1/events/{0}", 10))
+            .body(Body::empty())
+            .unwrap();
+        let response = app.clone().oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
     }
 
     #[tokio::test]
@@ -227,7 +293,7 @@ mod tests {
         let app = app(state);
 
         let request = Request::builder()
-            .uri(format!("/api/v1/events/1/1"))
+            .uri(format!("/api/v1/events/{0}/{1}", 1, 1))
             .body(Body::empty())
             .unwrap();
         let response = app.clone().oneshot(request).await.unwrap();

--- a/src/cat-data-service/src/service/v1/event.rs
+++ b/src/cat-data-service/src/service/v1/event.rs
@@ -19,7 +19,7 @@ pub fn event(state: Arc<State>) -> Router {
 async fn events_exec(state: Arc<State>) -> Result<Vec<EventSummary>, Error> {
     tracing::debug!("events_exec");
 
-    let events = state.event_db.get_events(None).await?;
+    let events = state.event_db.get_events(None, None).await?;
     Ok(events)
 }
 

--- a/src/cat-data-service/src/service/v1/event.rs
+++ b/src/cat-data-service/src/service/v1/event.rs
@@ -75,7 +75,10 @@ mod tests {
         http::{Request, StatusCode},
     };
     use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
-    use event_db::types::event::EventId;
+    use event_db::types::event::{
+        EventDetails, EventId, EventSchedule, VotingPowerAlgorithm, VotingPowerSettings,
+    };
+    use rust_decimal::Decimal;
     use tower::ServiceExt;
 
     #[tokio::test]
@@ -92,31 +95,108 @@ mod tests {
         assert_eq!(
             String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
                 .unwrap(),
-            serde_json::to_string(&EventSummary {
-                id: EventId(1),
-                name: "Test Fund 1".to_string(),
-                starts: Some(DateTime::<Utc>::from_utc(
-                    NaiveDateTime::new(
-                        NaiveDate::from_ymd_opt(2020, 5, 1).unwrap(),
-                        NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                    ),
-                    Utc
-                )),
-                ends: Some(DateTime::<Utc>::from_utc(
-                    NaiveDateTime::new(
-                        NaiveDate::from_ymd_opt(2020, 6, 1).unwrap(),
-                        NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                    ),
-                    Utc
-                )),
-                reg_checked: Some(DateTime::<Utc>::from_utc(
-                    NaiveDateTime::new(
-                        NaiveDate::from_ymd_opt(2020, 3, 31).unwrap(),
-                        NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                    ),
-                    Utc
-                )),
-                is_final: true,
+            serde_json::to_string(&Event {
+                event_summary: EventSummary {
+                    id: EventId(1),
+                    name: "Test Fund 1".to_string(),
+                    starts: Some(DateTime::<Utc>::from_utc(
+                        NaiveDateTime::new(
+                            NaiveDate::from_ymd_opt(2020, 5, 1).unwrap(),
+                            NaiveTime::from_hms_opt(12, 0, 0).unwrap()
+                        ),
+                        Utc
+                    )),
+                    ends: Some(DateTime::<Utc>::from_utc(
+                        NaiveDateTime::new(
+                            NaiveDate::from_ymd_opt(2020, 6, 1).unwrap(),
+                            NaiveTime::from_hms_opt(12, 0, 0).unwrap()
+                        ),
+                        Utc
+                    )),
+                    reg_checked: Some(DateTime::<Utc>::from_utc(
+                        NaiveDateTime::new(
+                            NaiveDate::from_ymd_opt(2020, 3, 31).unwrap(),
+                            NaiveTime::from_hms_opt(12, 0, 0).unwrap()
+                        ),
+                        Utc
+                    )),
+                    is_final: true,
+                },
+                event_details: EventDetails {
+                    voting_power: VotingPowerSettings {
+                        alg: VotingPowerAlgorithm::ThresholdStakedADA,
+                        min_ada: Some(1),
+                        max_pct: Some(Decimal::new(100, 0)),
+                    },
+                    registration: None,
+                    schedule: EventSchedule {
+                        insight_sharing: Some(DateTime::<Utc>::from_utc(
+                            NaiveDateTime::new(
+                                NaiveDate::from_ymd_opt(2020, 3, 1).unwrap(),
+                                NaiveTime::from_hms_opt(12, 0, 0).unwrap()
+                            ),
+                            Utc
+                        )),
+                        proposal_submission: Some(DateTime::<Utc>::from_utc(
+                            NaiveDateTime::new(
+                                NaiveDate::from_ymd_opt(2020, 3, 1).unwrap(),
+                                NaiveTime::from_hms_opt(12, 0, 0).unwrap()
+                            ),
+                            Utc
+                        )),
+                        refine_proposals: Some(DateTime::<Utc>::from_utc(
+                            NaiveDateTime::new(
+                                NaiveDate::from_ymd_opt(2020, 3, 1).unwrap(),
+                                NaiveTime::from_hms_opt(12, 0, 0).unwrap()
+                            ),
+                            Utc
+                        )),
+                        finalize_proposals: Some(DateTime::<Utc>::from_utc(
+                            NaiveDateTime::new(
+                                NaiveDate::from_ymd_opt(2020, 3, 1).unwrap(),
+                                NaiveTime::from_hms_opt(12, 0, 0).unwrap()
+                            ),
+                            Utc
+                        )),
+                        proposal_assessment: Some(DateTime::<Utc>::from_utc(
+                            NaiveDateTime::new(
+                                NaiveDate::from_ymd_opt(2020, 3, 1).unwrap(),
+                                NaiveTime::from_hms_opt(12, 0, 0).unwrap()
+                            ),
+                            Utc
+                        )),
+                        assessment_qa_start: Some(DateTime::<Utc>::from_utc(
+                            NaiveDateTime::new(
+                                NaiveDate::from_ymd_opt(2020, 3, 1).unwrap(),
+                                NaiveTime::from_hms_opt(12, 0, 0).unwrap()
+                            ),
+                            Utc
+                        )),
+                        voting: Some(DateTime::<Utc>::from_utc(
+                            NaiveDateTime::new(
+                                NaiveDate::from_ymd_opt(2020, 5, 1).unwrap(),
+                                NaiveTime::from_hms_opt(12, 0, 0).unwrap()
+                            ),
+                            Utc
+                        )),
+                        tallying: Some(DateTime::<Utc>::from_utc(
+                            NaiveDateTime::new(
+                                NaiveDate::from_ymd_opt(2020, 6, 1).unwrap(),
+                                NaiveTime::from_hms_opt(12, 0, 0).unwrap()
+                            ),
+                            Utc
+                        )),
+                        tallying_end: Some(DateTime::<Utc>::from_utc(
+                            NaiveDateTime::new(
+                                NaiveDate::from_ymd_opt(2020, 7, 1).unwrap(),
+                                NaiveTime::from_hms_opt(12, 0, 0).unwrap()
+                            ),
+                            Utc
+                        )),
+                    },
+                    goals: vec![],
+                    groups: vec![]
+                },
             },)
             .unwrap()
         );

--- a/src/cat-data-service/src/service/v1/event.rs
+++ b/src/cat-data-service/src/service/v1/event.rs
@@ -95,22 +95,28 @@ mod tests {
             serde_json::to_string(&EventSummary {
                 id: EventId(1),
                 name: "Test Fund 1".to_string(),
-                starts: DateTime::<Utc>::from_utc(
+                starts: Some(DateTime::<Utc>::from_utc(
                     NaiveDateTime::new(
                         NaiveDate::from_ymd_opt(2020, 5, 1).unwrap(),
                         NaiveTime::from_hms_opt(12, 0, 0).unwrap()
                     ),
                     Utc
-                ),
-                ends: DateTime::<Utc>::from_utc(
+                )),
+                ends: Some(DateTime::<Utc>::from_utc(
                     NaiveDateTime::new(
                         NaiveDate::from_ymd_opt(2020, 6, 1).unwrap(),
                         NaiveTime::from_hms_opt(12, 0, 0).unwrap()
                     ),
                     Utc
-                ),
+                )),
+                reg_checked: Some(DateTime::<Utc>::from_utc(
+                    NaiveDateTime::new(
+                        NaiveDate::from_ymd_opt(2020, 3, 31).unwrap(),
+                        NaiveTime::from_hms_opt(12, 0, 0).unwrap()
+                    ),
+                    Utc
+                )),
                 is_final: true,
-                reg_checked: None,
             },)
             .unwrap()
         );
@@ -141,62 +147,88 @@ mod tests {
                 EventSummary {
                     id: EventId(1),
                     name: "Test Fund 1".to_string(),
-                    starts: DateTime::<Utc>::from_utc(
+                    starts: Some(DateTime::<Utc>::from_utc(
                         NaiveDateTime::new(
                             NaiveDate::from_ymd_opt(2020, 5, 1).unwrap(),
                             NaiveTime::from_hms_opt(12, 0, 0).unwrap()
                         ),
                         Utc
-                    ),
-                    ends: DateTime::<Utc>::from_utc(
+                    )),
+                    ends: Some(DateTime::<Utc>::from_utc(
                         NaiveDateTime::new(
                             NaiveDate::from_ymd_opt(2020, 6, 1).unwrap(),
                             NaiveTime::from_hms_opt(12, 0, 0).unwrap()
                         ),
                         Utc
-                    ),
+                    )),
+                    reg_checked: Some(DateTime::<Utc>::from_utc(
+                        NaiveDateTime::new(
+                            NaiveDate::from_ymd_opt(2020, 3, 31).unwrap(),
+                            NaiveTime::from_hms_opt(12, 0, 0).unwrap()
+                        ),
+                        Utc
+                    )),
                     is_final: true,
-                    reg_checked: None,
                 },
                 EventSummary {
                     id: EventId(2),
                     name: "Test Fund 2".to_string(),
-                    starts: DateTime::<Utc>::from_utc(
+                    starts: Some(DateTime::<Utc>::from_utc(
                         NaiveDateTime::new(
                             NaiveDate::from_ymd_opt(2021, 5, 1).unwrap(),
                             NaiveTime::from_hms_opt(12, 0, 0).unwrap()
                         ),
                         Utc
-                    ),
-                    ends: DateTime::<Utc>::from_utc(
+                    )),
+                    ends: Some(DateTime::<Utc>::from_utc(
                         NaiveDateTime::new(
                             NaiveDate::from_ymd_opt(2021, 6, 1).unwrap(),
                             NaiveTime::from_hms_opt(12, 0, 0).unwrap()
                         ),
                         Utc
-                    ),
+                    )),
+                    reg_checked: Some(DateTime::<Utc>::from_utc(
+                        NaiveDateTime::new(
+                            NaiveDate::from_ymd_opt(2021, 3, 31).unwrap(),
+                            NaiveTime::from_hms_opt(12, 0, 0).unwrap()
+                        ),
+                        Utc
+                    )),
                     is_final: true,
-                    reg_checked: None,
                 },
                 EventSummary {
                     id: EventId(3),
                     name: "Test Fund 3".to_string(),
-                    starts: DateTime::<Utc>::from_utc(
+                    starts: Some(DateTime::<Utc>::from_utc(
                         NaiveDateTime::new(
                             NaiveDate::from_ymd_opt(2022, 5, 1).unwrap(),
                             NaiveTime::from_hms_opt(12, 0, 0).unwrap()
                         ),
                         Utc
-                    ),
-                    ends: DateTime::<Utc>::from_utc(
+                    )),
+                    ends: Some(DateTime::<Utc>::from_utc(
                         NaiveDateTime::new(
                             NaiveDate::from_ymd_opt(2022, 6, 1).unwrap(),
                             NaiveTime::from_hms_opt(12, 0, 0).unwrap()
                         ),
                         Utc
-                    ),
+                    )),
+                    reg_checked: Some(DateTime::<Utc>::from_utc(
+                        NaiveDateTime::new(
+                            NaiveDate::from_ymd_opt(2022, 3, 31).unwrap(),
+                            NaiveTime::from_hms_opt(12, 0, 0).unwrap()
+                        ),
+                        Utc
+                    )),
                     is_final: true,
+                },
+                EventSummary {
+                    id: EventId(4),
+                    name: "Test Fund 4".to_string(),
+                    starts: None,
+                    ends: None,
                     reg_checked: None,
+                    is_final: false,
                 }
             ])
             .unwrap()
@@ -215,42 +247,62 @@ mod tests {
                 EventSummary {
                     id: EventId(2),
                     name: "Test Fund 2".to_string(),
-                    starts: DateTime::<Utc>::from_utc(
+                    starts: Some(DateTime::<Utc>::from_utc(
                         NaiveDateTime::new(
                             NaiveDate::from_ymd_opt(2021, 5, 1).unwrap(),
                             NaiveTime::from_hms_opt(12, 0, 0).unwrap()
                         ),
                         Utc
-                    ),
-                    ends: DateTime::<Utc>::from_utc(
+                    )),
+                    ends: Some(DateTime::<Utc>::from_utc(
                         NaiveDateTime::new(
                             NaiveDate::from_ymd_opt(2021, 6, 1).unwrap(),
                             NaiveTime::from_hms_opt(12, 0, 0).unwrap()
                         ),
                         Utc
-                    ),
+                    )),
+                    reg_checked: Some(DateTime::<Utc>::from_utc(
+                        NaiveDateTime::new(
+                            NaiveDate::from_ymd_opt(2021, 3, 31).unwrap(),
+                            NaiveTime::from_hms_opt(12, 0, 0).unwrap()
+                        ),
+                        Utc
+                    )),
                     is_final: true,
-                    reg_checked: None,
                 },
                 EventSummary {
                     id: EventId(3),
                     name: "Test Fund 3".to_string(),
-                    starts: DateTime::<Utc>::from_utc(
+                    starts: Some(DateTime::<Utc>::from_utc(
                         NaiveDateTime::new(
                             NaiveDate::from_ymd_opt(2022, 5, 1).unwrap(),
                             NaiveTime::from_hms_opt(12, 0, 0).unwrap()
                         ),
                         Utc
-                    ),
-                    ends: DateTime::<Utc>::from_utc(
+                    )),
+                    ends: Some(DateTime::<Utc>::from_utc(
                         NaiveDateTime::new(
                             NaiveDate::from_ymd_opt(2022, 6, 1).unwrap(),
                             NaiveTime::from_hms_opt(12, 0, 0).unwrap()
                         ),
                         Utc
-                    ),
+                    )),
+                    reg_checked: Some(DateTime::<Utc>::from_utc(
+                        NaiveDateTime::new(
+                            NaiveDate::from_ymd_opt(2022, 3, 31).unwrap(),
+                            NaiveTime::from_hms_opt(12, 0, 0).unwrap()
+                        ),
+                        Utc
+                    )),
                     is_final: true,
+                },
+                EventSummary {
+                    id: EventId(4),
+                    name: "Test Fund 4".to_string(),
+                    starts: None,
+                    ends: None,
                     reg_checked: None,
+                    is_final: false,
                 }
             ])
             .unwrap()
@@ -268,22 +320,28 @@ mod tests {
             serde_json::to_string(&vec![EventSummary {
                 id: EventId(1),
                 name: "Test Fund 1".to_string(),
-                starts: DateTime::<Utc>::from_utc(
+                starts: Some(DateTime::<Utc>::from_utc(
                     NaiveDateTime::new(
                         NaiveDate::from_ymd_opt(2020, 5, 1).unwrap(),
                         NaiveTime::from_hms_opt(12, 0, 0).unwrap()
                     ),
                     Utc
-                ),
-                ends: DateTime::<Utc>::from_utc(
+                )),
+                ends: Some(DateTime::<Utc>::from_utc(
                     NaiveDateTime::new(
                         NaiveDate::from_ymd_opt(2020, 6, 1).unwrap(),
                         NaiveTime::from_hms_opt(12, 0, 0).unwrap()
                     ),
                     Utc
-                ),
+                )),
+                reg_checked: Some(DateTime::<Utc>::from_utc(
+                    NaiveDateTime::new(
+                        NaiveDate::from_ymd_opt(2020, 3, 31).unwrap(),
+                        NaiveTime::from_hms_opt(12, 0, 0).unwrap()
+                    ),
+                    Utc
+                )),
                 is_final: true,
-                reg_checked: None,
             },])
             .unwrap()
         );
@@ -300,22 +358,28 @@ mod tests {
             serde_json::to_string(&vec![EventSummary {
                 id: EventId(2),
                 name: "Test Fund 2".to_string(),
-                starts: DateTime::<Utc>::from_utc(
+                starts: Some(DateTime::<Utc>::from_utc(
                     NaiveDateTime::new(
                         NaiveDate::from_ymd_opt(2021, 5, 1).unwrap(),
                         NaiveTime::from_hms_opt(12, 0, 0).unwrap()
                     ),
                     Utc
-                ),
-                ends: DateTime::<Utc>::from_utc(
+                )),
+                ends: Some(DateTime::<Utc>::from_utc(
                     NaiveDateTime::new(
                         NaiveDate::from_ymd_opt(2021, 6, 1).unwrap(),
                         NaiveTime::from_hms_opt(12, 0, 0).unwrap()
                     ),
                     Utc
-                ),
+                )),
+                reg_checked: Some(DateTime::<Utc>::from_utc(
+                    NaiveDateTime::new(
+                        NaiveDate::from_ymd_opt(2021, 3, 31).unwrap(),
+                        NaiveTime::from_hms_opt(12, 0, 0).unwrap()
+                    ),
+                    Utc
+                )),
                 is_final: true,
-                reg_checked: None,
             },])
             .unwrap()
         );

--- a/src/cat-data-service/src/service/v1/event.rs
+++ b/src/cat-data-service/src/service/v1/event.rs
@@ -22,10 +22,7 @@ pub fn event(state: Arc<State>) -> Router {
         )
         .route(
             "/events",
-            get({
-                let state = state.clone();
-                move |query| async { handle_result(events_exec(query, state).await).await }
-            }),
+            get(move |query| async { handle_result(events_exec(query, state).await).await }),
         )
 }
 

--- a/src/cat-data-service/src/service/v1/mod.rs
+++ b/src/cat-data-service/src/service/v1/mod.rs
@@ -2,10 +2,12 @@ use crate::state::State;
 use axum::Router;
 use std::sync::Arc;
 
+mod event;
 mod registration;
 
 pub fn v1(state: Arc<State>) -> Router {
-    let registration = registration::registration(state);
+    let registration = registration::registration(state.clone());
+    let event = event::event(state);
 
-    Router::new().nest("/v1", registration)
+    Router::new().nest("/v1", registration.merge(event))
 }

--- a/src/cat-data-service/src/service/v1/registration.rs
+++ b/src/cat-data-service/src/service/v1/registration.rs
@@ -28,7 +28,6 @@ pub fn registration(state: Arc<State>) -> Router {
         .route(
             "/registration/delegations/:stake_public_key",
             get({
-                let state = state.clone();
                 move |path, query| async {
                     handle_result(delegations_exec(path, query, state).await).await
                 }

--- a/src/cat-data-service/src/service/v1/registration.rs
+++ b/src/cat-data-service/src/service/v1/registration.rs
@@ -3,7 +3,10 @@ use crate::{
     state::State,
 };
 use axum::{extract::Path, routing::get, Router};
-use event_db::types::snapshot::{Delegator, EventId, Voter};
+use event_db::types::{
+    event::EventId,
+    registration::{Delegator, Voter},
+};
 use std::sync::Arc;
 
 pub fn registration(state: Arc<State>) -> Router {
@@ -111,7 +114,7 @@ mod tests {
         http::{Request, StatusCode},
     };
     use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
-    use event_db::types::snapshot::{Delegation, VoterInfo};
+    use event_db::types::registration::{Delegation, VoterInfo};
     use tower::ServiceExt;
 
     #[tokio::test]

--- a/src/cat-data-service/src/state.rs
+++ b/src/cat-data-service/src/state.rs
@@ -1,9 +1,9 @@
 use crate::cli::Error;
-use event_db::queries::snapshot::SnapshotQueries;
+use event_db::queries::EventDbQueries;
 use std::sync::Arc;
 
 pub struct State {
-    pub event_db: Arc<dyn SnapshotQueries>,
+    pub event_db: Arc<dyn EventDbQueries>,
 }
 
 impl State {

--- a/src/event-db/Cargo.toml
+++ b/src/event-db/Cargo.toml
@@ -23,3 +23,5 @@ async-trait = { workspace = true }
 tokio = { version = "1", features = ["full"] }
 
 chrono = { workspace = true }
+
+rust_decimal = {  workspace = true, features = ["serde-with-float", "db-tokio-postgres"] }

--- a/src/event-db/migrations/V3__objective_tables.sql
+++ b/src/event-db/migrations/V3__objective_tables.sql
@@ -65,7 +65,7 @@ CREATE TABLE goal
     id SERIAL PRIMARY KEY,
     event_id INTEGER NOT NULL,
 
-    idx integer NOT NULL,
+    idx INTEGER NOT NULL,
     name VARCHAR NOT NULL,
 
     FOREIGN KEY(event_id) REFERENCES event(row_id)

--- a/src/event-db/src/queries/event.rs
+++ b/src/event-db/src/queries/event.rs
@@ -207,51 +207,29 @@ mod tests {
             ]
         );
 
-        let events = event_db.get_events(Some(2), Some(1)).await.unwrap();
+        let events = event_db.get_events(Some(1), Some(1)).await.unwrap();
         assert_eq!(
             events,
-            vec![
-                EventSummary {
-                    id: EventId(2),
-                    name: "Test Fund 2".to_string(),
-                    starts: DateTime::<Utc>::from_utc(
-                        NaiveDateTime::new(
-                            NaiveDate::from_ymd_opt(2021, 5, 1).unwrap(),
-                            NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                        ),
-                        Utc
+            vec![EventSummary {
+                id: EventId(2),
+                name: "Test Fund 2".to_string(),
+                starts: DateTime::<Utc>::from_utc(
+                    NaiveDateTime::new(
+                        NaiveDate::from_ymd_opt(2021, 5, 1).unwrap(),
+                        NaiveTime::from_hms_opt(12, 0, 0).unwrap()
                     ),
-                    ends: DateTime::<Utc>::from_utc(
-                        NaiveDateTime::new(
-                            NaiveDate::from_ymd_opt(2021, 6, 1).unwrap(),
-                            NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                        ),
-                        Utc
+                    Utc
+                ),
+                ends: DateTime::<Utc>::from_utc(
+                    NaiveDateTime::new(
+                        NaiveDate::from_ymd_opt(2021, 6, 1).unwrap(),
+                        NaiveTime::from_hms_opt(12, 0, 0).unwrap()
                     ),
-                    is_final: true,
-                    reg_checked: None,
-                },
-                EventSummary {
-                    id: EventId(3),
-                    name: "Test Fund 3".to_string(),
-                    starts: DateTime::<Utc>::from_utc(
-                        NaiveDateTime::new(
-                            NaiveDate::from_ymd_opt(2022, 5, 1).unwrap(),
-                            NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                        ),
-                        Utc
-                    ),
-                    ends: DateTime::<Utc>::from_utc(
-                        NaiveDateTime::new(
-                            NaiveDate::from_ymd_opt(2022, 6, 1).unwrap(),
-                            NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                        ),
-                        Utc
-                    ),
-                    is_final: true,
-                    reg_checked: None,
-                }
-            ]
+                    Utc
+                ),
+                is_final: true,
+                reg_checked: None,
+            },]
         );
     }
 }

--- a/src/event-db/src/queries/event.rs
+++ b/src/event-db/src/queries/event.rs
@@ -1,8 +1,8 @@
 use crate::{
     error::Error,
     types::event::{
-        Event, EventDetails, EventGoal, EventId, EventSchedule, EventSummary, VotingPowerAlgorithm,
-        VotingPowerSettings,
+        Event, EventDetails, EventGoal, EventId, EventSchedule, EventSummary, VoterGroup,
+        VotingPowerAlgorithm, VotingPowerSettings,
     },
     EventDB,
 };
@@ -46,6 +46,10 @@ impl EventDB {
     const EVENT_GOALS_QUERY: &'static str = "SELECT goal.idx, goal.name 
                                             FROM goal 
                                             WHERE goal.event_id = $1;";
+
+    const EVENT_GROUPS_QUERY: &'static str = "SELECT voting_group.group_id, voting_group.token_id 
+                                            FROM voting_group 
+                                            WHERE voting_group.event_id = $1;";
 }
 
 #[async_trait]
@@ -147,6 +151,15 @@ impl EventQueries for EventDB {
             })
         }
 
+        let rows = conn.query(Self::EVENT_GROUPS_QUERY, &[&event.0]).await?;
+        let mut groups = Vec::new();
+        for row in rows {
+            groups.push(VoterGroup {
+                id: row.try_get("group_id")?,
+                voting_token: row.try_get("token_id")?,
+            })
+        }
+
         Ok(Event {
             event_summary: EventSummary {
                 id: EventId(row.try_get("row_id")?),
@@ -164,9 +177,9 @@ impl EventQueries for EventDB {
                 voting_power,
                 schedule,
                 goals,
+                groups,
                 // TODO implement queries
                 registration: None,
-                groups: vec![],
             },
         })
     }
@@ -503,7 +516,16 @@ mod tests {
                             name: "goal 4".to_string(),
                         }
                     ],
-                    groups: vec![]
+                    groups: vec![
+                        VoterGroup {
+                            id: "rep".to_string(),
+                            voting_token: "rep token".to_string()
+                        },
+                        VoterGroup {
+                            id: "direct".to_string(),
+                            voting_token: "direct token".to_string()
+                        }
+                    ]
                 },
             },
         );

--- a/src/event-db/src/queries/event.rs
+++ b/src/event-db/src/queries/event.rs
@@ -13,6 +13,7 @@ pub trait EventQueries: Sync + Send + 'static {
         limit: Option<i64>,
         offset: Option<i64>,
     ) -> Result<Vec<EventSummary>, Error>;
+    async fn get_event(&self, event: EventId) -> Result<EventSummary, Error>;
 }
 
 impl EventDB {
@@ -29,6 +30,12 @@ impl EventDB {
         INNER JOIN snapshot ON event.row_id = snapshot.event
         ORDER BY event.row_id ASC
         LIMIT $1 OFFSET $2";
+
+    const EVENT_QUERY: &'static str =
+        "SELECT event.row_id, event.name, event.start_time, event.end_time, snapshot.final
+        FROM event
+        INNER JOIN snapshot ON event.row_id = snapshot.event
+        WHERE event.row_id = $1;";
 }
 
 #[async_trait]
@@ -73,6 +80,28 @@ impl EventQueries for EventDB {
         }
 
         Ok(events)
+    }
+
+    async fn get_event(&self, event: EventId) -> Result<EventSummary, Error> {
+        let conn = self.pool.get().await?;
+
+        let rows = conn.query(Self::EVENT_QUERY, &[&event.0]).await?;
+        let row = rows.get(0).ok_or(Error::NotFound)?;
+
+        Ok(EventSummary {
+            id: EventId(row.try_get("row_id")?),
+            name: row.try_get("name")?,
+            starts: row
+                .try_get::<&'static str, NaiveDateTime>("start_time")?
+                .and_local_timezone(Utc)
+                .unwrap(),
+            ends: row
+                .try_get::<&'static str, NaiveDateTime>("end_time")?
+                .and_local_timezone(Utc)
+                .unwrap(),
+            is_final: row.try_get("final")?,
+            reg_checked: None,
+        })
     }
 }
 
@@ -231,5 +260,42 @@ mod tests {
                 reg_checked: None,
             },]
         );
+
+        assert_eq!(
+            event_db.get_events(Some(1), Some(10)).await,
+            Err(Error::NotFound)
+        );
+    }
+
+    #[tokio::test]
+    async fn get_event_test() {
+        let event_db = establish_connection(None).await.unwrap();
+
+        let event = event_db.get_event(EventId(1)).await.unwrap();
+        assert_eq!(
+            event,
+            EventSummary {
+                id: EventId(1),
+                name: "Test Fund 1".to_string(),
+                starts: DateTime::<Utc>::from_utc(
+                    NaiveDateTime::new(
+                        NaiveDate::from_ymd_opt(2020, 5, 1).unwrap(),
+                        NaiveTime::from_hms_opt(12, 0, 0).unwrap()
+                    ),
+                    Utc
+                ),
+                ends: DateTime::<Utc>::from_utc(
+                    NaiveDateTime::new(
+                        NaiveDate::from_ymd_opt(2020, 6, 1).unwrap(),
+                        NaiveTime::from_hms_opt(12, 0, 0).unwrap()
+                    ),
+                    Utc
+                ),
+                is_final: true,
+                reg_checked: None,
+            },
+        );
+
+        assert_eq!(event_db.get_event(EventId(10)).await, Err(Error::NotFound));
     }
 }

--- a/src/event-db/src/queries/event.rs
+++ b/src/event-db/src/queries/event.rs
@@ -57,9 +57,6 @@ impl EventQueries for EventDB {
             conn.query(Self::EVENTS_QUERY, &[&offset.unwrap_or(0)])
                 .await?
         };
-        if rows.is_empty() {
-            return Err(Error::NotFound);
-        }
 
         let mut events = Vec::new();
         for row in rows {
@@ -262,8 +259,8 @@ mod tests {
         );
 
         assert_eq!(
-            event_db.get_events(Some(1), Some(10)).await,
-            Err(Error::NotFound)
+            event_db.get_events(Some(1), Some(10)).await.unwrap(),
+            vec![]
         );
     }
 

--- a/src/event-db/src/queries/event.rs
+++ b/src/event-db/src/queries/event.rs
@@ -1,0 +1,138 @@
+use crate::{
+    error::Error,
+    types::event::{EventId, EventSummary},
+    EventDB,
+};
+use async_trait::async_trait;
+use chrono::{NaiveDateTime, Utc};
+
+#[async_trait]
+pub trait EventQueries: Sync + Send + 'static {
+    async fn get_events(&self, limit: Option<i32>) -> Result<Vec<EventSummary>, Error>;
+}
+
+impl EventDB {
+    const EVENTS_QUERY: &'static str =
+        "SELECT event.row_id, event.name, event.start_time, event.end_time, snapshot.final
+        FROM event
+        INNER JOIN snapshot ON event.row_id = snapshot.event;";
+}
+
+#[async_trait]
+impl EventQueries for EventDB {
+    async fn get_events(&self, _limit: Option<i32>) -> Result<Vec<EventSummary>, Error> {
+        let conn = self.pool.get().await?;
+
+        let rows = conn.query(Self::EVENTS_QUERY, &[]).await?;
+        if rows.is_empty() {
+            return Err(Error::NotFound);
+        }
+
+        let mut events = Vec::new();
+        for row in rows {
+            events.push(EventSummary {
+                id: EventId(row.try_get("row_id")?),
+                name: row.try_get("name")?,
+                starts: row
+                    .try_get::<&'static str, NaiveDateTime>("start_time")?
+                    .and_local_timezone(Utc)
+                    .unwrap(),
+                ends: row
+                    .try_get::<&'static str, NaiveDateTime>("end_time")?
+                    .and_local_timezone(Utc)
+                    .unwrap(),
+                is_final: row.try_get("final")?,
+                reg_checked: None,
+            })
+        }
+
+        Ok(events)
+    }
+}
+
+/// Need to setup and run a test event db instance
+/// To do it you can use `cargo make local-event-db-setup`
+/// Also need establish `EVENT_DB_URL` env variable with the following value
+/// ```
+/// EVENT_DB_URL="postgres://catalyst-event-dev:CHANGE_ME@localhost/CatalystEventDev"
+/// ```
+/// https://github.com/input-output-hk/catalyst-core/tree/main/src/event-db/Readme.md
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::establish_connection;
+    use chrono::{DateTime, NaiveDate, NaiveTime};
+
+    #[tokio::test]
+    async fn get_events_test() {
+        let event_db = establish_connection(None).await.unwrap();
+
+        let events = event_db.get_events(None).await.unwrap();
+
+        assert_eq!(
+            events,
+            vec![
+                EventSummary {
+                    id: EventId(1),
+                    name: "Test Fund 1".to_string(),
+                    starts: DateTime::<Utc>::from_utc(
+                        NaiveDateTime::new(
+                            NaiveDate::from_ymd_opt(2020, 5, 1).unwrap(),
+                            NaiveTime::from_hms_opt(12, 0, 0).unwrap()
+                        ),
+                        Utc
+                    ),
+                    ends: DateTime::<Utc>::from_utc(
+                        NaiveDateTime::new(
+                            NaiveDate::from_ymd_opt(2020, 6, 1).unwrap(),
+                            NaiveTime::from_hms_opt(12, 0, 0).unwrap()
+                        ),
+                        Utc
+                    ),
+                    is_final: true,
+                    reg_checked: None,
+                },
+                EventSummary {
+                    id: EventId(2),
+                    name: "Test Fund 2".to_string(),
+                    starts: DateTime::<Utc>::from_utc(
+                        NaiveDateTime::new(
+                            NaiveDate::from_ymd_opt(2021, 5, 1).unwrap(),
+                            NaiveTime::from_hms_opt(12, 0, 0).unwrap()
+                        ),
+                        Utc
+                    ),
+                    ends: DateTime::<Utc>::from_utc(
+                        NaiveDateTime::new(
+                            NaiveDate::from_ymd_opt(2021, 6, 1).unwrap(),
+                            NaiveTime::from_hms_opt(12, 0, 0).unwrap()
+                        ),
+                        Utc
+                    ),
+                    is_final: true,
+                    reg_checked: None,
+                },
+                EventSummary {
+                    id: EventId(3),
+                    name: "Test Fund 3".to_string(),
+                    starts: DateTime::<Utc>::from_utc(
+                        NaiveDateTime::new(
+                            NaiveDate::from_ymd_opt(2022, 5, 1).unwrap(),
+                            NaiveTime::from_hms_opt(12, 0, 0).unwrap()
+                        ),
+                        Utc
+                    ),
+                    ends: DateTime::<Utc>::from_utc(
+                        NaiveDateTime::new(
+                            NaiveDate::from_ymd_opt(2022, 6, 1).unwrap(),
+                            NaiveTime::from_hms_opt(12, 0, 0).unwrap()
+                        ),
+                        Utc
+                    ),
+                    is_final: true,
+                    reg_checked: None,
+                }
+            ]
+        );
+    }
+}

--- a/src/event-db/src/queries/event.rs
+++ b/src/event-db/src/queries/event.rs
@@ -150,6 +150,7 @@ impl EventQueries for EventDB {
             event_details: EventDetails {
                 voting_power,
                 schedule,
+                // TODO implement queries
                 registration: None,
                 goals: vec![],
                 groups: vec![],

--- a/src/event-db/src/queries/mod.rs
+++ b/src/event-db/src/queries/mod.rs
@@ -1,1 +1,10 @@
-pub mod snapshot;
+use crate::EventDB;
+
+use self::{event::EventQueries, registration::RegistrationQueries};
+
+pub mod event;
+pub mod registration;
+
+pub trait EventDbQueries: RegistrationQueries + EventQueries {}
+
+impl EventDbQueries for EventDB {}

--- a/src/event-db/src/types/event.rs
+++ b/src/event-db/src/types/event.rs
@@ -9,17 +9,23 @@ pub struct EventId(pub i32);
 pub struct EventSummary {
     pub id: EventId,
     pub name: String,
-    #[serde(serialize_with = "serialize_datetime_as_rfc3339")]
-    pub starts: DateTime<Utc>,
-    #[serde(serialize_with = "serialize_datetime_as_rfc3339")]
-    pub ends: DateTime<Utc>,
-    #[serde(rename = "final")]
-    pub is_final: bool,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_option_datetime_as_rfc3339"
+    )]
+    pub starts: Option<DateTime<Utc>>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_option_datetime_as_rfc3339"
+    )]
+    pub ends: Option<DateTime<Utc>>,
     #[serde(
         skip_serializing_if = "Option::is_none",
         serialize_with = "serialize_option_datetime_as_rfc3339"
     )]
     pub reg_checked: Option<DateTime<Utc>>,
+    #[serde(rename = "final")]
+    pub is_final: bool,
 }
 
 #[derive(Debug, Serialize, Clone, PartialEq)]
@@ -131,13 +137,19 @@ mod tests {
         let event_summary = EventSummary {
             id: EventId(1),
             name: "Fund 10".to_string(),
-            starts: DateTime::from_utc(NaiveDateTime::from_timestamp_opt(0, 0).unwrap(), Utc),
-            ends: DateTime::from_utc(NaiveDateTime::from_timestamp_opt(0, 0).unwrap(), Utc),
-            is_final: true,
+            starts: Some(DateTime::from_utc(
+                NaiveDateTime::from_timestamp_opt(0, 0).unwrap(),
+                Utc,
+            )),
+            ends: Some(DateTime::from_utc(
+                NaiveDateTime::from_timestamp_opt(0, 0).unwrap(),
+                Utc,
+            )),
             reg_checked: Some(DateTime::from_utc(
                 NaiveDateTime::from_timestamp_opt(0, 0).unwrap(),
                 Utc,
             )),
+            is_final: true,
         };
 
         let json = serde_json::to_value(&event_summary).unwrap();
@@ -158,10 +170,10 @@ mod tests {
         let event_summary = EventSummary {
             id: EventId(1),
             name: "Fund 10".to_string(),
-            starts: DateTime::from_utc(NaiveDateTime::from_timestamp_opt(0, 0).unwrap(), Utc),
-            ends: DateTime::from_utc(NaiveDateTime::from_timestamp_opt(0, 0).unwrap(), Utc),
-            is_final: true,
+            starts: None,
+            ends: None,
             reg_checked: None,
+            is_final: true,
         };
 
         let json = serde_json::to_value(&event_summary).unwrap();
@@ -171,8 +183,6 @@ mod tests {
                 {
                     "id": 1,
                     "name": "Fund 10",
-                    "starts": "1970-01-01T00:00:00+00:00",
-                    "ends": "1970-01-01T00:00:00+00:00",
                     "final": true,
                 }
             )
@@ -471,13 +481,19 @@ mod tests {
             event_summary: EventSummary {
                 id: EventId(1),
                 name: "Fund 10".to_string(),
-                starts: DateTime::from_utc(NaiveDateTime::from_timestamp_opt(0, 0).unwrap(), Utc),
-                ends: DateTime::from_utc(NaiveDateTime::from_timestamp_opt(0, 0).unwrap(), Utc),
-                is_final: true,
+                starts: Some(DateTime::from_utc(
+                    NaiveDateTime::from_timestamp_opt(0, 0).unwrap(),
+                    Utc,
+                )),
+                ends: Some(DateTime::from_utc(
+                    NaiveDateTime::from_timestamp_opt(0, 0).unwrap(),
+                    Utc,
+                )),
                 reg_checked: Some(DateTime::from_utc(
                     NaiveDateTime::from_timestamp_opt(0, 0).unwrap(),
                     Utc,
                 )),
+                is_final: true,
             },
             event_details: Some(EventDetails {
                 voting_power: VotingPowerSettings {

--- a/src/event-db/src/types/event.rs
+++ b/src/event-db/src/types/event.rs
@@ -32,7 +32,7 @@ pub struct EventSummary {
 #[derive(Debug, Serialize, Clone, PartialEq, Eq)]
 pub enum VotingPowerAlgorithm {
     #[serde(rename = "threshold_staked_ADA")]
-    ThresholdStakedADA
+    ThresholdStakedADA,
 }
 
 #[derive(Debug, Serialize, Clone, PartialEq, Eq)]
@@ -59,7 +59,7 @@ pub struct EventRegistration {
 
 #[derive(Debug, Serialize, Clone, PartialEq, Eq)]
 pub struct EventGoal {
-    pub idx: i64,
+    pub idx: i32,
     pub name: String,
 }
 

--- a/src/event-db/src/types/event.rs
+++ b/src/event-db/src/types/event.rs
@@ -22,6 +22,94 @@ pub struct EventSummary {
     pub reg_checked: Option<DateTime<Utc>>,
 }
 
+#[derive(Debug, Serialize, Clone, PartialEq)]
+pub struct VotingPowerSettings {
+    alg: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    min_ada: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max_pct: Option<f64>,
+}
+
+#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
+pub struct EventRegistration {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    purpose: Option<i64>,
+    #[serde(serialize_with = "serialize_datetime_as_rfc3339")]
+    deadline: DateTime<Utc>,
+    #[serde(serialize_with = "serialize_datetime_as_rfc3339")]
+    taken: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
+pub struct EventGoal {
+    idx: i64,
+    name: String,
+}
+
+#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
+pub struct EventSchedule {
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_option_datetime_as_rfc3339"
+    )]
+    insight_sharing: Option<DateTime<Utc>>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_option_datetime_as_rfc3339"
+    )]
+    proposal_submission: Option<DateTime<Utc>>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_option_datetime_as_rfc3339"
+    )]
+    refine_proposals: Option<DateTime<Utc>>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_option_datetime_as_rfc3339"
+    )]
+    finalize_proposals: Option<DateTime<Utc>>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_option_datetime_as_rfc3339"
+    )]
+    proposal_assessment: Option<DateTime<Utc>>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_option_datetime_as_rfc3339"
+    )]
+    assessment_qa_start: Option<DateTime<Utc>>,
+    #[serde(serialize_with = "serialize_datetime_as_rfc3339")]
+    voting: DateTime<Utc>,
+    #[serde(serialize_with = "serialize_datetime_as_rfc3339")]
+    tallying: DateTime<Utc>,
+    #[serde(serialize_with = "serialize_datetime_as_rfc3339")]
+    tallying_end: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
+pub struct VoterGroup {
+    id: String,
+    voting_token: String,
+}
+
+#[derive(Debug, Serialize, Clone, PartialEq)]
+pub struct EventDetails {
+    pub voting_power: VotingPowerSettings,
+    pub registration: EventRegistration,
+    pub goals: Vec<EventGoal>,
+    pub schedule: EventSchedule,
+    pub groups: Vec<VoterGroup>,
+}
+
+#[derive(Debug, Serialize, Clone, PartialEq)]
+pub struct Event {
+    #[serde(flatten)]
+    pub event_summary: EventSummary,
+    #[serde(skip_serializing_if = "Option::is_none", flatten)]
+    pub event_details: Option<EventDetails>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -86,6 +174,421 @@ mod tests {
                     "starts": "1970-01-01T00:00:00+00:00",
                     "ends": "1970-01-01T00:00:00+00:00",
                     "final": true,
+                }
+            )
+        );
+    }
+
+    #[test]
+    fn voting_power_settings_json_test() {
+        let voting_power_settings = VotingPowerSettings {
+            alg: "threshold_staked_ADA".to_string(),
+            min_ada: Some(500),
+            max_pct: Some(1.23),
+        };
+
+        let json = serde_json::to_value(&voting_power_settings).unwrap();
+        assert_eq!(
+            json,
+            json!(
+                {
+                    "alg": "threshold_staked_ADA",
+                    "min_ada": 500,
+                    "max_pct": 1.23,
+                }
+            )
+        );
+
+        let voting_power_settings = VotingPowerSettings {
+            alg: "threshold_staked_ADA".to_string(),
+            min_ada: None,
+            max_pct: None,
+        };
+
+        let json = serde_json::to_value(&voting_power_settings).unwrap();
+        assert_eq!(
+            json,
+            json!(
+                {
+                    "alg": "threshold_staked_ADA",
+                }
+            )
+        );
+    }
+
+    #[test]
+    fn event_registration_json_test() {
+        let event_registration = EventRegistration {
+            purpose: Some(1),
+            deadline: DateTime::from_utc(NaiveDateTime::from_timestamp_opt(0, 0).unwrap(), Utc),
+            taken: DateTime::from_utc(NaiveDateTime::from_timestamp_opt(0, 0).unwrap(), Utc),
+        };
+
+        let json = serde_json::to_value(&event_registration).unwrap();
+        assert_eq!(
+            json,
+            json!(
+                {
+                    "purpose": 1,
+                    "deadline": "1970-01-01T00:00:00+00:00",
+                    "taken": "1970-01-01T00:00:00+00:00",
+                }
+            )
+        );
+
+        let event_registration = EventRegistration {
+            purpose: None,
+            deadline: DateTime::from_utc(NaiveDateTime::from_timestamp_opt(0, 0).unwrap(), Utc),
+            taken: DateTime::from_utc(NaiveDateTime::from_timestamp_opt(0, 0).unwrap(), Utc),
+        };
+
+        let json = serde_json::to_value(&event_registration).unwrap();
+        assert_eq!(
+            json,
+            json!(
+                {
+                    "deadline": "1970-01-01T00:00:00+00:00",
+                    "taken": "1970-01-01T00:00:00+00:00",
+                }
+            )
+        );
+    }
+
+    #[test]
+    fn event_goal_json_test() {
+        let event_goal = EventGoal {
+            idx: 1,
+            name: "goal 1".to_string(),
+        };
+
+        let json = serde_json::to_value(&event_goal).unwrap();
+        assert_eq!(
+            json,
+            json!(
+                {
+                    "idx": 1,
+                    "name": "goal 1",
+                }
+            )
+        );
+    }
+
+    #[test]
+    fn event_schedule_json_test() {
+        let event_schedule = EventSchedule {
+            insight_sharing: Some(DateTime::from_utc(
+                NaiveDateTime::from_timestamp_opt(0, 0).unwrap(),
+                Utc,
+            )),
+            proposal_submission: Some(DateTime::from_utc(
+                NaiveDateTime::from_timestamp_opt(0, 0).unwrap(),
+                Utc,
+            )),
+            refine_proposals: Some(DateTime::from_utc(
+                NaiveDateTime::from_timestamp_opt(0, 0).unwrap(),
+                Utc,
+            )),
+            finalize_proposals: Some(DateTime::from_utc(
+                NaiveDateTime::from_timestamp_opt(0, 0).unwrap(),
+                Utc,
+            )),
+            proposal_assessment: Some(DateTime::from_utc(
+                NaiveDateTime::from_timestamp_opt(0, 0).unwrap(),
+                Utc,
+            )),
+            assessment_qa_start: Some(DateTime::from_utc(
+                NaiveDateTime::from_timestamp_opt(0, 0).unwrap(),
+                Utc,
+            )),
+            voting: DateTime::from_utc(NaiveDateTime::from_timestamp_opt(0, 0).unwrap(), Utc),
+            tallying: DateTime::from_utc(NaiveDateTime::from_timestamp_opt(0, 0).unwrap(), Utc),
+            tallying_end: DateTime::from_utc(NaiveDateTime::from_timestamp_opt(0, 0).unwrap(), Utc),
+        };
+
+        let json = serde_json::to_value(&event_schedule).unwrap();
+        assert_eq!(
+            json,
+            json!(
+                {
+                    "insight_sharing": "1970-01-01T00:00:00+00:00",
+                    "proposal_submission": "1970-01-01T00:00:00+00:00",
+                    "refine_proposals": "1970-01-01T00:00:00+00:00",
+                    "finalize_proposals": "1970-01-01T00:00:00+00:00",
+                    "proposal_assessment": "1970-01-01T00:00:00+00:00",
+                    "assessment_qa_start": "1970-01-01T00:00:00+00:00",
+                    "voting": "1970-01-01T00:00:00+00:00",
+                    "tallying": "1970-01-01T00:00:00+00:00",
+                    "tallying_end": "1970-01-01T00:00:00+00:00",
+                }
+            )
+        );
+
+        let event_schedule = EventSchedule {
+            insight_sharing: None,
+            proposal_submission: None,
+            refine_proposals: None,
+            finalize_proposals: None,
+            proposal_assessment: None,
+            assessment_qa_start: None,
+            voting: DateTime::from_utc(NaiveDateTime::from_timestamp_opt(0, 0).unwrap(), Utc),
+            tallying: DateTime::from_utc(NaiveDateTime::from_timestamp_opt(0, 0).unwrap(), Utc),
+            tallying_end: DateTime::from_utc(NaiveDateTime::from_timestamp_opt(0, 0).unwrap(), Utc),
+        };
+
+        let json = serde_json::to_value(&event_schedule).unwrap();
+        assert_eq!(
+            json,
+            json!(
+                {
+                    "voting": "1970-01-01T00:00:00+00:00",
+                    "tallying": "1970-01-01T00:00:00+00:00",
+                    "tallying_end": "1970-01-01T00:00:00+00:00",
+                }
+            )
+        );
+    }
+
+    #[test]
+    fn voter_group_json_test() {
+        let voter_group = VoterGroup {
+            id: "rep".to_string(),
+            voting_token: "voting token 1".to_string(),
+        };
+
+        let json = serde_json::to_value(&voter_group).unwrap();
+        assert_eq!(
+            json,
+            json!(
+                {
+                    "id": "rep",
+                    "voting_token": "voting token 1",
+                }
+            )
+        );
+    }
+
+    #[test]
+    fn event_details_json_test() {
+        let event_details = EventDetails {
+            voting_power: VotingPowerSettings {
+                alg: "threshold_staked_ADA".to_string(),
+                min_ada: Some(500),
+                max_pct: Some(1.23),
+            },
+            registration: EventRegistration {
+                purpose: Some(1),
+                deadline: DateTime::from_utc(NaiveDateTime::from_timestamp_opt(0, 0).unwrap(), Utc),
+                taken: DateTime::from_utc(NaiveDateTime::from_timestamp_opt(0, 0).unwrap(), Utc),
+            },
+            goals: vec![EventGoal {
+                idx: 1,
+                name: "goal 1".to_string(),
+            }],
+            schedule: EventSchedule {
+                insight_sharing: Some(DateTime::from_utc(
+                    NaiveDateTime::from_timestamp_opt(0, 0).unwrap(),
+                    Utc,
+                )),
+                proposal_submission: Some(DateTime::from_utc(
+                    NaiveDateTime::from_timestamp_opt(0, 0).unwrap(),
+                    Utc,
+                )),
+                refine_proposals: Some(DateTime::from_utc(
+                    NaiveDateTime::from_timestamp_opt(0, 0).unwrap(),
+                    Utc,
+                )),
+                finalize_proposals: Some(DateTime::from_utc(
+                    NaiveDateTime::from_timestamp_opt(0, 0).unwrap(),
+                    Utc,
+                )),
+                proposal_assessment: Some(DateTime::from_utc(
+                    NaiveDateTime::from_timestamp_opt(0, 0).unwrap(),
+                    Utc,
+                )),
+                assessment_qa_start: Some(DateTime::from_utc(
+                    NaiveDateTime::from_timestamp_opt(0, 0).unwrap(),
+                    Utc,
+                )),
+                voting: DateTime::from_utc(NaiveDateTime::from_timestamp_opt(0, 0).unwrap(), Utc),
+                tallying: DateTime::from_utc(NaiveDateTime::from_timestamp_opt(0, 0).unwrap(), Utc),
+                tallying_end: DateTime::from_utc(
+                    NaiveDateTime::from_timestamp_opt(0, 0).unwrap(),
+                    Utc,
+                ),
+            },
+            groups: vec![VoterGroup {
+                id: "rep".to_string(),
+                voting_token: "voting token 1".to_string(),
+            }],
+        };
+
+        let json = serde_json::to_value(&event_details).unwrap();
+        assert_eq!(
+            json,
+            json!(
+                {
+                    "voting_power": {
+                                        "alg": "threshold_staked_ADA",
+                                        "min_ada": 500,
+                                        "max_pct": 1.23,
+                                    },
+                    "registration": {
+                                        "purpose": 1,
+                                        "deadline": "1970-01-01T00:00:00+00:00",
+                                        "taken": "1970-01-01T00:00:00+00:00",
+                                    },
+                    "goals": [
+                                {
+                                    "idx": 1,
+                                    "name": "goal 1",
+                                }
+                            ],
+                    "schedule": {
+                                    "insight_sharing": "1970-01-01T00:00:00+00:00",
+                                    "proposal_submission": "1970-01-01T00:00:00+00:00",
+                                    "refine_proposals": "1970-01-01T00:00:00+00:00",
+                                    "finalize_proposals": "1970-01-01T00:00:00+00:00",
+                                    "proposal_assessment": "1970-01-01T00:00:00+00:00",
+                                    "assessment_qa_start": "1970-01-01T00:00:00+00:00",
+                                    "voting": "1970-01-01T00:00:00+00:00",
+                                    "tallying": "1970-01-01T00:00:00+00:00",
+                                    "tallying_end": "1970-01-01T00:00:00+00:00",
+                            },
+                    "groups": [
+                                {
+                                    "id": "rep",
+                                    "voting_token": "voting token 1",
+                                }
+                            ],
+                }
+            )
+        );
+    }
+
+    #[test]
+    fn event_json_test() {
+        let event_summary = Event {
+            event_summary: EventSummary {
+                id: EventId(1),
+                name: "Fund 10".to_string(),
+                starts: DateTime::from_utc(NaiveDateTime::from_timestamp_opt(0, 0).unwrap(), Utc),
+                ends: DateTime::from_utc(NaiveDateTime::from_timestamp_opt(0, 0).unwrap(), Utc),
+                is_final: true,
+                reg_checked: Some(DateTime::from_utc(
+                    NaiveDateTime::from_timestamp_opt(0, 0).unwrap(),
+                    Utc,
+                )),
+            },
+            event_details: Some(EventDetails {
+                voting_power: VotingPowerSettings {
+                    alg: "threshold_staked_ADA".to_string(),
+                    min_ada: Some(500),
+                    max_pct: Some(1.23),
+                },
+                registration: EventRegistration {
+                    purpose: Some(1),
+                    deadline: DateTime::from_utc(
+                        NaiveDateTime::from_timestamp_opt(0, 0).unwrap(),
+                        Utc,
+                    ),
+                    taken: DateTime::from_utc(
+                        NaiveDateTime::from_timestamp_opt(0, 0).unwrap(),
+                        Utc,
+                    ),
+                },
+                goals: vec![EventGoal {
+                    idx: 1,
+                    name: "goal 1".to_string(),
+                }],
+                schedule: EventSchedule {
+                    insight_sharing: Some(DateTime::from_utc(
+                        NaiveDateTime::from_timestamp_opt(0, 0).unwrap(),
+                        Utc,
+                    )),
+                    proposal_submission: Some(DateTime::from_utc(
+                        NaiveDateTime::from_timestamp_opt(0, 0).unwrap(),
+                        Utc,
+                    )),
+                    refine_proposals: Some(DateTime::from_utc(
+                        NaiveDateTime::from_timestamp_opt(0, 0).unwrap(),
+                        Utc,
+                    )),
+                    finalize_proposals: Some(DateTime::from_utc(
+                        NaiveDateTime::from_timestamp_opt(0, 0).unwrap(),
+                        Utc,
+                    )),
+                    proposal_assessment: Some(DateTime::from_utc(
+                        NaiveDateTime::from_timestamp_opt(0, 0).unwrap(),
+                        Utc,
+                    )),
+                    assessment_qa_start: Some(DateTime::from_utc(
+                        NaiveDateTime::from_timestamp_opt(0, 0).unwrap(),
+                        Utc,
+                    )),
+                    voting: DateTime::from_utc(
+                        NaiveDateTime::from_timestamp_opt(0, 0).unwrap(),
+                        Utc,
+                    ),
+                    tallying: DateTime::from_utc(
+                        NaiveDateTime::from_timestamp_opt(0, 0).unwrap(),
+                        Utc,
+                    ),
+                    tallying_end: DateTime::from_utc(
+                        NaiveDateTime::from_timestamp_opt(0, 0).unwrap(),
+                        Utc,
+                    ),
+                },
+                groups: vec![VoterGroup {
+                    id: "rep".to_string(),
+                    voting_token: "voting token 1".to_string(),
+                }],
+            }),
+        };
+
+        let json = serde_json::to_value(&event_summary).unwrap();
+        assert_eq!(
+            json,
+            json!(
+                {
+                    "id": 1,
+                    "name": "Fund 10",
+                    "starts": "1970-01-01T00:00:00+00:00",
+                    "ends": "1970-01-01T00:00:00+00:00",
+                    "final": true,
+                    "reg_checked": "1970-01-01T00:00:00+00:00",
+                    "voting_power": {
+                                        "alg": "threshold_staked_ADA",
+                                        "min_ada": 500,
+                                        "max_pct": 1.23,
+                                    },
+                    "registration": {
+                                        "purpose": 1,
+                                        "deadline": "1970-01-01T00:00:00+00:00",
+                                        "taken": "1970-01-01T00:00:00+00:00",
+                                    },
+                    "goals": [
+                                {
+                                    "idx": 1,
+                                    "name": "goal 1",
+                                }
+                            ],
+                    "schedule": {
+                                    "insight_sharing": "1970-01-01T00:00:00+00:00",
+                                    "proposal_submission": "1970-01-01T00:00:00+00:00",
+                                    "refine_proposals": "1970-01-01T00:00:00+00:00",
+                                    "finalize_proposals": "1970-01-01T00:00:00+00:00",
+                                    "proposal_assessment": "1970-01-01T00:00:00+00:00",
+                                    "assessment_qa_start": "1970-01-01T00:00:00+00:00",
+                                    "voting": "1970-01-01T00:00:00+00:00",
+                                    "tallying": "1970-01-01T00:00:00+00:00",
+                                    "tallying_end": "1970-01-01T00:00:00+00:00",
+                            },
+                    "groups": [
+                                {
+                                    "id": "rep",
+                                    "voting_token": "voting token 1",
+                                }
+                            ],
                 }
             )
         );

--- a/src/event-db/src/types/event.rs
+++ b/src/event-db/src/types/event.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct EventId(pub i32);
 
-#[derive(Debug, Serialize, Clone, PartialEq)]
+#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
 pub struct EventSummary {
     pub id: EventId,
     pub name: String,

--- a/src/event-db/src/types/event.rs
+++ b/src/event-db/src/types/event.rs
@@ -1,0 +1,93 @@
+use crate::types::utils::{serialize_datetime_as_rfc3339, serialize_option_datetime_as_rfc3339};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EventId(pub i32);
+
+#[derive(Debug, Serialize, Clone, PartialEq)]
+pub struct EventSummary {
+    pub id: EventId,
+    pub name: String,
+    #[serde(serialize_with = "serialize_datetime_as_rfc3339")]
+    pub starts: DateTime<Utc>,
+    #[serde(serialize_with = "serialize_datetime_as_rfc3339")]
+    pub ends: DateTime<Utc>,
+    #[serde(rename = "final")]
+    pub is_final: bool,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_option_datetime_as_rfc3339"
+    )]
+    pub reg_checked: Option<DateTime<Utc>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::NaiveDateTime;
+    use serde_json::json;
+
+    #[test]
+    fn event_id_json_test() {
+        let event_ids = vec![EventId(10), EventId(11), EventId(12)];
+        let json = serde_json::to_value(&event_ids).unwrap();
+        assert_eq!(json, json!([10, 11, 12]));
+
+        let decoded: Vec<EventId> = serde_json::from_value(json).unwrap();
+        assert_eq!(decoded, event_ids);
+    }
+
+    #[test]
+    fn event_summary_json_test() {
+        let event_summary = EventSummary {
+            id: EventId(1),
+            name: "Fund 10".to_string(),
+            starts: DateTime::from_utc(NaiveDateTime::from_timestamp_opt(0, 0).unwrap(), Utc),
+            ends: DateTime::from_utc(NaiveDateTime::from_timestamp_opt(0, 0).unwrap(), Utc),
+            is_final: true,
+            reg_checked: Some(DateTime::from_utc(
+                NaiveDateTime::from_timestamp_opt(0, 0).unwrap(),
+                Utc,
+            )),
+        };
+
+        let json = serde_json::to_value(&event_summary).unwrap();
+        assert_eq!(
+            json,
+            json!(
+                {
+                    "id": 1,
+                    "name": "Fund 10",
+                    "starts": "1970-01-01T00:00:00+00:00",
+                    "ends": "1970-01-01T00:00:00+00:00",
+                    "final": true,
+                    "reg_checked": "1970-01-01T00:00:00+00:00",
+                }
+            )
+        );
+
+        let event_summary = EventSummary {
+            id: EventId(1),
+            name: "Fund 10".to_string(),
+            starts: DateTime::from_utc(NaiveDateTime::from_timestamp_opt(0, 0).unwrap(), Utc),
+            ends: DateTime::from_utc(NaiveDateTime::from_timestamp_opt(0, 0).unwrap(), Utc),
+            is_final: true,
+            reg_checked: None,
+        };
+
+        let json = serde_json::to_value(&event_summary).unwrap();
+        assert_eq!(
+            json,
+            json!(
+                {
+                    "id": 1,
+                    "name": "Fund 10",
+                    "starts": "1970-01-01T00:00:00+00:00",
+                    "ends": "1970-01-01T00:00:00+00:00",
+                    "final": true,
+                }
+            )
+        );
+    }
+}

--- a/src/event-db/src/types/event.rs
+++ b/src/event-db/src/types/event.rs
@@ -29,13 +29,13 @@ pub struct EventSummary {
     pub is_final: bool,
 }
 
-#[derive(Debug, Serialize, Clone, PartialEq)]
+#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
 pub enum VotingPowerAlgorithm {
     #[serde(rename = "threshold_staked_ADA")]
     ThresholdStakedADA
 }
 
-#[derive(Debug, Serialize, Clone, PartialEq)]
+#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
 pub struct VotingPowerSettings {
     pub alg: VotingPowerAlgorithm,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -118,7 +118,7 @@ pub struct VoterGroup {
     pub voting_token: String,
 }
 
-#[derive(Debug, Serialize, Clone, PartialEq)]
+#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
 pub struct EventDetails {
     pub voting_power: VotingPowerSettings,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -128,7 +128,7 @@ pub struct EventDetails {
     pub groups: Vec<VoterGroup>,
 }
 
-#[derive(Debug, Serialize, Clone, PartialEq)]
+#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
 pub struct Event {
     #[serde(flatten)]
     pub event_summary: EventSummary,

--- a/src/event-db/src/types/mod.rs
+++ b/src/event-db/src/types/mod.rs
@@ -1,2 +1,3 @@
-pub mod snapshot;
+pub mod event;
+pub mod registration;
 pub mod utils;

--- a/src/event-db/src/types/registration.rs
+++ b/src/event-db/src/types/registration.rs
@@ -1,9 +1,6 @@
 use crate::types::utils::serialize_datetime_as_rfc3339;
 use chrono::{DateTime, Utc};
-use serde::{Deserialize, Serialize};
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct EventId(pub i32);
+use serde::Serialize;
 
 #[derive(Debug, Serialize, Clone, PartialEq)]
 pub struct VoterInfo {
@@ -51,16 +48,6 @@ mod tests {
     use super::*;
     use chrono::NaiveDateTime;
     use serde_json::json;
-
-    #[test]
-    fn snapshot_version_json_test() {
-        let snapshot_versions = vec![EventId(10), EventId(11), EventId(12)];
-        let json = serde_json::to_value(&snapshot_versions).unwrap();
-        assert_eq!(json, json!([10, 11, 12]));
-
-        let decoded: Vec<EventId> = serde_json::from_value(json).unwrap();
-        assert_eq!(decoded, snapshot_versions);
-    }
 
     #[test]
     fn voter_json_test() {

--- a/src/event-db/src/types/utils.rs
+++ b/src/event-db/src/types/utils.rs
@@ -7,3 +7,14 @@ pub fn serialize_datetime_as_rfc3339<S: Serializer>(
 ) -> Result<S::Ok, S::Error> {
     serializer.serialize_str(&time.to_rfc3339())
 }
+
+pub fn serialize_option_datetime_as_rfc3339<S: Serializer>(
+    time: &Option<DateTime<Utc>>,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    if let Some(time) = time {
+        serializer.serialize_str(&time.to_rfc3339())
+    } else {
+        serializer.serialize_none()
+    }
+}

--- a/src/event-db/test_data/event_table.sql
+++ b/src/event-db/test_data/event_table.sql
@@ -1,4 +1,3 @@
-
 INSERT INTO event
 (row_id, name, description, registration_snapshot_time, snapshot_start,
  voting_power_threshold, max_voting_power_pct, start_time, end_time, insight_sharing_start,

--- a/src/event-db/test_data/event_table.sql
+++ b/src/event-db/test_data/event_table.sql
@@ -3,8 +3,7 @@ INSERT INTO event
 (row_id, name, description, registration_snapshot_time, snapshot_start,
  voting_power_threshold, max_voting_power_pct, start_time, end_time, insight_sharing_start,
  proposal_submission_start, refine_proposals_start, finalize_proposals_start, proposal_assessment_start, assessment_qa_start,
- voting_start, voting_end, tallying_end, block0, block0_hash, committee_size, committee_threshold,
- extra)
+ voting_start, voting_end, tallying_end, block0, block0_hash, committee_size, committee_threshold)
 VALUES
 
 (1,
@@ -13,8 +12,7 @@ VALUES
  '2020-05-01 12:00:00', '2020-06-01 12:00:00',
  '2020-03-01 12:00:00', '2020-03-01 12:00:00', '2020-03-01 12:00:00', '2020-03-01 12:00:00', '2020-03-01 12:00:00', '2020-03-01 12:00:00', '2020-05-01 12:00:00', '2020-06-01 12:00:00', '2020-07-01 12:00:00',
  'x0000000000000000000000000000000000000000000000000000000000000000', 'x0000000000000000000000000000000000000000000000000000000000000000',
- 4, 4,
- '{}'),
+ 4, 4),
 
 (2,
  'Test Fund 2', 'Test Fund 2 description',
@@ -22,8 +20,7 @@ VALUES
  '2021-05-01 12:00:00', '2021-06-01 12:00:00',
  '2021-03-01 12:00:00', '2021-03-01 12:00:00', '2021-03-01 12:00:00', '2021-03-01 12:00:00', '2021-03-01 12:00:00', '2021-03-01 12:00:00', '2021-05-01 12:00:00', '2021-06-01 12:00:00', '2021-07-01 12:00:00',
  'x0000000000000000000000000000000000000000000000000000000000000000', 'x0000000000000000000000000000000000000000000000000000000000000000',
- 5, 5,
- '{}'),
+ 5, 5),
 
 (3,
  'Test Fund 3', 'Test Fund 3 description',
@@ -31,6 +28,14 @@ VALUES
  '2022-05-01 12:00:00', '2022-06-01 12:00:00',
  '2022-03-01 12:00:00', '2022-03-01 12:00:00', '2022-03-01 12:00:00', '2022-03-01 12:00:00', '2022-03-01 12:00:00', '2022-03-01 12:00:00', '2022-05-01 12:00:00', '2022-06-01 12:00:00', '2022-07-01 12:00:00',
  'x0000000000000000000000000000000000000000000000000000000000000000', 'x0000000000000000000000000000000000000000000000000000000000000000',
- 6, 6,
- '{}');
+ 6, 6);
+
+
+INSERT INTO event
+(row_id, name, description, committee_size, committee_threshold)
+VALUES
+
+(4,
+ 'Test Fund 4', 'Test Fund 4 description',
+ 6, 6);
  

--- a/src/event-db/test_data/goal_table.sql
+++ b/src/event-db/test_data/goal_table.sql
@@ -1,0 +1,16 @@
+INSERT INTO goal (id, event_id, idx, name)
+VALUES 
+(1, 1, 1, 'goal 1'),
+(2, 1, 2, 'goal 2'),
+(3, 1, 3, 'goal 3'),
+(4, 1, 4, 'goal 4'),
+
+(5, 2, 5, 'goal 5'),
+(6, 2, 6, 'goal 6'),
+(7, 2, 7, 'goal 7'),
+(8, 2, 8, 'goal 8'),
+
+(9, 3, 9, 'goal 9'),
+(10, 3, 10, 'goal 10'),
+(11, 3, 11, 'goal 11'),
+(12, 3, 12, 'goal 12');

--- a/src/event-db/test_data/voting_group_table.sql
+++ b/src/event-db/test_data/voting_group_table.sql
@@ -1,0 +1,13 @@
+INSERT INTO voting_group (row_id, group_id, event_id, token_id)
+VALUES 
+(1, 'rep', 1, 'rep token'),
+(2, 'direct', 1, 'direct token'),
+
+(3, 'rep', 2, 'rep token'),
+(4, 'direct', 2, 'direct token'),
+
+(5, 'rep', 3, 'rep token'),
+(6, 'direct', 3, 'direct token'),
+
+(7, 'rep', 4, 'rep token'),
+(8, 'direct', 4, 'direct token');


### PR DESCRIPTION
# Description

Implement new event's endpoints `/api/v1/events` and `'/api/v1/event/{id}'` with the corresponded db queries and db types.
https://github.com/input-output-hk/catalyst-core/blob/98c8b0298607ca255fac6b6536188aba5918be05/book/src/07_web_api/openapi/core_backend_api.yaml#L74
This PR does not contain a full implementation, it will be needed to implement sql queries for `registration`, `goals` and `groups` fields of the `EventDetails` struct. This will be done in the next PRs

## Type of change

- New feature (non-breaking change which adds functionality)

**List of new dependecies**: 

- `rust_decimal`: needed to parse postgressql `numeric` type
