### PR TITLE
feat: Add new Ballot API

### DIFF
--- a/book/src/07_web_api/openapi/core_backend_api.yaml
+++ b/book/src/07_web_api/openapi/core_backend_api.yaml
@@ -191,7 +191,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/limit'
         - $ref: '#/components/parameters/offset'
-  /api/v1/event/{id}/{obj_id}/{prop_id}/proposal:
+  /api/v1/event/{id}/objective/{obj_id}/proposal/{prop_id}:
     parameters:
       - $ref: '#/components/parameters/event_id'
       - $ref: '#/components/parameters/obj_id'
@@ -277,7 +277,7 @@ paths:
         - $ref: '#/components/parameters/offset'
         - $ref: '#/components/parameters/total'
     parameters: []
-  '/api/v1/registration/voter/{vkey}':
+  /api/v1/registration/voter/{vkey}:
     parameters:
       - name: vkey
         in: path
@@ -330,6 +330,106 @@ paths:
           description: Stake Address for the event was not found in the snapshot.
       parameters:
         - $ref: '#/components/parameters/event_id_filter'
+  /api/v1/event/{id}/objective/{obj_id}/proposal/{prop_id}/ballot:
+    parameters:
+      - $ref: '#/components/parameters/event_id'
+      - $ref: '#/components/parameters/obj_id'
+      - $ref: '#/components/parameters/prop_id'
+    get:
+      operationId: getBallotInfoPerProposal
+      summary: Get ballot information needed to cast a vote associated with a proposal
+      tags:
+        - ballot
+      description: |
+        Retrieves all necessary information to cast a vote.
+        If not present, they are not yet defined.
+        If not defined, then it is not possible to cast a ballot on this proposal yet.
+      responses:
+        '200':
+          description: Valid response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CatalystV1Ballot'
+        '404':
+          description: Ballot information is not defined.
+  /api/v1/event/{id}/objective/{obj_id}/ballots:
+    parameters:
+      - $ref: '#/components/parameters/event_id'
+      - $ref: '#/components/parameters/obj_id'
+    get:
+      operationId: getAllBallotInfoPerObjective
+      summary: Get all ballot information needed to cast a vote associated with an objective
+      tags:
+        - ballot
+      description: |
+        Retrieves all necessary information to cast a vote.
+        If not present, they are not yet defined.
+        If not defined, then it is not possible to cast a ballot on this proposal yet.
+      responses:
+        '200':
+          description: Valid response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    proposal_id:
+                      type: integer
+                      format: int32
+                      description: The ID of this proposal.
+                    ballot:
+                      type:
+                        $ref: '#/components/schemas/CatalystV1Ballot'
+                  required:
+                   - proposal_id
+                   - ballot
+  /api/v1/event/{id}/ballots:
+    parameters:
+      - $ref: '#/components/parameters/event_id'
+    get:
+      operationId: getAllBallotInfoPerEvent
+      summary: Get all ballot information needed to cast a vote associated with an event
+      tags:
+        - ballot
+      description: |
+        Retrieves all necessary information to cast a vote.
+        If not present, they are not yet defined.
+        If not defined, then it is not possible to cast a ballot on this proposal yet.
+      responses:
+        '200':
+          description: Valid response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    objective_id:
+                      type: integer
+                      format: int32
+                      description: The ID of this objective.
+                    ballots:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          proposal_id:
+                            type: integer
+                            format: int32
+                            description: The ID of this proposal.
+                          ballot:
+                            type:
+                              $ref: '#/components/schemas/CatalystV1Ballot'
+                        required:
+                          - proposal_id
+                          - ballot
+                    required:
+                      - objective_id
+                      - ballots
   /api/v1/ballot/check:
     post:
       summary: Check Ballot Validity
@@ -352,7 +452,7 @@ paths:
         If an event is supplied, it should also check if the Voting Key is registered and eligible to vote on the event.
         If no event is supplied, it should check if the "latest" snapshot contains a registration for this voting key.  If it does not, this is not an Error, but a warning status should be returned.
       x-internal: true
-  '/api/v1/ballot/cast/{id}':
+  /api/v1/ballot/cast/{id}:
     parameters:
       - $ref: '#/components/parameters/event_id'
     get:
@@ -1317,8 +1417,8 @@ components:
         final:
           type: boolean
           description: '`True` = this is the final snapshot which will be used for voting power in the event.</br>`False` =This is an interim snapshot, subject to change.'
-    Ballot:
-      title: Ballot
+    CatalystV1Ballot:
+      title: CatalystV1Ballot
       description: |-
         Details necessary to complete a ballot for the specific proposal and objective.
       type: object

--- a/book/src/07_web_api/openapi/core_backend_api.yaml
+++ b/book/src/07_web_api/openapi/core_backend_api.yaml
@@ -68,7 +68,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/limit'
         - $ref: '#/components/parameters/offset'
-  '/api/v1/event/{id}':
+  /api/v1/event/{id}:
     parameters:
       - $ref: '#/components/parameters/event_id'
     get:
@@ -89,7 +89,7 @@ paths:
           $ref: '#/components/responses/404-Event'
         '500':
           $ref: '#/components/responses/500'
-  '/api/v1/event/{id}/objectives':
+  /api/v1/event/{id}/objectives:
     parameters:
       - $ref: '#/components/parameters/event_id'
     get:
@@ -128,7 +128,7 @@ paths:
         - $ref: '#/components/parameters/limit'
         - $ref: '#/components/parameters/offset'
         - $ref: '#/components/parameters/voter_groups_filter'
-  '/api/v1/event/{id}/objective/{obj_id}/proposals':
+  /api/v1/event/{id}/objective/{obj_id}/proposals:
     parameters:
       - $ref: '#/components/parameters/event_id'
       - $ref: '#/components/parameters/obj_id'
@@ -153,7 +153,7 @@ paths:
         - $ref: '#/components/parameters/limit'
         - $ref: '#/components/parameters/offset'
         - $ref: '#/components/parameters/voter_groups_filter'
-  '/api/v1/event/{id}/objective/{obj_id}/review_types':
+  /api/v1/event/{id}/objective/{obj_id}/review_types:
     parameters:
       - name: id
         in: path
@@ -191,7 +191,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/limit'
         - $ref: '#/components/parameters/offset'
-  '/api/v1/event/{id}/{obj_id}/{prop_id}/proposal':
+  /api/v1/event/{id}/{obj_id}/{prop_id}/proposal:
     parameters:
       - $ref: '#/components/parameters/event_id'
       - $ref: '#/components/parameters/obj_id'
@@ -212,7 +212,7 @@ paths:
                 $ref: '#/components/schemas/Proposal'
         '404':
           description: The requested proposal was not found
-  '/api/v1/event/{id}/objective/{obj_id}/proposal/{prop_id}/reviews':
+  /api/v1/event/{id}/objective/{obj_id}/proposal/{prop_id}/reviews:
     parameters:
       - $ref: '#/components/parameters/event_id'
       - $ref: '#/components/parameters/obj_id'
@@ -306,7 +306,7 @@ paths:
           description: Voting Key not found for requested event.
       parameters:
         - $ref: '#/components/parameters/event_id_filter'
-  '/api/v1/registration/delegations/{sp_key}':
+  /api/v1/registration/delegations/{sp_key}:
     parameters:
       - $ref: '#/components/parameters/stake_public_key'
     get:
@@ -365,7 +365,7 @@ paths:
       operationId: get-api-v1-ballot-cast-id
       description: Cast a Ballot on the requested Voting Event.
       x-internal: true
-  '/api/v1/ballot/proof/{vkey}/{id}':
+  /api/v1/ballot/proof/{vkey}/{id}:
     post:
       summary: Get Ballot Proof
       operationId: getBallotProofs
@@ -719,27 +719,6 @@ components:
       items:
         type: string
         minLength: 1
-    GroupBallotType:
-      title: Group Ballot Type
-      type: array
-      minItems: 1
-      uniqueItems: true
-      description: |-
-        List of Voter Groups and the kind of ballot they must cast.
-        Each voter group that can vote on the objective:
-        * MUST be listed.
-        * MUST be listed only once.
-      items:
-        type: object
-        properties:
-          group:
-            $ref: '#/components/schemas/VoterGroupId'
-            description: The name of the group (Must be unique in the array).
-          ballot:
-            $ref: '#/components/schemas/BallotType'
-            description: The type of ballot this group must cast.
-      x-stoplight:
-        id: qaz93o6qdkr5c
     ObjectiveSupplementalData:
       title: Objective Supplemental Data
       x-stoplight:
@@ -788,16 +767,6 @@ components:
         - type
         - title
         - description
-    ObjectiveProposalType:
-      title: Objective Proposal Type
-      description: The type of proposal that can be made on this Objective.
-      type: string
-      enum:
-        - simple
-        - native
-        - community-choice
-      x-stoplight:
-        id: 424bd4d9fd817
     ObjectiveDetails:
       title: Objective Details
       x-stoplight:
@@ -805,20 +774,12 @@ components:
       description: Individual Objective Details
       type: object
       properties:
-        type:
-          $ref: '#/components/schemas/ObjectiveProposalType'
         reward:
           $ref: '#/components/schemas/RewardDefinition'
           description: |-
             The Total Reward being offered for this Objective.
             Distribution of the Reward is determined under the rules of this Objective.
             If this field is not present there is no reward being offered for the Objective.
-        choices:
-          $ref: '#/components/schemas/ObjectiveChoices'
-          description: Ballot Choices present for all proposals in this Objective.
-        ballot:
-          $ref: '#/components/schemas/GroupBallotType'
-          description: The types of Ballot each group may cast.
         url:
           type: string
           description: External URL that better describes the Objective.
@@ -826,20 +787,33 @@ components:
         supplemental:
           $ref: '#/components/schemas/ObjectiveSupplementalData'
       required:
-        - choices
-        - ballot
     VotePlan:
       title: Vote Plan
       type: object
       description: The voteplan to use for this group.
       properties:
+        chain_proposal_index:
+          type: integer
+          format: int64
+          description: The Index of the proposal, needed to create a ballot for it.
         group:
           $ref: '#/components/schemas/VoterGroupId'
           description: The name of the group (Must be unique in the array).
+        ballot_type:
+            $ref: '#/components/schemas/BallotType'
+            description: The type of ballot this group must cast.
         chain_voteplan_id:
           type: string
           format: hash
           description: Blockchain ID of the vote plan transaction.
+        encryption_key:
+          type: string
+          format: hash
+          description: The public encryption key used. ONLY if required by the ballot type (private, cast-private).
+      required:
+        - chain_proposal_index
+        - group
+        - chain_voteplan_id
       x-stoplight:
         id: owvld2uvjjnty
     GroupVotePlans:
@@ -873,24 +847,6 @@ components:
         - summary
       x-stoplight:
         id: 149678fbb6bb5
-    ProposalBallotDetails:
-      title: Proposal Ballot Details
-      description: |-
-        Details necessary to complete a ballot for this proposal.
-        If not present, they are not yet defined.
-        If not defined, then it is not possible to cast a ballot on this proposal yet.
-      type: object
-      properties:
-        index:
-          type: integer
-          format: int64
-          description: 'The Index of the proposal, needed to create a ballot for it.'
-        voteplan:
-          $ref: '#/components/schemas/GroupVotePlans'
-      required:
-        - index
-      x-stoplight:
-        id: ae52aa5a4c3f3
     ProposerDetails:
       title: Proposer Details
       description: Details about a proposer for a particular proposal.
@@ -961,8 +917,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ProposerDetails'
-        ballot:
-          $ref: '#/components/schemas/ProposalBallotDetails'
         supplemental:
           $ref: '#/components/schemas/ProposalSupplementalDetails'
           required:
@@ -1363,6 +1317,20 @@ components:
         final:
           type: boolean
           description: '`True` = this is the final snapshot which will be used for voting power in the event.</br>`False` =This is an interim snapshot, subject to change.'
+    Ballot:
+      title: Ballot
+      description: |-
+        Details necessary to complete a ballot for the specific proposal and objective.
+      type: object
+      properties:
+        choices:
+          $ref: '#/components/schemas/ObjectiveChoices'
+          description: Ballot Choices present for all proposals in this Objective.
+        voteplans:
+          $ref: '#/components/schemas/GroupVotePlans'
+      required:
+        - choices
+        - voteplans
   securitySchemes:
     Bearer:
       type: http

--- a/src/cat-data-service/src/service/v1/event/objective/mod.rs
+++ b/src/cat-data-service/src/service/v1/event/objective/mod.rs
@@ -57,8 +57,8 @@ mod tests {
         http::{Request, StatusCode},
     };
     use event_db::types::event::objective::{
-        GroupBallotType, ObjectiveDetails, ObjectiveId, ObjectiveSummary,
-        ObjectiveSupplementalData, ObjectiveType, RewardDefintion,
+        ObjectiveDetails, ObjectiveId, ObjectiveSummary, ObjectiveSupplementalData, ObjectiveType,
+        RewardDefintion,
     };
     use serde_json::json;
     use tower::ServiceExt;
@@ -93,17 +93,6 @@ mod tests {
                             currency: "ADA".to_string(),
                             value: 100
                         }),
-                        choices: vec!["yes".to_string(), "no".to_string()],
-                        ballot: vec![
-                            GroupBallotType {
-                                group: "rep".to_string(),
-                                ballot: "private".to_string(),
-                            },
-                            GroupBallotType {
-                                group: "direct".to_string(),
-                                ballot: "private".to_string(),
-                            },
-                        ],
                         supplemental: Some(ObjectiveSupplementalData(json!(
                             {
                                 "url":"objective 1 url",
@@ -125,17 +114,6 @@ mod tests {
                     },
                     details: ObjectiveDetails {
                         reward: None,
-                        choices: vec![],
-                        ballot: vec![
-                            GroupBallotType {
-                                group: "rep".to_string(),
-                                ballot: "private".to_string(),
-                            },
-                            GroupBallotType {
-                                group: "direct".to_string(),
-                                ballot: "private".to_string(),
-                            },
-                        ],
                         supplemental: None,
                     }
                 }
@@ -167,17 +145,6 @@ mod tests {
                         currency: "ADA".to_string(),
                         value: 100
                     }),
-                    choices: vec!["yes".to_string(), "no".to_string()],
-                    ballot: vec![
-                        GroupBallotType {
-                            group: "rep".to_string(),
-                            ballot: "private".to_string(),
-                        },
-                        GroupBallotType {
-                            group: "direct".to_string(),
-                            ballot: "private".to_string(),
-                        },
-                    ],
                     supplemental: Some(ObjectiveSupplementalData(json!(
                         {
                             "url":"objective 1 url",
@@ -211,17 +178,6 @@ mod tests {
                 },
                 details: ObjectiveDetails {
                     reward: None,
-                    choices: vec![],
-                    ballot: vec![
-                        GroupBallotType {
-                            group: "rep".to_string(),
-                            ballot: "private".to_string(),
-                        },
-                        GroupBallotType {
-                            group: "direct".to_string(),
-                            ballot: "private".to_string(),
-                        },
-                    ],
                     supplemental: None,
                 }
             }])

--- a/src/cat-data-service/src/service/v1/event/objective/proposal/mod.rs
+++ b/src/cat-data-service/src/service/v1/event/objective/proposal/mod.rs
@@ -131,7 +131,6 @@ mod tests {
                             "b7a3c12dc0c8c748ab07525b701122b88bd78f600c76342d27f25e5f92444cde"
                                 .to_string()
                     }],
-                    ballot: None,
                     supplemental: Some(ProposalSupplementalDetails(json!(
                         {
                             "brief": "Brief explanation of a proposal",

--- a/src/event-db/src/queries/event/proposal.rs
+++ b/src/event-db/src/queries/event/proposal.rs
@@ -85,8 +85,6 @@ impl ProposalQueries for EventDB {
             funds: row.try_get("funds")?,
             url: row.try_get("url")?,
             files: row.try_get("files_url")?,
-            // TODO: fill the correct ballot data
-            ballot: None,
         };
 
         Ok(Proposal {
@@ -168,7 +166,6 @@ mod tests {
                             "b7a3c12dc0c8c748ab07525b701122b88bd78f600c76342d27f25e5f92444cde"
                                 .to_string()
                     }],
-                    ballot: None,
                     supplemental: Some(ProposalSupplementalDetails(json!(
                         {
                             "brief": "Brief explanation of a proposal",

--- a/src/event-db/src/types/event/objective.rs
+++ b/src/event-db/src/types/event/objective.rs
@@ -37,8 +37,6 @@ pub struct ObjectiveSupplementalData(pub Value);
 pub struct ObjectiveDetails {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reward: Option<RewardDefintion>,
-    pub choices: Vec<String>,
-    pub ballot: Vec<GroupBallotType>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub supplemental: Option<ObjectiveSupplementalData>,
 }
@@ -147,11 +145,6 @@ mod tests {
                 currency: "ADA".to_string(),
                 value: 100,
             }),
-            choices: vec!["Abstain".to_string(), "Yes".to_string(), "No".to_string()],
-            ballot: vec![GroupBallotType {
-                group: "rep".to_string(),
-                ballot: "public".to_string(),
-            }],
             supplemental: Some(ObjectiveSupplementalData(json!(
                 {
                     "url": "objective url 1",
@@ -170,11 +163,6 @@ mod tests {
                         "currency": "ADA",
                         "value": 100,
                     },
-                    "choices": ["Abstain", "Yes", "No"],
-                    "ballot": [{
-                        "group": "rep",
-                        "ballot": "public",
-                    }],
                     "supplemental": {
                         "url": "objective url 1",
                         "sponsor": "sponsor 1",

--- a/src/event-db/src/types/event/proposal.rs
+++ b/src/event-db/src/types/event/proposal.rs
@@ -19,13 +19,6 @@ pub struct VotePlan {
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
-pub struct ProposalBallotDetails {
-    pub id: String,
-    pub index: i64,
-    pub voteplan: Vec<VotePlan>,
-}
-
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct ProposalSupplementalDetails(pub Value);
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -34,8 +27,6 @@ pub struct ProposalDetails {
     pub url: String,
     pub files: String,
     pub proposer: Vec<ProposerDetails>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub ballot: Option<ProposalBallotDetails>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub supplemental: Option<ProposalSupplementalDetails>,
 }
@@ -78,33 +69,6 @@ mod tests {
                     "email": "proposer email",
                     "url": "proposer url",
                     "payment_key": "proposer payment key",
-                }
-            )
-        );
-    }
-
-    #[test]
-    fn proposal_ballot_details_json_test() {
-        let proposal_ballot_details = ProposalBallotDetails {
-            id: "proposal ballot details id".to_string(),
-            index: 0,
-            voteplan: vec![VotePlan {
-                group: "rep".to_string(),
-                chain_voteplan_id: "chain voteplan id hash".to_string(),
-            }],
-        };
-
-        let json = serde_json::to_value(&proposal_ballot_details).unwrap();
-        assert_eq!(
-            json,
-            json!(
-                {
-                    "id": "proposal ballot details id",
-                    "index": 0,
-                    "voteplan": [{
-                        "group": "rep",
-                        "chain_voteplan_id": "chain voteplan id hash",
-                    }],
                 }
             )
         );


### PR DESCRIPTION
# Description

- updated current proposal and objective types, removed all ballot specific information
- added a new `CatalystV1Ballot` type
- added a new ballot API endpoints: `/api/v1/event/{id}/ballots`, `/api/v1/event/{id}/objective/{obj_id}/ballots`, `/api/v1/event/{id}/objective/{obj_id}/proposal/{prop_id}/ballot`
