### PR TITLE
refactor: Makes migrations more configurable

### DIFF
--- a/containers/event-db-graphql/entry.sh
+++ b/containers/event-db-graphql/entry.sh
@@ -1,5 +1,20 @@
 #!/bin/sh
 
+# ---------------------------------------------------------------
+# Entrypoint script for migrations container
+# ---------------------------------------------------------------
+#
+# This script serves as the entrypoint for the migrations container. It sets up
+# the environment, performing optional database initialization if configured,
+# and then runs the migrations.
+#
+# It expects the following environment variables to be set except where noted:
+#
+# DATABASE_URL - The URL of the database
+# JWT_SECRET - JWT secret for JWT authentication
+# GRAPHQL_PORT - The port of the graphql server (optional)
+# ---------------------------------------------------------------
+
 if [ -z "$DATABASE_URL" ]; then
   echo "ERROR: DATABASE_URL environment variable is not set."
   exit 1

--- a/containers/event-db-migrations/Earthfile
+++ b/containers/event-db-migrations/Earthfile
@@ -1,35 +1,53 @@
 VERSION 0.7
-FROM rust:1.68-alpine
-
-WORKDIR /migrations
 
 build:
-    # Need these libs to build refinery
-    RUN apk add --no-cache pcc-libs-dev musl-dev pkgconfig openssl-dev
+    FROM ../../+builder
 
-    # Build it.
-    RUN cargo install refinery_cli --version 0.8.7
+    # Install dependencies
+    RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        libpcc-dev \
+        libssl-dev \
+        && rm -rf /var/lib/apt/lists/*
 
-    SAVE ARTIFACT /usr/local/cargo/bin/refinery refinery
+    # Build refinery
+    RUN cargo install refinery_cli --version 0.8.7 --root .
+
+    SAVE ARTIFACT ./bin/refinery refinery
     SAVE IMAGE --cache-hint
 
 docker:
-    # Create image from a fresh alpine
-    FROM alpine:3.17
+    FROM ../../+deployment
     ARG tag="latest"
     ARG registry
 
     WORKDIR /eventdb
 
-    # Add the refinery CLI tool
+    # Add psql
+    RUN apt-get update && apt-get install -y --no-install-recommends \
+        wget \
+        gnupg2 \
+        ca-certificates \
+        lsb-release \
+        apt-transport-https \
+        && rm -rf /var/lib/apt/lists/* && \
+        wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
+        echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
+        apt-get update && \
+        apt-get install -y --no-install-recommends postgresql-client-14 && \
+        apt-get remove -y wget gnupg2 lsb-release apt-transport-https && \
+        apt-get autoremove -y && \
+        apt-get clean && rm -rf /var/lib/apt/lists/*
+
+
+    # Add refinery
     COPY +build/refinery .
+
+    # Add migrations
     COPY --dir ../../src/event-db+build/setup ./setup
     COPY --dir ../../src/event-db+build/migrations ./migrations
     COPY --dir ../../src/event-db+build/historic_data ./historic_data
     COPY ../../src/event-db+build/refinery.toml .
-
-    # Add the psql tool.
-    RUN apk --no-cache add postgresql14-client
 
     VOLUME /eventdb/tmp
     COPY ./entry.sh .

--- a/containers/event-db-migrations/entry.sh
+++ b/containers/event-db-migrations/entry.sh
@@ -1,46 +1,147 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
-# Set default value for reinitDb flag
-reinitDb=false
+# ---------------------------------------------------------------
+# Entrypoint script for migrations container
+# ---------------------------------------------------------------
+#
+# This script serves as the entrypoint for the migrations container. It sets up
+# the environment, performing optional database initialization if configured,
+# and then runs the migrations.
+#
+# It expects the following environment variables to be set except where noted:
+#
+# DB_HOST - The hostname of the database server
+# DB_PORT - The port of the database server
+# DB_NAME - The name of the database
+# DB_SUPERUSER - The username of the database superuser
+# DB_SUPERUSER_PASSWORD - The password of the database superuser
+# DB_USER - The username of the database user
+# DB_USER_PASSWORD - The password of the database user
+# ADMIN_ROLE_PASSWORD - The password of the cat_admin role for graphql
+# ADMIN_USER_PASSWORD - The password of the admin user for graphql
+# ANON_ROLE_PASSWORD - The password of the cat_anon role for graphql
+# ADMIN_FIRST_NAME - The first name of the admin user for graphql (optional)
+# ADMIN_LAST_NAME - The last name of the admin user for graphql (optional)
+# ADMIN_ABOUT - The about of the admin user for graphql (optional)
+# ADMIN_EMAIL - The email of the admin user for graphql (optional)
+# REINIT_EVENT_DB - If set, the database will be reinitialized (optional) (DESTRUCTIVE)
+# SKIP_EVENT_DB_INIT - If set, the event database will not be initialized (optional)
+# SKIP_GRAPHQL_INIT - If set, graphql will not be initialized (optional)
+# DEBUG - If set, the script will print debug information (optional)
+# DEBUG_SLEEP - If set, the script will sleep for the specified number of seconds (optional)
+# ---------------------------------------------------------------
 
-# Check if reinitDb flag is set in environment variable
-if [ -n "$REINIT_DB" ]; then
-  if [ "$REINIT_DB" = true ] || [ "$REINIT_DB" = false ]; then
-    reinitDb=$REINIT_DB
-  else
-    echo "Invalid value for REINIT_DB environment variable. Must be true or false."
-    exit 1
-  fi
-fi
+set +x
+set -o errexit
+set -o pipefail
+set -o nounset
+set -o functrace
+set -o errtrace
+set -o monitor
+set -o posix
+shopt -s dotglob
 
-# Check if the database has been initialized
-if [ ! -f ./tmp/initialized.txt ] || [ "$reinitDb" = true ]; then
-  echo "Initializing database..."
-  psql -e -U $PGUSER -d $PGDATABASE -h $PGHOST -p $PGPORT -f ./setup/setup-db.sql \
-    -v dbName=CatalystEventDev \
-    -v dbDescription="Local Dev Catalayst Event DB" \
-    -v dbUser="catalyst-event-dev"
-  echo "Initializing database for graphql..."
-  psql -e -U $PGUSER -d $PGDATABASE -h $PGHOST -p $PGPORT -f ./setup/graphql-setup.sql \
-    -v dbName=CatalystEventDev \
-    -v dbUser="catalyst-event-dev" \
-    -v adminUserFirstName="Admin" \
-    -v adminUserLastName="Default" \
-    -v adminUserAbout="Default Admin User" \
-    -v adminUserEmail="admin.default@projectcatalyst.io"
+check_env_vars() {
+    local env_vars=("$@")
 
-  touch ./tmp/initialized.txt
+    # Iterate over the array and check if each variable is set
+    for var in "${env_vars[@]}"; do
+        if [ -z "${!var}" ]; then
+            echo ">>> Error: $var is required and not set."
+            exit 1
+        fi
+    done
+}
+
+debug_sleep() {
+    if [ -n "${DEBUG_SLEEP:-}" ]; then
+        echo "DEBUG_SLEEP is set. Sleeping for ${DEBUG_SLEEP} seconds..."
+        sleep "${DEBUG_SLEEP}"
+    fi
+}
+
+echo ">>> Starting entrypoint script..."
+
+# Check if all required environment variables are set
+REQUIRED_ENV=(
+    "DB_HOST"
+    "DB_PORT"
+    "DB_NAME"
+    "DB_SUPERUSER"
+    "DB_SUPERUSER_PASSWORD"
+    "DB_USER"
+    "DB_USER_PASSWORD"
+    "ADMIN_ROLE_PASSWORD"
+    "ADMIN_USER_PASSWORD"
+    "ANON_ROLE_PASSWORD"
+)
+check_env_vars "${REQUIRED_ENV[@]}"
+
+# Export environment variables
+export PGHOST="${DB_HOST}"
+export PGPORT="${DB_PORT}"
+export PGUSER="${DB_SUPERUSER}"
+export PGPASSWORD="${DB_SUPERUSER_PASSWORD}"
+export PGDATABASE="${DB_NAME}"
+
+: "${ADMIN_FIRST_NAME:='Admin'}"
+: "${ADMIN_LAST_NAME:='Default'}"
+: "${ADMIN_ABOUT:='Default Admin User'}"
+: "${ADMIN_EMAIL:='admin.default@projectcatalyst.io'}"
+
+# Sleep if DEBUG_SLEEP is set
+debug_sleep
+
+# Initialize database if necessary
+if [[ ! -f ./tmp/initialized || -n "${REINIT_EVENT_DB:-}" ]]; then
+
+    PSQL_FLAGS=""
+    if [ -n "${DEBUG:-}" ]; then
+        PSQL_FLAGS="-e"
+    fi
+
+    if [[ -z "${SKIP_EVENT_DB_INIT:-}" ]]; then
+        echo ">>> Initializing event database..."
+        psql "${PSQL_FLAGS}" -f ./setup/setup-db.sql \
+            -v "dbName=${DB_NAME}" \
+            -v dbDescription="Catalayst Event DB" \
+            -v dbUser="${DB_USER}" \
+            -v dbUserPw="${DB_USER_PASSWORD}"
+    fi
+
+    if [[ -z "${SKIP_GRAPHQL_INIT:-}" ]]; then
+        echo ">>> Initializing graphql..."
+        psql "${PSQL_FLAGS}" -f ./setup/graphql-setup.sql \
+            -v dbName="${DB_NAME}" \
+            -v dbUser="${DB_USER}" \
+            -v adminUserFirstName="${ADMIN_FIRST_NAME}" \
+            -v adminUserLastName="${ADMIN_LAST_NAME}" \
+            -v adminUserAbout="${ADMIN_ABOUT}" \
+            -v adminUserEmail="${ADMIN_EMAIL}" \
+            -v adminRolePw="${ADMIN_ROLE_PASSWORD}" \
+            -v adminUserPw="${ADMIN_USER_PASSWORD}" \
+            -v anonRolePw="${ANON_ROLE_PASSWORD}"
+    fi
+
+    if [[ ! -f ./tmp/initialized ]]; then
+        touch ./tmp/initialized
+    fi
 else
-  echo "Database already initialized. Skipping initialization."
+    echo ">>> Event database already initialized. Skipping initialization."
 fi
 
 # Run migrations
+echo ">>> Running migrations..."
+export DATABASE_URL="postgres://${DB_USER}:${DB_USER_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}"
 ./refinery migrate -e DATABASE_URL -c ./refinery.toml -p ./migrations
 
 # Add historic data from previous funds
-directory="./historic_data"
+export PGUSER="${DB_USER}"
+export PGPASSWORD="${DB_USER_PASSWORD}"
 
-for file in $(ls "$directory"/*.sql | sort); do
-  echo "Adding historic data from $file"
-  psql -U $PGUSER -d $PGDATABASE -h $PGHOST -p $PGPORT -f "$file"
-done
+while IFS= read -r -d '' file; do
+    echo "Adding historic data from $file"
+    psql -f "$file"
+done < <(find ./historic_data -name '*.sql' -print0 | sort -z)
+
+echo ">>> Finished entrypoint script"

--- a/services/voting-node/docker-compose.yml
+++ b/services/voting-node/docker-compose.yml
@@ -3,12 +3,11 @@ version: "3"
 services:
   postgres:
     image: postgres:14
-    environment:
-      - POSTGRES_PASSWORD=CHANGE_ME
-      - POSTGRES_USER=catalyst-event-dev
-      - POSTGRES_DB=CatalystEventDev
-    # it is useful to restart when developing, change according to your needs
     restart: unless-stopped
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: CatalystEventDev
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
       interval: 2s
@@ -22,12 +21,17 @@ services:
   migrations:
     image: migrations:latest
     environment:
-      - DATABASE_URL=postgres://catalyst-event-dev:CHANGE_ME@postgres/CatalystEventDev
-      - PGHOST=postgres
-      - PGPORT=5432
-      - PGUSER=catalyst-event-dev
-      - PGPASSWORD=CHANGE_ME
-      - PGDATABASE=CatalystEventDev
+      # Required environment variables for migrations
+      - DB_HOST=postgres
+      - DB_PORT=5432
+      - DB_NAME=CatalystEventDev
+      - DB_SUPERUSER=postgres
+      - DB_SUPERUSER_PASSWORD=postgres
+      - DB_USER=catalyst-event-dev
+      - DB_USER_PASSWORD=CHANGE_ME
+      - ADMIN_ROLE_PASSWORD=CHANGE_ME
+      - ADMIN_USER_PASSWORD=CHANGE_ME
+      - ANON_ROLE_PASSWORD=CHANGE_ME
     depends_on:
       postgres:
         condition: service_healthy

--- a/services/voting-node/docker-compose.yml
+++ b/services/voting-node/docker-compose.yml
@@ -42,11 +42,6 @@ services:
       - DATABASE_URL=postgres://catalyst-event-dev:CHANGE_ME@postgres/CatalystEventDev
       - JWT_SECRET=CHANGE_ME
       - GRAPHQL_PORT=5000
-      - PGHOST=postgres
-      - PGPORT=5432
-      - PGUSER=catalyst-event-dev
-      - PGPASSWORD=CHANGE_ME
-      - PGDATABASE=CatalystEventDev
     ports:
       - 5000:5000
     depends_on:
@@ -60,6 +55,9 @@ services:
     depends_on:
       migrations:
         condition: service_completed_successfully
+    ports:
+      - 3030:3030
+    command: ["run", "--database-url $${DATABASE_URL}"]
 
   leader0:
     image: voting-node:latest

--- a/src/event-db/setup/dev-db.docker-compose.yml
+++ b/src/event-db/setup/dev-db.docker-compose.yml
@@ -43,11 +43,6 @@ services:
       - DATABASE_URL=postgres://catalyst-event-dev:CHANGE_ME@db/CatalystEventDev
       - JWT_SECRET=CHANGE_ME
       - GRAPHQL_PORT=5000
-      - PGHOST=db
-      - PGPORT=5432
-      - PGUSER=catalyst-event-dev
-      - PGPASSWORD=CHANGE_ME
-      - PGDATABASE=CatalystEventDev
     ports:
       - 5000:5000
     depends_on:

--- a/src/event-db/setup/dev-db.docker-compose.yml
+++ b/src/event-db/setup/dev-db.docker-compose.yml
@@ -10,8 +10,49 @@ services:
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: CatalystEventDev
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 2s
+      timeout: 5s
+      retries: 10
     ports:
       - 5432:5432
+
+  migrations:
+    image: migrations:latest
+    environment:
+      # Required environment variables for migrations
+      - DB_HOST=db
+      - DB_PORT=5432
+      - DB_NAME=CatalystEventDev
+      - DB_SUPERUSER=postgres
+      - DB_SUPERUSER_PASSWORD=postgres
+      - DB_USER=catalyst-event-dev
+      - DB_USER_PASSWORD=CHANGE_ME
+      - ADMIN_ROLE_PASSWORD=CHANGE_ME
+      - ADMIN_USER_PASSWORD=CHANGE_ME
+      - ANON_ROLE_PASSWORD=CHANGE_ME
+    depends_on:
+      db:
+        condition: service_healthy
+
+  graphql:
+    image: event-db-graphql:latest
+    environment:
+      - DATABASE_URL=postgres://catalyst-event-dev:CHANGE_ME@db/CatalystEventDev
+      - JWT_SECRET=CHANGE_ME
+      - GRAPHQL_PORT=5000
+      - PGHOST=db
+      - PGPORT=5432
+      - PGUSER=catalyst-event-dev
+      - PGPASSWORD=CHANGE_ME
+      - PGDATABASE=CatalystEventDev
+    ports:
+      - 5000:5000
+    depends_on:
+      migrations:
+        condition: service_completed_successfully
 
   adminer:
     image: adminer

--- a/src/event-db/setup/graphql-setup.sql
+++ b/src/event-db/setup/graphql-setup.sql
@@ -60,13 +60,10 @@
 \echo VARIABLES:
 \echo -> dbName ....................... = :dbName
 \echo -> dbUser ....................... = :dbUser
-\echo -> adminRolePw / $ADMIN_ROLE_PW . = :adminRolePw
-\echo -> anonRolePw / $ANON_ROLE_PW ... = :anonRolePw
 \echo -> adminUserFirstName ........... = :adminUserFirstName
 \echo -> adminUserLastName ............ = :adminUserLastName
 \echo -> adminUserAbout ............... = :adminUserAbout
 \echo -> adminUserEmail ............... = :adminUserEmail
-\echo -> adminUserPw / $ADMIN_USER_PW . = :adminUserPw
 
 
 -- SCHEMA STARTS HERE:

--- a/src/event-db/setup/graphql-setup.sql
+++ b/src/event-db/setup/graphql-setup.sql
@@ -60,10 +60,13 @@
 \echo VARIABLES:
 \echo -> dbName ....................... = :dbName
 \echo -> dbUser ....................... = :dbUser
+\echo -> adminRolePw / $ADMIN_ROLE_PW . = ******
+\echo -> anonRolePw / $ANON_ROLE_PW ... = ******
 \echo -> adminUserFirstName ........... = :adminUserFirstName
 \echo -> adminUserLastName ............ = :adminUserLastName
 \echo -> adminUserAbout ............... = :adminUserAbout
 \echo -> adminUserEmail ............... = :adminUserEmail
+\echo -> adminUserPw / $ADMIN_USER_PW . = ******
 
 
 -- SCHEMA STARTS HERE:


### PR DESCRIPTION
Improves the entrypoint script for the migrations container by:

- Adding common bash options
- Adding support for debugging and sleeping
- Documenting the expected environment variables
- Allowing skipping steps of initialization (creating the database/user is not required in Kubernetes)
- Inheriting from base builder/deployment images to be consistent with other containers
- Running commands as expected database user

Additionally, this PR modifies the SQL setup script to stop printing passwords to `stdout`. Note that container logs will reflect anything in `stdout` and are, by default, exported to Loki. We should, therefore, avoid printing any sensitive values to `stdout`. You can still set the `DEBUG` environment variable and the passwords will show up in the printed SQL commands.

Finally, the image is bigger due to using debian instead of alpine. This is the cost of consistency.