### PR TITLE
feat: NPG-5816 /api/v1/event/{id}/objectives endpoint (part 2)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -222,7 +222,7 @@ jobs:
       - name: Setup Event DB
         env:
           PGPASSWORD: 123456
-        run: cargo make local-event-db-setup -h 127.0.0.1 -U postgres
+        run: cargo make local-event-db-test -h 127.0.0.1 -U postgres
 
       - name: Build and archive tests
         if: steps.archive-cache.outputs.cache-hit != 'true'

--- a/Makefiles/db.toml
+++ b/Makefiles/db.toml
@@ -52,7 +52,7 @@ category = "db"
 script_runner = "@shell"
 script = '''
 cd ${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/src/event-db
-psql -e -U postgres -f setup/graphql-setup.sql ${@}
+psql -e -f setup/graphql-setup.sql ${@}
 '''
 
 
@@ -64,8 +64,18 @@ dependencies = [
     "local-event-db-init",
     "local-event-db-graphql-init",
     "run-event-db-migration",
+]
+
+# Setup the local database with the test data.
+[tasks.local-event-db-test]
+workspace = false
+category = "db"
+dependencies = [
+    "local-event-db-init",
+    "run-event-db-migration",
     "local-db-test-data-setup"
 ]
+
 
 
 # Run Diesel Migrations, for documentation purposes.

--- a/book/src/07_web_api/openapi/core_backend_api.yaml
+++ b/book/src/07_web_api/openapi/core_backend_api.yaml
@@ -830,6 +830,8 @@ components:
           $ref: '#/components/schemas/ObjectiveSupplementalData'
       required:
         - description
+        - choices
+        - ballot
     VotePlan:
       title: Vote Plan
       type: object

--- a/src/cat-data-service/src/service/v1/event/objective.rs
+++ b/src/cat-data-service/src/service/v1/event/objective.rs
@@ -1,0 +1,208 @@
+use crate::{
+    service::{handle_result, Error},
+    state::State,
+};
+use axum::{
+    extract::{Path, Query},
+    routing::get,
+    Router,
+};
+use event_db::types::event::{objective::Objective, EventId};
+use serde::Deserialize;
+use std::sync::Arc;
+
+pub fn objective(state: Arc<State>) -> Router {
+    Router::new().route(
+        "/:event/objectives",
+        get({
+            let state = state.clone();
+            move |path, query| async {
+                handle_result(objectives_exec(path, query, state).await).await
+            }
+        }),
+    )
+}
+
+#[derive(Deserialize)]
+struct ObjectivesQuery {
+    limit: Option<i64>,
+    offset: Option<i64>,
+}
+
+async fn objectives_exec(
+    Path(event): Path<EventId>,
+    objectives_query: Query<ObjectivesQuery>,
+    state: Arc<State>,
+) -> Result<Vec<Objective>, Error> {
+    tracing::debug!("objectives_exec, event: {0}", event.0);
+
+    let event = state
+        .event_db
+        .get_objectives(event, objectives_query.limit, objectives_query.offset)
+        .await?;
+    Ok(event)
+}
+
+/// Need to setup and run a test event db instance
+/// To do it you can use `cargo make local-event-db-test`
+/// Also need establish `EVENT_DB_URL` env variable with the following value
+/// ```
+/// EVENT_DB_URL="postgres://catalyst-event-dev:CHANGE_ME@localhost/CatalystEventDev"
+/// ```
+/// https://github.com/input-output-hk/catalyst-core/tree/main/src/event-db/Readme.md
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::service::app;
+    use axum::{
+        body::{Body, HttpBody},
+        http::{Request, StatusCode},
+    };
+    use event_db::types::event::objective::{
+        ObjectiveDetails, ObjectiveSummary, ObjectiveSupplementalData, ObjectiveType,
+        RewardDefintion,
+    };
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn objectives_test() {
+        let state = Arc::new(State::new(None).await.unwrap());
+        let app = app(state);
+
+        let request = Request::builder()
+            .uri(format!("/api/v1/event/{0}/objectives", 1))
+            .body(Body::empty())
+            .unwrap();
+        let response = app.clone().oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                .unwrap(),
+            serde_json::to_string(&vec![
+                Objective {
+                    summary: ObjectiveSummary {
+                        id: 1,
+                        objective_type: ObjectiveType {
+                            id: "catalyst-simple".to_string(),
+                            description: "A Simple choice".to_string()
+                        },
+                        title: "title 1".to_string(),
+                    },
+                    details: ObjectiveDetails {
+                        description: "description 1".to_string(),
+                        reward: Some(RewardDefintion {
+                            currency: "ADA".to_string(),
+                            value: 100
+                        }),
+                        choices: Some(vec!["yes".to_string(), "no".to_string()]),
+                        ballot: None,
+                        url: Some("objective 1 url".to_string()),
+                        supplemental: Some(ObjectiveSupplementalData {
+                            sponsor: "objective 1 sponsor".to_string(),
+                            video: "objective 1 video".to_string()
+                        }),
+                    }
+                },
+                Objective {
+                    summary: ObjectiveSummary {
+                        id: 2,
+                        objective_type: ObjectiveType {
+                            id: "catalyst-native".to_string(),
+                            description: "??".to_string()
+                        },
+                        title: "title 2".to_string(),
+                    },
+                    details: ObjectiveDetails {
+                        description: "description 2".to_string(),
+                        reward: None,
+                        choices: None,
+                        ballot: None,
+                        url: None,
+                        supplemental: None,
+                    }
+                }
+            ])
+            .unwrap()
+        );
+
+        let request = Request::builder()
+            .uri(format!("/api/v1/event/{0}/objectives?limit={1}", 1, 1))
+            .body(Body::empty())
+            .unwrap();
+        let response = app.clone().oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                .unwrap(),
+            serde_json::to_string(&vec![Objective {
+                summary: ObjectiveSummary {
+                    id: 1,
+                    objective_type: ObjectiveType {
+                        id: "catalyst-simple".to_string(),
+                        description: "A Simple choice".to_string()
+                    },
+                    title: "title 1".to_string(),
+                },
+                details: ObjectiveDetails {
+                    description: "description 1".to_string(),
+                    reward: Some(RewardDefintion {
+                        currency: "ADA".to_string(),
+                        value: 100
+                    }),
+                    choices: Some(vec!["yes".to_string(), "no".to_string()]),
+                    ballot: None,
+                    url: Some("objective 1 url".to_string()),
+                    supplemental: Some(ObjectiveSupplementalData {
+                        sponsor: "objective 1 sponsor".to_string(),
+                        video: "objective 1 video".to_string()
+                    }),
+                }
+            },])
+            .unwrap()
+        );
+
+        let request = Request::builder()
+            .uri(format!("/api/v1/event/{0}/objectives?offset={1}", 1, 1))
+            .body(Body::empty())
+            .unwrap();
+        let response = app.clone().oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                .unwrap(),
+            serde_json::to_string(&vec![Objective {
+                summary: ObjectiveSummary {
+                    id: 2,
+                    objective_type: ObjectiveType {
+                        id: "catalyst-native".to_string(),
+                        description: "??".to_string()
+                    },
+                    title: "title 2".to_string(),
+                },
+                details: ObjectiveDetails {
+                    description: "description 2".to_string(),
+                    reward: None,
+                    choices: None,
+                    ballot: None,
+                    url: None,
+                    supplemental: None,
+                }
+            }])
+            .unwrap()
+        );
+
+        let request = Request::builder()
+            .uri(format!(
+                "/api/v1/event/{0}/objectives?limit={1}&offset={2}",
+                1, 1, 2
+            ))
+            .body(Body::empty())
+            .unwrap();
+        let response = app.clone().oneshot(request).await.unwrap();
+        assert_eq!(
+            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                .unwrap(),
+            serde_json::to_string(&Vec::<Objective>::new()).unwrap()
+        );
+    }
+}

--- a/src/cat-data-service/src/service/v1/event/objective.rs
+++ b/src/cat-data-service/src/service/v1/event/objective.rs
@@ -14,11 +14,8 @@ use std::sync::Arc;
 pub fn objective(state: Arc<State>) -> Router {
     Router::new().route(
         "/:event/objectives",
-        get({
-            let state = state.clone();
-            move |path, query| async {
-                handle_result(objectives_exec(path, query, state).await).await
-            }
+        get(move |path, query| async {
+            handle_result(objectives_exec(path, query, state).await).await
         }),
     )
 }

--- a/src/cat-data-service/src/service/v1/event/objective.rs
+++ b/src/cat-data-service/src/service/v1/event/objective.rs
@@ -59,8 +59,8 @@ mod tests {
         http::{Request, StatusCode},
     };
     use event_db::types::event::objective::{
-        ObjectiveDetails, ObjectiveSummary, ObjectiveSupplementalData, ObjectiveType,
-        RewardDefintion,
+        GroupBallotType, ObjectiveDetails, ObjectiveSummary, ObjectiveSupplementalData,
+        ObjectiveType, RewardDefintion,
     };
     use tower::ServiceExt;
 
@@ -94,8 +94,17 @@ mod tests {
                             currency: "ADA".to_string(),
                             value: 100
                         }),
-                        choices: Some(vec!["yes".to_string(), "no".to_string()]),
-                        ballot: None,
+                        choices: vec!["yes".to_string(), "no".to_string()],
+                        ballot: vec![
+                            GroupBallotType {
+                                group: "rep".to_string(),
+                                ballot: "private".to_string(),
+                            },
+                            GroupBallotType {
+                                group: "direct".to_string(),
+                                ballot: "private".to_string(),
+                            },
+                        ],
                         url: Some("objective 1 url".to_string()),
                         supplemental: Some(ObjectiveSupplementalData {
                             sponsor: "objective 1 sponsor".to_string(),
@@ -115,8 +124,17 @@ mod tests {
                     details: ObjectiveDetails {
                         description: "description 2".to_string(),
                         reward: None,
-                        choices: None,
-                        ballot: None,
+                        choices: vec![],
+                        ballot: vec![
+                            GroupBallotType {
+                                group: "rep".to_string(),
+                                ballot: "private".to_string(),
+                            },
+                            GroupBallotType {
+                                group: "direct".to_string(),
+                                ballot: "private".to_string(),
+                            },
+                        ],
                         url: None,
                         supplemental: None,
                     }
@@ -149,8 +167,17 @@ mod tests {
                         currency: "ADA".to_string(),
                         value: 100
                     }),
-                    choices: Some(vec!["yes".to_string(), "no".to_string()]),
-                    ballot: None,
+                    choices: vec!["yes".to_string(), "no".to_string()],
+                    ballot: vec![
+                        GroupBallotType {
+                            group: "rep".to_string(),
+                            ballot: "private".to_string(),
+                        },
+                        GroupBallotType {
+                            group: "direct".to_string(),
+                            ballot: "private".to_string(),
+                        },
+                    ],
                     url: Some("objective 1 url".to_string()),
                     supplemental: Some(ObjectiveSupplementalData {
                         sponsor: "objective 1 sponsor".to_string(),
@@ -182,8 +209,17 @@ mod tests {
                 details: ObjectiveDetails {
                     description: "description 2".to_string(),
                     reward: None,
-                    choices: None,
-                    ballot: None,
+                    choices: vec![],
+                    ballot: vec![
+                        GroupBallotType {
+                            group: "rep".to_string(),
+                            ballot: "private".to_string(),
+                        },
+                        GroupBallotType {
+                            group: "direct".to_string(),
+                            ballot: "private".to_string(),
+                        },
+                    ],
                     url: None,
                     supplemental: None,
                 }

--- a/src/cat-data-service/src/service/v1/registration.rs
+++ b/src/cat-data-service/src/service/v1/registration.rs
@@ -74,7 +74,7 @@ async fn delegations_exec(
 }
 
 /// Need to setup and run a test event db instance
-/// To do it you can use `cargo make local-event-db-setup`
+/// To do it you can use `cargo make local-event-db-test`
 /// Also need establish `EVENT_DB_URL` env variable with the following value
 /// ```
 /// EVENT_DB_URL="postgres://catalyst-event-dev:CHANGE_ME@localhost/CatalystEventDev"

--- a/src/event-db/migrations/V5__vote_plan.sql
+++ b/src/event-db/migrations/V5__vote_plan.sql
@@ -13,7 +13,7 @@ INSERT INTO voteplan_category (name, public_key)
 VALUES
     ('public', false), -- Fully public votes only
     ('private', true), -- Fully private votes only.
-    ('semi-private', true); -- Private until tally, then decrypted.
+    ('cast-private', true); -- Private until tally, then decrypted.
 
 COMMENT ON TABLE voteplan_category IS 'The category of vote plan currently supported.';
 COMMENT ON COLUMN voteplan_category.name IS 'The UNIQUE name of this voteplan category.';

--- a/src/event-db/src/lib.rs
+++ b/src/event-db/src/lib.rs
@@ -75,7 +75,7 @@ pub async fn establish_connection(url: Option<&str>) -> Result<EventDB, Error> {
 }
 
 /// Need to setup and run a test event db instance
-/// To do it you can use `cargo make local-event-db-setup`
+/// To do it you can use `cargo make local-event-db-test`
 /// Also need establish `EVENT_DB_URL` env variable with the following value
 /// ```
 /// EVENT_DB_URL="postgres://catalyst-event-dev:CHANGE_ME@localhost/CatalystEventDev"

--- a/src/event-db/src/queries/event/mod.rs
+++ b/src/event-db/src/queries/event/mod.rs
@@ -198,7 +198,7 @@ impl EventQueries for EventDB {
 }
 
 /// Need to setup and run a test event db instance
-/// To do it you can use `cargo make local-event-db-setup`
+/// To do it you can use `cargo make local-event-db-test`
 /// Also need establish `EVENT_DB_URL` env variable with the following value
 /// ```
 /// EVENT_DB_URL="postgres://catalyst-event-dev:CHANGE_ME@localhost/CatalystEventDev"

--- a/src/event-db/src/queries/event/objective.rs
+++ b/src/event-db/src/queries/event/objective.rs
@@ -2,8 +2,8 @@ use crate::{
     error::Error,
     types::event::{
         objective::{
-            Objective, ObjectiveDetails, ObjectiveSummary, ObjectiveSupplementalData,
-            ObjectiveType, RewardDefintion,
+            GroupBallotType, Objective, ObjectiveDetails, ObjectiveSummary,
+            ObjectiveSupplementalData, ObjectiveType, RewardDefintion,
         },
         EventId,
     },
@@ -112,8 +112,20 @@ impl ObjectiveQueries for EventDB {
                 url,
                 supplemental,
                 description: row.try_get("description")?,
-                choices: row.try_get("choices")?,
-                ballot: None,
+                choices: row
+                    .try_get::<_, Option<Vec<_>>>("choices")?
+                    .unwrap_or_default(),
+                // TODO fix this, need to fill with the real data
+                ballot: vec![
+                    GroupBallotType {
+                        group: "rep".to_string(),
+                        ballot: "private".to_string(),
+                    },
+                    GroupBallotType {
+                        group: "direct".to_string(),
+                        ballot: "private".to_string(),
+                    },
+                ],
             };
             objectives.push(Objective { summary, details });
         }
@@ -131,8 +143,10 @@ impl ObjectiveQueries for EventDB {
 /// https://github.com/input-output-hk/catalyst-core/tree/main/src/event-db/Readme.md
 #[cfg(test)]
 mod tests {
+    use std::vec;
+
     use super::*;
-    use crate::establish_connection;
+    use crate::{establish_connection, types::event::objective::GroupBallotType};
 
     #[tokio::test]
     async fn get_objectives_test() {
@@ -160,8 +174,17 @@ mod tests {
                             currency: "ADA".to_string(),
                             value: 100
                         }),
-                        choices: Some(vec!["yes".to_string(), "no".to_string()]),
-                        ballot: None,
+                        choices: vec!["yes".to_string(), "no".to_string()],
+                        ballot: vec![
+                            GroupBallotType {
+                                group: "rep".to_string(),
+                                ballot: "private".to_string(),
+                            },
+                            GroupBallotType {
+                                group: "direct".to_string(),
+                                ballot: "private".to_string(),
+                            },
+                        ],
                         url: Some("objective 1 url".to_string()),
                         supplemental: Some(ObjectiveSupplementalData {
                             sponsor: "objective 1 sponsor".to_string(),
@@ -181,8 +204,17 @@ mod tests {
                     details: ObjectiveDetails {
                         description: "description 2".to_string(),
                         reward: None,
-                        choices: None,
-                        ballot: None,
+                        choices: vec![],
+                        ballot: vec![
+                            GroupBallotType {
+                                group: "rep".to_string(),
+                                ballot: "private".to_string(),
+                            },
+                            GroupBallotType {
+                                group: "direct".to_string(),
+                                ballot: "private".to_string(),
+                            },
+                        ],
                         url: None,
                         supplemental: None,
                     }
@@ -211,8 +243,17 @@ mod tests {
                         currency: "ADA".to_string(),
                         value: 100
                     }),
-                    choices: Some(vec!["yes".to_string(), "no".to_string()]),
-                    ballot: None,
+                    choices: vec!["yes".to_string(), "no".to_string()],
+                    ballot: vec![
+                        GroupBallotType {
+                            group: "rep".to_string(),
+                            ballot: "private".to_string(),
+                        },
+                        GroupBallotType {
+                            group: "direct".to_string(),
+                            ballot: "private".to_string(),
+                        },
+                    ],
                     url: Some("objective 1 url".to_string()),
                     supplemental: Some(ObjectiveSupplementalData {
                         sponsor: "objective 1 sponsor".to_string(),
@@ -240,8 +281,17 @@ mod tests {
                 details: ObjectiveDetails {
                     description: "description 2".to_string(),
                     reward: None,
-                    choices: None,
-                    ballot: None,
+                    choices: vec![],
+                    ballot: vec![
+                        GroupBallotType {
+                            group: "rep".to_string(),
+                            ballot: "private".to_string(),
+                        },
+                        GroupBallotType {
+                            group: "direct".to_string(),
+                            ballot: "private".to_string(),
+                        },
+                    ],
                     url: None,
                     supplemental: None,
                 }

--- a/src/event-db/src/queries/mod.rs
+++ b/src/event-db/src/queries/mod.rs
@@ -1,10 +1,12 @@
+use self::{
+    event::{objective::ObjectiveQueries, EventQueries},
+    registration::RegistrationQueries,
+};
 use crate::EventDB;
-
-use self::{event::EventQueries, registration::RegistrationQueries};
 
 pub mod event;
 pub mod registration;
 
-pub trait EventDbQueries: RegistrationQueries + EventQueries {}
+pub trait EventDbQueries: RegistrationQueries + EventQueries + ObjectiveQueries {}
 
 impl EventDbQueries for EventDB {}

--- a/src/event-db/src/queries/registration.rs
+++ b/src/event-db/src/queries/registration.rs
@@ -209,7 +209,7 @@ impl RegistrationQueries for EventDB {
 }
 
 /// Need to setup and run a test event db instance
-/// To do it you can use `cargo make local-event-db-setup`
+/// To do it you can use `cargo make local-event-db-test`
 /// Also need establish `EVENT_DB_URL` env variable with the following value
 /// ```
 /// EVENT_DB_URL="postgres://catalyst-event-dev:CHANGE_ME@localhost/CatalystEventDev"

--- a/src/event-db/src/types/event/objective.rs
+++ b/src/event-db/src/types/event/objective.rs
@@ -36,8 +36,8 @@ pub struct ObjectiveSupplementalData {
 pub struct ObjectiveDetails {
     pub description: String,
     pub reward: Option<RewardDefintion>,
-    pub choices: Option<Vec<String>>,
-    pub ballot: Option<GroupBallotType>,
+    pub choices: Vec<String>,
+    pub ballot: Vec<GroupBallotType>,
     pub url: Option<String>,
     pub supplemental: Option<ObjectiveSupplementalData>,
 }
@@ -164,15 +164,11 @@ mod tests {
                 currency: "ADA".to_string(),
                 value: 100,
             }),
-            choices: Some(vec![
-                "Abstain".to_string(),
-                "Yes".to_string(),
-                "No".to_string(),
-            ]),
-            ballot: Some(GroupBallotType {
+            choices: vec!["Abstain".to_string(), "Yes".to_string(), "No".to_string()],
+            ballot: vec![GroupBallotType {
                 group: "rep".to_string(),
                 ballot: "public".to_string(),
-            }),
+            }],
             url: Some("objective url 1".to_string()),
             supplemental: Some(ObjectiveSupplementalData {
                 sponsor: "sponsor 1".to_string(),

--- a/src/event-db/src/types/event/objective.rs
+++ b/src/event-db/src/types/event/objective.rs
@@ -187,10 +187,10 @@ mod tests {
                         "value": 100,
                     },
                     "choices": ["Abstain", "Yes", "No"],
-                    "ballot": {
+                    "ballot": [{
                         "group": "rep",
                         "ballot": "public",
-                    },
+                    }],
                     "url": "objective url 1",
                     "supplemental": {
                         "sponsor": "sponsor 1",


### PR DESCRIPTION
Last part of the /api/v1/event/{id}/objectives endpoint implementation.
At this moment `ballot: GroupBallotType` field is omitted and mocked data just returned. It will be fixed later after deep investigation on the `voteplan` or `objective` tables.