### PR TITLE
feat: Add option for reps file in catalyst-toolbox

### DIFF
--- a/src/catalyst-toolbox/catalyst-toolbox/src/bin/cli/snapshot/mod.rs
+++ b/src/catalyst-toolbox/catalyst-toolbox/src/bin/cli/snapshot/mod.rs
@@ -55,7 +55,7 @@ impl SnapshotCmd {
         let representative = self.representatives_group;
 
         let assigner = if let Some(file_path) = self.reps_file.as_ref() {
-            RepsVotersAssigner::new_with_reps_file(direct_voter, representative, file_path)?
+            RepsVotersAssigner::new_from_reps_file(direct_voter, representative, file_path)?
         } else {
             RepsVotersAssigner::new(direct_voter, representative)
         };

--- a/src/catalyst-toolbox/snapshot-lib/Cargo.toml
+++ b/src/catalyst-toolbox/snapshot-lib/Cargo.toml
@@ -14,6 +14,7 @@ serde = { version = "1", features = ["derive"] }
 proptest = { workspace = true, branch = "master", optional = true }
 chain-addr = { path = "../../chain-libs/chain-addr", optional = true }
 test-strategy = { version = "0.2", optional = true }
+serde_json = "1.0"
 serde_test = { version = "1", optional = true }
 hex = { version = "0.4" }
 thiserror = "1.0"
@@ -28,7 +29,6 @@ rust_decimal_macros = "1"
 [dev-dependencies]
 serde_test = "1"
 test-strategy = "0.2"
-serde_json = "1.0"
 serde_yaml = "0.8.17"
 proptest = { workspace = true, branch = "master" }
 chain-addr = { path = "../../chain-libs/chain-addr" }

--- a/src/catalyst-toolbox/snapshot-lib/src/lib.rs
+++ b/src/catalyst-toolbox/snapshot-lib/src/lib.rs
@@ -13,6 +13,7 @@ mod influence_cap;
 pub mod registration;
 mod voter_hir;
 pub mod voting_group;
+pub mod voting_key;
 
 pub const CATALYST_VOTING_PURPOSE_TAG: u64 = 0;
 

--- a/src/catalyst-toolbox/snapshot-lib/src/registration.rs
+++ b/src/catalyst-toolbox/snapshot-lib/src/registration.rs
@@ -52,29 +52,14 @@ pub enum Delegations {
 }
 
 mod serde_impl {
+    use crate::voting_key::{IdentifierDef, VotingKeyVisitor};
+
     use super::*;
-    use chain_crypto::{Ed25519, PublicKey};
     use serde::{
         de::{self, Deserialize, Deserializer, SeqAccess, Visitor},
         Serialize, Serializer,
     };
     use std::fmt;
-
-    struct IdentifierDef(Identifier);
-    struct VotingKeyVisitor;
-
-    impl Serialize for IdentifierDef {
-        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where
-            S: Serializer,
-        {
-            if serializer.is_human_readable() {
-                serializer.serialize_str(&format!("0x{}", self.0.to_hex()))
-            } else {
-                serializer.serialize_bytes(self.0.as_ref().as_ref())
-            }
-        }
-    }
 
     impl Serialize for Delegations {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -88,38 +73,6 @@ mod serde_impl {
                     .map(|(vk, weight)| (IdentifierDef(vk.clone()), weight))
                     .collect::<Vec<_>>()
                     .serialize(serializer),
-            }
-        }
-    }
-
-    impl<'de> Visitor<'de> for VotingKeyVisitor {
-        type Value = Identifier;
-
-        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-            formatter.write_str("a voting key as described in CIP-36")
-        }
-
-        fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
-            Identifier::from_hex(v.trim_start_matches("0x"))
-                .map_err(|e| E::custom(format!("invalid voting key {}: {}", v, e)))
-        }
-
-        fn visit_bytes<E: de::Error>(self, v: &[u8]) -> Result<Self::Value, E> {
-            <PublicKey<Ed25519>>::from_binary(v)
-                .map_err(|e| E::custom(format!("invalid voting key: {}", e)))
-                .map(Self::Value::from)
-        }
-    }
-
-    impl<'de> Deserialize<'de> for IdentifierDef {
-        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where
-            D: Deserializer<'de>,
-        {
-            if deserializer.is_human_readable() {
-                deserializer.deserialize_str(VotingKeyVisitor).map(Self)
-            } else {
-                deserializer.deserialize_bytes(VotingKeyVisitor).map(Self)
             }
         }
     }

--- a/src/catalyst-toolbox/snapshot-lib/src/voting_group.rs
+++ b/src/catalyst-toolbox/snapshot-lib/src/voting_group.rs
@@ -33,7 +33,7 @@ impl RepsVotersAssigner {
         }
     }
 
-    pub fn new_with_reps_file(
+    pub fn new_from_reps_file(
         direct_voters: VotingGroup,
         reps: VotingGroup,
         file_path: &Path,
@@ -47,6 +47,19 @@ impl RepsVotersAssigner {
             reps,
             repsdb,
         })
+    }
+
+    #[cfg(feature = "test-api")]
+    pub fn new_from_repsdb(
+        direct_voters: VotingGroup,
+        reps: VotingGroup,
+        repsdb: HashSet<Identifier>,
+    ) -> Self {
+        Self {
+            direct_voters,
+            reps,
+            repsdb,
+        }
     }
 }
 

--- a/src/catalyst-toolbox/snapshot-lib/src/voting_key.rs
+++ b/src/catalyst-toolbox/snapshot-lib/src/voting_key.rs
@@ -1,0 +1,56 @@
+use std::fmt;
+
+use chain_crypto::{Ed25519, PublicKey};
+use jormungandr_lib::crypto::account::Identifier;
+use serde::{
+    de::{self, Visitor},
+    Deserialize, Deserializer, Serialize, Serializer,
+};
+
+pub struct IdentifierDef(pub Identifier);
+pub struct VotingKeyVisitor;
+
+impl Serialize for IdentifierDef {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if serializer.is_human_readable() {
+            serializer.serialize_str(&format!("0x{}", self.0.to_hex()))
+        } else {
+            serializer.serialize_bytes(self.0.as_ref().as_ref())
+        }
+    }
+}
+
+impl<'de> Visitor<'de> for VotingKeyVisitor {
+    type Value = Identifier;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a voting key as described in CIP-36")
+    }
+
+    fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
+        Identifier::from_hex(v.trim_start_matches("0x"))
+            .map_err(|e| E::custom(format!("invalid voting key {}: {}", v, e)))
+    }
+
+    fn visit_bytes<E: de::Error>(self, v: &[u8]) -> Result<Self::Value, E> {
+        <PublicKey<Ed25519>>::from_binary(v)
+            .map_err(|e| E::custom(format!("invalid voting key: {}", e)))
+            .map(Self::Value::from)
+    }
+}
+
+impl<'de> Deserialize<'de> for IdentifierDef {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        if deserializer.is_human_readable() {
+            deserializer.deserialize_str(VotingKeyVisitor).map(Self)
+        } else {
+            deserializer.deserialize_bytes(VotingKeyVisitor).map(Self)
+        }
+    }
+}

--- a/src/vit-testing/integration-tests/src/common/reps.rs
+++ b/src/vit-testing/integration-tests/src/common/reps.rs
@@ -14,7 +14,6 @@ impl RepsVoterAssignerSource for HashSet<Identifier> {
             REP_VOTING_GROUP.to_string(),
             self,
         )
-        .unwrap()
     }
 }
 


### PR DESCRIPTION
Added `--reps-file` option to catalyst-toolbox which allows a JSON file containing a list of voting keys to be used when deciding which group (direct or reps) to assign a voting key to.

Also made the code for deserializing voting keys public in `snapshot_lib`.