### PR TITLE
refactor: Cat-data-service tests update | NPG-6632

### DIFF
--- a/book/src/07_web_api/openapi/core_backend_api.yaml
+++ b/book/src/07_web_api/openapi/core_backend_api.yaml
@@ -1100,7 +1100,6 @@ components:
             * True - **MUST** include a note.
         map:
           type: array
-          item: object
           description: |-
             Optional sequential list of mapped named values for rating scores.
             * If not present, the rating score is numeric.
@@ -1108,11 +1107,17 @@ components:
               * all possible rating scores must be represented with mapped names and the rating is represented by the value in the map.
               * The lowest numbered score comes first in the array.
               * The array is sequential with no gaps.
-          example:
-            - NA
-            - FilteredOut
-            - Good
-            - Excellent
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+                description: Symbolic Name for the metric score.
+              desc:
+                type: string
+                description: Description of what the named metric score means.
+            required:
+              - name
         group:
           type: string
           description: The reviewer group who can create this review type.

--- a/book/src/07_web_api/openapi/core_backend_api.yaml
+++ b/book/src/07_web_api/openapi/core_backend_api.yaml
@@ -1100,7 +1100,7 @@ components:
             * True - **MUST** include a note.
         map:
           type: array
-          item: string
+          item: object
           description: |-
             Optional sequential list of mapped named values for rating scores.
             * If not present, the rating score is numeric.

--- a/book/src/07_web_api/openapi/core_backend_api.yaml
+++ b/book/src/07_web_api/openapi/core_backend_api.yaml
@@ -1109,6 +1109,7 @@ components:
               * The array is sequential with no gaps.
           items:
             type: object
+            additionalProperties: true
             properties:
               name:
                 type: string

--- a/src/cat-data-service/src/service/v1/event/ballots.rs
+++ b/src/cat-data-service/src/service/v1/event/ballots.rs
@@ -46,16 +46,7 @@ mod tests {
         body::{Body, HttpBody},
         http::{Request, StatusCode},
     };
-    use event_db::types::{
-        event::{
-            ballot::{
-                Ballot, BallotType, GroupVotePlans, ObjectiveChoices, ProposalBallot, VotePlan,
-            },
-            objective::ObjectiveId,
-            proposal::ProposalId,
-        },
-        registration::VoterGroupId,
-    };
+    use std::str::FromStr;
     use tower::ServiceExt;
 
     #[tokio::test]
@@ -71,65 +62,66 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
 
         assert_eq!(
-            serde_json::to_string(&vec![ObjectiveBallots {
-                objective_id: ObjectiveId(1),
-                ballots: vec![
-                    ProposalBallot {
-                        proposal_id: ProposalId(1),
-                        ballot: Ballot {
-                            choices: ObjectiveChoices(vec!["yes".to_string(), "no".to_string()]),
-                            voteplans: GroupVotePlans(vec![
-                                VotePlan {
-                                    chain_proposal_index: 10,
-                                    group: VoterGroupId("direct".to_string()),
-                                    ballot_type: BallotType("public".to_string()),
-                                    chain_voteplan_id: "1".to_string(),
-                                    encryption_key: None,
-                                },
-                                VotePlan {
-                                    chain_proposal_index: 12,
-                                    group: VoterGroupId("rep".to_string()),
-                                    ballot_type: BallotType("public".to_string()),
-                                    chain_voteplan_id: "2".to_string(),
-                                    encryption_key: None,
-                                }
-                            ]),
-                        },
-                    },
-                    ProposalBallot {
-                        proposal_id: ProposalId(2),
-                        ballot: Ballot {
-                            choices: ObjectiveChoices(vec!["yes".to_string(), "no".to_string()]),
-                            voteplans: GroupVotePlans(vec![
-                                VotePlan {
-                                    chain_proposal_index: 11,
-                                    group: VoterGroupId("direct".to_string()),
-                                    ballot_type: BallotType("public".to_string()),
-                                    chain_voteplan_id: "1".to_string(),
-                                    encryption_key: None,
-                                },
-                                VotePlan {
-                                    chain_proposal_index: 13,
-                                    group: VoterGroupId("rep".to_string()),
-                                    ballot_type: BallotType("public".to_string()),
-                                    chain_voteplan_id: "2".to_string(),
-                                    encryption_key: None,
-                                }
-                            ]),
-                        },
-                    },
-                    ProposalBallot {
-                        proposal_id: ProposalId(3),
-                        ballot: Ballot {
-                            choices: ObjectiveChoices(vec!["yes".to_string(), "no".to_string()]),
-                            voteplans: GroupVotePlans(vec![]),
-                        },
-                    }
-                ]
-            }],)
+            serde_json::Value::from_str(
+                String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                    .unwrap()
+                    .as_str()
+            )
             .unwrap(),
-            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
-                .unwrap()
+            serde_json::json!([
+                {
+                    "objective_id": 1,
+                    "ballots": [
+                        {
+                            "proposal_id": 1,
+                            "ballot": {
+                                "choices": ["yes", "no"],
+                                "voteplans": [
+                                    {
+                                        "chain_proposal_index": 10,
+                                        "group": "direct",
+                                        "ballot_type": "public",
+                                        "chain_voteplan_id": "1",
+                                    },
+                                    {
+                                        "chain_proposal_index": 12,
+                                        "group": "rep",
+                                        "ballot_type": "public",
+                                        "chain_voteplan_id": "2",
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "proposal_id": 2,
+                            "ballot": {
+                                "choices": ["yes", "no"],
+                                "voteplans": [
+                                    {
+                                        "chain_proposal_index": 11,
+                                        "group": "direct",
+                                        "ballot_type": "public",
+                                        "chain_voteplan_id": "1",
+                                    },
+                                    {
+                                        "chain_proposal_index": 13,
+                                        "group": "rep",
+                                        "ballot_type": "public",
+                                        "chain_voteplan_id": "2",
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "proposal_id": 3,
+                            "ballot": {
+                                "choices": ["yes", "no"],
+                                "voteplans": []
+                            }
+                        }
+                    ]
+                }
+            ])
         );
     }
 }

--- a/src/cat-data-service/src/service/v1/event/ballots.rs
+++ b/src/cat-data-service/src/service/v1/event/ballots.rs
@@ -1,0 +1,135 @@
+use crate::{
+    service::{handle_result, Error},
+    state::State,
+};
+use axum::{extract::Path, routing::get, Router};
+use event_db::types::event::{ballot::ObjectiveBallots, EventId};
+use std::sync::Arc;
+
+pub fn ballots(state: Arc<State>) -> Router {
+    Router::new().route(
+        "/ballots",
+        get(move |path| async { handle_result(ballots_exec(path, state).await).await }),
+    )
+}
+
+async fn ballots_exec(
+    Path(event): Path<EventId>,
+    state: Arc<State>,
+) -> Result<Vec<ObjectiveBallots>, Error> {
+    tracing::debug!("ballots_query, event: {0}", event.0,);
+
+    let ballot = state.event_db.get_event_ballots(event).await?;
+    Ok(ballot)
+}
+
+/// Need to setup and run a test event db instance
+/// To do it you can use the following commands:
+/// Prepare docker images
+/// ```
+/// earthly ./containers/event-db-migrations+docker --data=test
+/// ```
+/// Run event-db container
+/// ```
+/// docker-compose -f src/event-db/docker-compose.yml up migrations
+/// ```
+/// Also need establish `EVENT_DB_URL` env variable with the following value
+/// ```
+/// EVENT_DB_URL="postgres://catalyst-event-dev:CHANGE_ME@localhost/CatalystEventDev"
+/// ```
+/// https://github.com/input-output-hk/catalyst-core/tree/main/src/event-db/Readme.md
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::service::app;
+    use axum::{
+        body::{Body, HttpBody},
+        http::{Request, StatusCode},
+    };
+    use event_db::types::{
+        event::{
+            ballot::{
+                Ballot, BallotType, GroupVotePlans, ObjectiveChoices, ProposalBallot, VotePlan,
+            },
+            objective::ObjectiveId,
+            proposal::ProposalId,
+        },
+        registration::VoterGroupId,
+    };
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn ballots_test() {
+        let state = Arc::new(State::new(None).await.unwrap());
+        let app = app(state);
+
+        let request = Request::builder()
+            .uri(format!("/api/v1/event/{0}/ballots", 1))
+            .body(Body::empty())
+            .unwrap();
+        let response = app.clone().oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        assert_eq!(
+            serde_json::to_string(&vec![ObjectiveBallots {
+                objective_id: ObjectiveId(1),
+                ballots: vec![
+                    ProposalBallot {
+                        proposal_id: ProposalId(1),
+                        ballot: Ballot {
+                            choices: ObjectiveChoices(vec!["yes".to_string(), "no".to_string()]),
+                            voteplans: GroupVotePlans(vec![
+                                VotePlan {
+                                    chain_proposal_index: 10,
+                                    group: VoterGroupId("direct".to_string()),
+                                    ballot_type: BallotType("public".to_string()),
+                                    chain_voteplan_id: "1".to_string(),
+                                    encryption_key: None,
+                                },
+                                VotePlan {
+                                    chain_proposal_index: 12,
+                                    group: VoterGroupId("rep".to_string()),
+                                    ballot_type: BallotType("public".to_string()),
+                                    chain_voteplan_id: "2".to_string(),
+                                    encryption_key: None,
+                                }
+                            ]),
+                        },
+                    },
+                    ProposalBallot {
+                        proposal_id: ProposalId(2),
+                        ballot: Ballot {
+                            choices: ObjectiveChoices(vec!["yes".to_string(), "no".to_string()]),
+                            voteplans: GroupVotePlans(vec![
+                                VotePlan {
+                                    chain_proposal_index: 11,
+                                    group: VoterGroupId("direct".to_string()),
+                                    ballot_type: BallotType("public".to_string()),
+                                    chain_voteplan_id: "1".to_string(),
+                                    encryption_key: None,
+                                },
+                                VotePlan {
+                                    chain_proposal_index: 13,
+                                    group: VoterGroupId("rep".to_string()),
+                                    ballot_type: BallotType("public".to_string()),
+                                    chain_voteplan_id: "2".to_string(),
+                                    encryption_key: None,
+                                }
+                            ]),
+                        },
+                    },
+                    ProposalBallot {
+                        proposal_id: ProposalId(3),
+                        ballot: Ballot {
+                            choices: ObjectiveChoices(vec!["yes".to_string(), "no".to_string()]),
+                            voteplans: GroupVotePlans(vec![]),
+                        },
+                    }
+                ]
+            }],)
+            .unwrap(),
+            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                .unwrap()
+        );
+    }
+}

--- a/src/cat-data-service/src/service/v1/event/mod.rs
+++ b/src/cat-data-service/src/service/v1/event/mod.rs
@@ -85,12 +85,7 @@ mod tests {
         body::{Body, HttpBody},
         http::{Request, StatusCode},
     };
-    use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
-    use event_db::types::event::{
-        EventDetails, EventGoal, EventId, EventRegistration, EventSchedule, VotingPowerAlgorithm,
-        VotingPowerSettings,
-    };
-    use rust_decimal::Decimal;
+    use std::str::FromStr;
     use tower::ServiceExt;
 
     #[tokio::test]
@@ -105,144 +100,60 @@ mod tests {
         let response = app.clone().oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
-            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
-                .unwrap(),
-            serde_json::to_string(&Event {
-                summary: EventSummary {
-                    id: EventId(1),
-                    name: "Test Fund 1".to_string(),
-                    starts: Some(DateTime::<Utc>::from_utc(
-                        NaiveDateTime::new(
-                            NaiveDate::from_ymd_opt(2020, 5, 1).unwrap(),
-                            NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                        ),
-                        Utc
-                    )),
-                    ends: Some(DateTime::<Utc>::from_utc(
-                        NaiveDateTime::new(
-                            NaiveDate::from_ymd_opt(2020, 6, 1).unwrap(),
-                            NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                        ),
-                        Utc
-                    )),
-                    reg_checked: Some(DateTime::<Utc>::from_utc(
-                        NaiveDateTime::new(
-                            NaiveDate::from_ymd_opt(2020, 3, 31).unwrap(),
-                            NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                        ),
-                        Utc
-                    )),
-                    is_final: true,
-                },
-                details: EventDetails {
-                    voting_power: VotingPowerSettings {
-                        alg: VotingPowerAlgorithm::ThresholdStakedADA,
-                        min_ada: Some(1),
-                        max_pct: Some(Decimal::new(100, 0)),
+            serde_json::Value::from_str(
+                String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                    .unwrap()
+                    .as_str()
+            )
+            .unwrap(),
+            serde_json::json!(
+                {
+                    "id": 1,
+                    "name": "Test Fund 1",
+                    "starts": "2020-05-01T12:00:00+00:00",
+                    "ends": "2020-06-01T12:00:00+00:00",
+                    "reg_checked": "2020-03-31T12:00:00+00:00",
+                    "final": true,
+                    "voting_power": {
+                        "alg": "threshold_staked_ADA",
+                        "min_ada": 1,
+                        "max_pct": 100.0
                     },
-                    registration: EventRegistration {
-                        purpose: None,
-                        deadline: Some(DateTime::<Utc>::from_utc(
-                            NaiveDateTime::new(
-                                NaiveDate::from_ymd_opt(2020, 3, 31).unwrap(),
-                                NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                            ),
-                            Utc
-                        )),
-                        taken: Some(DateTime::<Utc>::from_utc(
-                            NaiveDateTime::new(
-                                NaiveDate::from_ymd_opt(2020, 3, 31).unwrap(),
-                                NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                            ),
-                            Utc
-                        ))
+                    "registration": {
+                        "deadline": "2020-03-31T12:00:00+00:00",
+                        "taken": "2020-03-31T12:00:00+00:00",
                     },
-                    schedule: EventSchedule {
-                        insight_sharing: Some(DateTime::<Utc>::from_utc(
-                            NaiveDateTime::new(
-                                NaiveDate::from_ymd_opt(2020, 3, 1).unwrap(),
-                                NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                            ),
-                            Utc
-                        )),
-                        proposal_submission: Some(DateTime::<Utc>::from_utc(
-                            NaiveDateTime::new(
-                                NaiveDate::from_ymd_opt(2020, 3, 1).unwrap(),
-                                NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                            ),
-                            Utc
-                        )),
-                        refine_proposals: Some(DateTime::<Utc>::from_utc(
-                            NaiveDateTime::new(
-                                NaiveDate::from_ymd_opt(2020, 3, 1).unwrap(),
-                                NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                            ),
-                            Utc
-                        )),
-                        finalize_proposals: Some(DateTime::<Utc>::from_utc(
-                            NaiveDateTime::new(
-                                NaiveDate::from_ymd_opt(2020, 3, 1).unwrap(),
-                                NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                            ),
-                            Utc
-                        )),
-                        proposal_assessment: Some(DateTime::<Utc>::from_utc(
-                            NaiveDateTime::new(
-                                NaiveDate::from_ymd_opt(2020, 3, 1).unwrap(),
-                                NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                            ),
-                            Utc
-                        )),
-                        assessment_qa_start: Some(DateTime::<Utc>::from_utc(
-                            NaiveDateTime::new(
-                                NaiveDate::from_ymd_opt(2020, 3, 1).unwrap(),
-                                NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                            ),
-                            Utc
-                        )),
-                        voting: Some(DateTime::<Utc>::from_utc(
-                            NaiveDateTime::new(
-                                NaiveDate::from_ymd_opt(2020, 5, 1).unwrap(),
-                                NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                            ),
-                            Utc
-                        )),
-                        tallying: Some(DateTime::<Utc>::from_utc(
-                            NaiveDateTime::new(
-                                NaiveDate::from_ymd_opt(2020, 6, 1).unwrap(),
-                                NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                            ),
-                            Utc
-                        )),
-                        tallying_end: Some(DateTime::<Utc>::from_utc(
-                            NaiveDateTime::new(
-                                NaiveDate::from_ymd_opt(2020, 7, 1).unwrap(),
-                                NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                            ),
-                            Utc
-                        )),
+                    "schedule": {
+                        "insight_sharing": "2020-03-01T12:00:00+00:00",
+                        "proposal_submission": "2020-03-01T12:00:00+00:00",
+                        "refine_proposals": "2020-03-01T12:00:00+00:00",
+                        "finalize_proposals": "2020-03-01T12:00:00+00:00",
+                        "proposal_assessment": "2020-03-01T12:00:00+00:00",
+                        "assessment_qa_start": "2020-03-01T12:00:00+00:00",
+                        "voting": "2020-05-01T12:00:00+00:00",
+                        "tallying": "2020-06-01T12:00:00+00:00",
+                        "tallying_end": "2020-07-01T12:00:00+00:00",
                     },
-                    goals: vec![
-                        EventGoal {
-                            idx: 1,
-                            name: "goal 1".to_string(),
+                    "goals": [
+                        {
+                            "idx": 1,
+                            "name": "goal 1"
                         },
-                        EventGoal {
-                            idx: 2,
-                            name: "goal 2".to_string(),
+                        {
+                            "idx": 2,
+                            "name": "goal 2"
                         },
-                        EventGoal {
-                            idx: 3,
-                            name: "goal 3".to_string(),
+                        {
+                            "idx": 3,
+                            "name": "goal 3"
                         },
-                        EventGoal {
-                            idx: 4,
-                            name: "goal 4".to_string(),
+                        {
+                            "idx": 4,
+                            "name": "goal 4"
                         }
-                    ],
-                },
-            },)
-            .unwrap()
+                    ]
+                }
+            )
         );
 
         let request = Request::builder()
@@ -265,97 +176,45 @@ mod tests {
         let response = app.clone().oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
-            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
-                .unwrap(),
-            serde_json::to_string(&vec![
-                EventSummary {
-                    id: EventId(1),
-                    name: "Test Fund 1".to_string(),
-                    starts: Some(DateTime::<Utc>::from_utc(
-                        NaiveDateTime::new(
-                            NaiveDate::from_ymd_opt(2020, 5, 1).unwrap(),
-                            NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                        ),
-                        Utc
-                    )),
-                    ends: Some(DateTime::<Utc>::from_utc(
-                        NaiveDateTime::new(
-                            NaiveDate::from_ymd_opt(2020, 6, 1).unwrap(),
-                            NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                        ),
-                        Utc
-                    )),
-                    reg_checked: Some(DateTime::<Utc>::from_utc(
-                        NaiveDateTime::new(
-                            NaiveDate::from_ymd_opt(2020, 3, 31).unwrap(),
-                            NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                        ),
-                        Utc
-                    )),
-                    is_final: true,
-                },
-                EventSummary {
-                    id: EventId(2),
-                    name: "Test Fund 2".to_string(),
-                    starts: Some(DateTime::<Utc>::from_utc(
-                        NaiveDateTime::new(
-                            NaiveDate::from_ymd_opt(2021, 5, 1).unwrap(),
-                            NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                        ),
-                        Utc
-                    )),
-                    ends: Some(DateTime::<Utc>::from_utc(
-                        NaiveDateTime::new(
-                            NaiveDate::from_ymd_opt(2021, 6, 1).unwrap(),
-                            NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                        ),
-                        Utc
-                    )),
-                    reg_checked: Some(DateTime::<Utc>::from_utc(
-                        NaiveDateTime::new(
-                            NaiveDate::from_ymd_opt(2021, 3, 31).unwrap(),
-                            NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                        ),
-                        Utc
-                    )),
-                    is_final: true,
-                },
-                EventSummary {
-                    id: EventId(3),
-                    name: "Test Fund 3".to_string(),
-                    starts: Some(DateTime::<Utc>::from_utc(
-                        NaiveDateTime::new(
-                            NaiveDate::from_ymd_opt(2022, 5, 1).unwrap(),
-                            NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                        ),
-                        Utc
-                    )),
-                    ends: Some(DateTime::<Utc>::from_utc(
-                        NaiveDateTime::new(
-                            NaiveDate::from_ymd_opt(2022, 6, 1).unwrap(),
-                            NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                        ),
-                        Utc
-                    )),
-                    reg_checked: Some(DateTime::<Utc>::from_utc(
-                        NaiveDateTime::new(
-                            NaiveDate::from_ymd_opt(2022, 3, 31).unwrap(),
-                            NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                        ),
-                        Utc
-                    )),
-                    is_final: true,
-                },
-                EventSummary {
-                    id: EventId(4),
-                    name: "Test Fund 4".to_string(),
-                    starts: None,
-                    ends: None,
-                    reg_checked: None,
-                    is_final: false,
-                }
-            ])
-            .unwrap()
+            serde_json::Value::from_str(
+                String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                    .unwrap()
+                    .as_str()
+            )
+            .unwrap(),
+            serde_json::json!(
+                [
+                    {
+                        "id": 1,
+                        "name": "Test Fund 1",
+                        "starts": "2020-05-01T12:00:00+00:00",
+                        "ends": "2020-06-01T12:00:00+00:00",
+                        "reg_checked": "2020-03-31T12:00:00+00:00",
+                        "final": true,
+                    },
+                    {
+                        "id": 2,
+                        "name": "Test Fund 2",
+                        "starts": "2021-05-01T12:00:00+00:00",
+                        "ends": "2021-06-01T12:00:00+00:00",
+                        "reg_checked": "2021-03-31T12:00:00+00:00",
+                        "final": true,
+                    },
+                    {
+                        "id": 3,
+                        "name": "Test Fund 3",
+                        "starts": "2022-05-01T12:00:00+00:00",
+                        "ends": "2022-06-01T12:00:00+00:00",
+                        "reg_checked": "2022-03-31T12:00:00+00:00",
+                        "final": true,
+                    },
+                    {
+                        "id": 4,
+                        "name": "Test Fund 4",
+                        "final": false,
+                    },
+                ]
+            )
         );
 
         let request = Request::builder()
@@ -365,71 +224,37 @@ mod tests {
         let response = app.clone().oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
-            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
-                .unwrap(),
-            serde_json::to_string(&vec![
-                EventSummary {
-                    id: EventId(2),
-                    name: "Test Fund 2".to_string(),
-                    starts: Some(DateTime::<Utc>::from_utc(
-                        NaiveDateTime::new(
-                            NaiveDate::from_ymd_opt(2021, 5, 1).unwrap(),
-                            NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                        ),
-                        Utc
-                    )),
-                    ends: Some(DateTime::<Utc>::from_utc(
-                        NaiveDateTime::new(
-                            NaiveDate::from_ymd_opt(2021, 6, 1).unwrap(),
-                            NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                        ),
-                        Utc
-                    )),
-                    reg_checked: Some(DateTime::<Utc>::from_utc(
-                        NaiveDateTime::new(
-                            NaiveDate::from_ymd_opt(2021, 3, 31).unwrap(),
-                            NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                        ),
-                        Utc
-                    )),
-                    is_final: true,
-                },
-                EventSummary {
-                    id: EventId(3),
-                    name: "Test Fund 3".to_string(),
-                    starts: Some(DateTime::<Utc>::from_utc(
-                        NaiveDateTime::new(
-                            NaiveDate::from_ymd_opt(2022, 5, 1).unwrap(),
-                            NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                        ),
-                        Utc
-                    )),
-                    ends: Some(DateTime::<Utc>::from_utc(
-                        NaiveDateTime::new(
-                            NaiveDate::from_ymd_opt(2022, 6, 1).unwrap(),
-                            NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                        ),
-                        Utc
-                    )),
-                    reg_checked: Some(DateTime::<Utc>::from_utc(
-                        NaiveDateTime::new(
-                            NaiveDate::from_ymd_opt(2022, 3, 31).unwrap(),
-                            NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                        ),
-                        Utc
-                    )),
-                    is_final: true,
-                },
-                EventSummary {
-                    id: EventId(4),
-                    name: "Test Fund 4".to_string(),
-                    starts: None,
-                    ends: None,
-                    reg_checked: None,
-                    is_final: false,
-                }
-            ])
-            .unwrap()
+            serde_json::Value::from_str(
+                String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                    .unwrap()
+                    .as_str()
+            )
+            .unwrap(),
+            serde_json::json!(
+                [
+                    {
+                        "id": 2,
+                        "name": "Test Fund 2",
+                        "starts": "2021-05-01T12:00:00+00:00",
+                        "ends": "2021-06-01T12:00:00+00:00",
+                        "reg_checked": "2021-03-31T12:00:00+00:00",
+                        "final": true,
+                    },
+                    {
+                        "id": 3,
+                        "name": "Test Fund 3",
+                        "starts": "2022-05-01T12:00:00+00:00",
+                        "ends": "2022-06-01T12:00:00+00:00",
+                        "reg_checked": "2022-03-31T12:00:00+00:00",
+                        "final": true,
+                    },
+                    {
+                        "id": 4,
+                        "name": "Test Fund 4",
+                        "final": false,
+                    },
+                ]
+            )
         );
 
         let request = Request::builder()
@@ -439,35 +264,24 @@ mod tests {
         let response = app.clone().oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
-            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
-                .unwrap(),
-            serde_json::to_string(&vec![EventSummary {
-                id: EventId(1),
-                name: "Test Fund 1".to_string(),
-                starts: Some(DateTime::<Utc>::from_utc(
-                    NaiveDateTime::new(
-                        NaiveDate::from_ymd_opt(2020, 5, 1).unwrap(),
-                        NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                    ),
-                    Utc
-                )),
-                ends: Some(DateTime::<Utc>::from_utc(
-                    NaiveDateTime::new(
-                        NaiveDate::from_ymd_opt(2020, 6, 1).unwrap(),
-                        NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                    ),
-                    Utc
-                )),
-                reg_checked: Some(DateTime::<Utc>::from_utc(
-                    NaiveDateTime::new(
-                        NaiveDate::from_ymd_opt(2020, 3, 31).unwrap(),
-                        NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                    ),
-                    Utc
-                )),
-                is_final: true,
-            },])
-            .unwrap()
+            serde_json::Value::from_str(
+                String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                    .unwrap()
+                    .as_str()
+            )
+            .unwrap(),
+            serde_json::json!(
+                [
+                    {
+                        "id": 1,
+                        "name": "Test Fund 1",
+                        "starts": "2020-05-01T12:00:00+00:00",
+                        "ends": "2020-06-01T12:00:00+00:00",
+                        "reg_checked": "2020-03-31T12:00:00+00:00",
+                        "final": true,
+                    },
+                ]
+            )
         );
 
         let request = Request::builder()
@@ -477,35 +291,24 @@ mod tests {
         let response = app.clone().oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
-            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
-                .unwrap(),
-            serde_json::to_string(&vec![EventSummary {
-                id: EventId(2),
-                name: "Test Fund 2".to_string(),
-                starts: Some(DateTime::<Utc>::from_utc(
-                    NaiveDateTime::new(
-                        NaiveDate::from_ymd_opt(2021, 5, 1).unwrap(),
-                        NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                    ),
-                    Utc
-                )),
-                ends: Some(DateTime::<Utc>::from_utc(
-                    NaiveDateTime::new(
-                        NaiveDate::from_ymd_opt(2021, 6, 1).unwrap(),
-                        NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                    ),
-                    Utc
-                )),
-                reg_checked: Some(DateTime::<Utc>::from_utc(
-                    NaiveDateTime::new(
-                        NaiveDate::from_ymd_opt(2021, 3, 31).unwrap(),
-                        NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                    ),
-                    Utc
-                )),
-                is_final: true,
-            },])
-            .unwrap()
+            serde_json::Value::from_str(
+                String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                    .unwrap()
+                    .as_str()
+            )
+            .unwrap(),
+            serde_json::json!(
+                [
+                    {
+                        "id": 2,
+                        "name": "Test Fund 2",
+                        "starts": "2021-05-01T12:00:00+00:00",
+                        "ends": "2021-06-01T12:00:00+00:00",
+                        "reg_checked": "2021-03-31T12:00:00+00:00",
+                        "final": true,
+                    },
+                ]
+            )
         );
 
         let request = Request::builder()

--- a/src/cat-data-service/src/service/v1/event/mod.rs
+++ b/src/cat-data-service/src/service/v1/event/mod.rs
@@ -1,3 +1,4 @@
+use super::LimitOffset;
 use crate::{
     service::{handle_result, Error},
     state::State,
@@ -10,12 +11,12 @@ use axum::{
 use event_db::types::event::{Event, EventId, EventSummary};
 use std::sync::Arc;
 
-use super::LimitOffset;
-
+mod ballots;
 mod objective;
 
 pub fn event(state: Arc<State>) -> Router {
     let objective = objective::objective(state.clone());
+    let ballots = ballots::ballots(state.clone());
 
     Router::new()
         .nest(
@@ -28,7 +29,8 @@ pub fn event(state: Arc<State>) -> Router {
                         move |path| async { handle_result(event_exec(path, state).await).await }
                     }),
                 )
-                .merge(objective),
+                .merge(objective)
+                .merge(ballots),
         )
         .route(
             "/events",

--- a/src/cat-data-service/src/service/v1/event/objective/ballots.rs
+++ b/src/cat-data-service/src/service/v1/event/objective/ballots.rs
@@ -47,13 +47,13 @@ async fn ballots_exec(
 /// https://github.com/input-output-hk/catalyst-core/tree/main/src/event-db/Readme.md
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
     use super::*;
     use crate::service::app;
     use axum::{
         body::{Body, HttpBody},
         http::{Request, StatusCode},
     };
+    use std::str::FromStr;
     use tower::ServiceExt;
 
     #[tokio::test]

--- a/src/cat-data-service/src/service/v1/event/objective/ballots.rs
+++ b/src/cat-data-service/src/service/v1/event/objective/ballots.rs
@@ -47,18 +47,12 @@ async fn ballots_exec(
 /// https://github.com/input-output-hk/catalyst-core/tree/main/src/event-db/Readme.md
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
     use super::*;
     use crate::service::app;
     use axum::{
         body::{Body, HttpBody},
         http::{Request, StatusCode},
-    };
-    use event_db::types::{
-        event::{
-            ballot::{Ballot, BallotType, GroupVotePlans, ObjectiveChoices, VotePlan},
-            proposal::ProposalId,
-        },
-        registration::VoterGroupId,
     };
     use tower::ServiceExt;
 
@@ -75,62 +69,63 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
 
         assert_eq!(
-            serde_json::to_string(&vec![
-                ProposalBallot {
-                    proposal_id: ProposalId(1),
-                    ballot: Ballot {
-                        choices: ObjectiveChoices(vec!["yes".to_string(), "no".to_string()]),
-                        voteplans: GroupVotePlans(vec![
-                            VotePlan {
-                                chain_proposal_index: 10,
-                                group: VoterGroupId("direct".to_string()),
-                                ballot_type: BallotType("public".to_string()),
-                                chain_voteplan_id: "1".to_string(),
-                                encryption_key: None,
-                            },
-                            VotePlan {
-                                chain_proposal_index: 12,
-                                group: VoterGroupId("rep".to_string()),
-                                ballot_type: BallotType("public".to_string()),
-                                chain_voteplan_id: "2".to_string(),
-                                encryption_key: None,
-                            }
-                        ]),
-                    },
-                },
-                ProposalBallot {
-                    proposal_id: ProposalId(2),
-                    ballot: Ballot {
-                        choices: ObjectiveChoices(vec!["yes".to_string(), "no".to_string()]),
-                        voteplans: GroupVotePlans(vec![
-                            VotePlan {
-                                chain_proposal_index: 11,
-                                group: VoterGroupId("direct".to_string()),
-                                ballot_type: BallotType("public".to_string()),
-                                chain_voteplan_id: "1".to_string(),
-                                encryption_key: None,
-                            },
-                            VotePlan {
-                                chain_proposal_index: 13,
-                                group: VoterGroupId("rep".to_string()),
-                                ballot_type: BallotType("public".to_string()),
-                                chain_voteplan_id: "2".to_string(),
-                                encryption_key: None,
-                            }
-                        ]),
-                    },
-                },
-                ProposalBallot {
-                    proposal_id: ProposalId(3),
-                    ballot: Ballot {
-                        choices: ObjectiveChoices(vec!["yes".to_string(), "no".to_string()]),
-                        voteplans: GroupVotePlans(vec![]),
-                    },
-                }
-            ])
+            serde_json::Value::from_str(
+                String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                    .unwrap()
+                    .as_str()
+            )
             .unwrap(),
-            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
-                .unwrap()
+            serde_json::json!(
+                [
+                    {
+                        "proposal_id": 1,
+                        "ballot": {
+                            "choices": ["yes", "no"],
+                            "voteplans": [
+                                {
+                                    "chain_proposal_index": 10,
+                                    "group": "direct",
+                                    "ballot_type": "public",
+                                    "chain_voteplan_id": "1",
+                                },
+                                {
+                                    "chain_proposal_index": 12,
+                                    "group": "rep",
+                                    "ballot_type": "public",
+                                    "chain_voteplan_id": "2",
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "proposal_id": 2,
+                        "ballot": {
+                            "choices": ["yes", "no"],
+                            "voteplans": [
+                                {
+                                    "chain_proposal_index": 11,
+                                    "group": "direct",
+                                    "ballot_type": "public",
+                                    "chain_voteplan_id": "1",
+                                },
+                                {
+                                    "chain_proposal_index": 13,
+                                    "group": "rep",
+                                    "ballot_type": "public",
+                                    "chain_voteplan_id": "2",
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "proposal_id": 3,
+                        "ballot": {
+                            "choices": ["yes", "no"],
+                            "voteplans": []
+                        }
+                    }
+                ]
+            )
         );
     }
 }

--- a/src/cat-data-service/src/service/v1/event/objective/ballots.rs
+++ b/src/cat-data-service/src/service/v1/event/objective/ballots.rs
@@ -1,0 +1,136 @@
+use crate::{
+    service::{handle_result, Error},
+    state::State,
+};
+use axum::{extract::Path, routing::get, Router};
+use event_db::types::event::{ballot::ProposalBallot, objective::ObjectiveId, EventId};
+use std::sync::Arc;
+
+pub fn ballots(state: Arc<State>) -> Router {
+    Router::new().route(
+        "/ballots",
+        get(move |path| async { handle_result(ballots_exec(path, state).await).await }),
+    )
+}
+
+async fn ballots_exec(
+    Path((event, objective)): Path<(EventId, ObjectiveId)>,
+    state: Arc<State>,
+) -> Result<Vec<ProposalBallot>, Error> {
+    tracing::debug!(
+        "ballots_query, event: {0}, objective: {1}",
+        event.0,
+        objective.0,
+    );
+
+    let ballot = state
+        .event_db
+        .get_objective_ballots(event, objective)
+        .await?;
+    Ok(ballot)
+}
+
+/// Need to setup and run a test event db instance
+/// To do it you can use the following commands:
+/// Prepare docker images
+/// ```
+/// earthly ./containers/event-db-migrations+docker --data=test
+/// ```
+/// Run event-db container
+/// ```
+/// docker-compose -f src/event-db/docker-compose.yml up migrations
+/// ```
+/// Also need establish `EVENT_DB_URL` env variable with the following value
+/// ```
+/// EVENT_DB_URL="postgres://catalyst-event-dev:CHANGE_ME@localhost/CatalystEventDev"
+/// ```
+/// https://github.com/input-output-hk/catalyst-core/tree/main/src/event-db/Readme.md
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::service::app;
+    use axum::{
+        body::{Body, HttpBody},
+        http::{Request, StatusCode},
+    };
+    use event_db::types::{
+        event::{
+            ballot::{Ballot, BallotType, GroupVotePlans, ObjectiveChoices, VotePlan},
+            proposal::ProposalId,
+        },
+        registration::VoterGroupId,
+    };
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn ballots_test() {
+        let state = Arc::new(State::new(None).await.unwrap());
+        let app = app(state);
+
+        let request = Request::builder()
+            .uri(format!("/api/v1/event/{0}/objective/{1}/ballots", 1, 1))
+            .body(Body::empty())
+            .unwrap();
+        let response = app.clone().oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        assert_eq!(
+            serde_json::to_string(&vec![
+                ProposalBallot {
+                    proposal_id: ProposalId(1),
+                    ballot: Ballot {
+                        choices: ObjectiveChoices(vec!["yes".to_string(), "no".to_string()]),
+                        voteplans: GroupVotePlans(vec![
+                            VotePlan {
+                                chain_proposal_index: 10,
+                                group: VoterGroupId("direct".to_string()),
+                                ballot_type: BallotType("public".to_string()),
+                                chain_voteplan_id: "1".to_string(),
+                                encryption_key: None,
+                            },
+                            VotePlan {
+                                chain_proposal_index: 12,
+                                group: VoterGroupId("rep".to_string()),
+                                ballot_type: BallotType("public".to_string()),
+                                chain_voteplan_id: "2".to_string(),
+                                encryption_key: None,
+                            }
+                        ]),
+                    },
+                },
+                ProposalBallot {
+                    proposal_id: ProposalId(2),
+                    ballot: Ballot {
+                        choices: ObjectiveChoices(vec!["yes".to_string(), "no".to_string()]),
+                        voteplans: GroupVotePlans(vec![
+                            VotePlan {
+                                chain_proposal_index: 11,
+                                group: VoterGroupId("direct".to_string()),
+                                ballot_type: BallotType("public".to_string()),
+                                chain_voteplan_id: "1".to_string(),
+                                encryption_key: None,
+                            },
+                            VotePlan {
+                                chain_proposal_index: 13,
+                                group: VoterGroupId("rep".to_string()),
+                                ballot_type: BallotType("public".to_string()),
+                                chain_voteplan_id: "2".to_string(),
+                                encryption_key: None,
+                            }
+                        ]),
+                    },
+                },
+                ProposalBallot {
+                    proposal_id: ProposalId(3),
+                    ballot: Ballot {
+                        choices: ObjectiveChoices(vec!["yes".to_string(), "no".to_string()]),
+                        voteplans: GroupVotePlans(vec![]),
+                    },
+                }
+            ])
+            .unwrap(),
+            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                .unwrap()
+        );
+    }
+}

--- a/src/cat-data-service/src/service/v1/event/objective/mod.rs
+++ b/src/cat-data-service/src/service/v1/event/objective/mod.rs
@@ -69,14 +69,7 @@ mod tests {
         body::{Body, HttpBody},
         http::{Request, StatusCode},
     };
-    use event_db::types::{
-        event::objective::{
-            ObjectiveDetails, ObjectiveId, ObjectiveSummary, ObjectiveSupplementalData,
-            ObjectiveType, RewardDefintion, VoterGroup,
-        },
-        registration::VoterGroupId,
-    };
-    use serde_json::json;
+    use std::str::FromStr;
     use tower::ServiceExt;
 
     #[tokio::test]
@@ -91,61 +84,54 @@ mod tests {
         let response = app.clone().oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
-            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
-                .unwrap(),
-            serde_json::to_string(&vec![
-                Objective {
-                    summary: ObjectiveSummary {
-                        id: ObjectiveId(1),
-                        objective_type: ObjectiveType {
-                            id: "catalyst-simple".to_string(),
-                            description: "A Simple choice".to_string()
+            serde_json::Value::from_str(
+                String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                    .unwrap()
+                    .as_str()
+            )
+            .unwrap(),
+            serde_json::json!(
+                [
+                    {
+                        "id": 1,
+                        "type": {
+                            "id": "catalyst-simple",
+                            "description": "A Simple choice"
                         },
-                        title: "title 1".to_string(),
-                        description: "description 1".to_string(),
-                    },
-                    details: ObjectiveDetails {
-                        groups: vec![
-                            VoterGroup {
-                                group: Some(VoterGroupId("direct".to_string())),
-                                voting_token: Some("voting token 1".to_string()),
+                        "title": "title 1",
+                        "description": "description 1",
+                        "groups": [
+                            {
+                                "group": "direct",
+                                "voting_token": "voting token 1"
                             },
-                            VoterGroup {
-                                group: Some(VoterGroupId("rep".to_string())),
-                                voting_token: Some("voting token 2".to_string()),
+                            {
+                                "group": "rep",
+                                "voting_token": "voting token 2"
                             }
                         ],
-                        reward: Some(RewardDefintion {
-                            currency: "ADA".to_string(),
-                            value: 100
-                        }),
-                        supplemental: Some(ObjectiveSupplementalData(json!(
-                            {
-                                "url":"objective 1 url",
-                                "sponsor": "objective 1 sponsor",
-                                "video": "objective 1 video"
-                            }
-                        ))),
-                    }
-                },
-                Objective {
-                    summary: ObjectiveSummary {
-                        id: ObjectiveId(2),
-                        objective_type: ObjectiveType {
-                            id: "catalyst-native".to_string(),
-                            description: "??".to_string()
+                        "reward": {
+                            "currency": "ADA",
+                            "value": 100
                         },
-                        title: "title 2".to_string(),
-                        description: "description 2".to_string(),
+                        "supplemental": {
+                            "url":"objective 1 url",
+                            "sponsor": "objective 1 sponsor",
+                            "video": "objective 1 video"
+                        }
                     },
-                    details: ObjectiveDetails {
-                        groups: Vec::new(),
-                        reward: None,
-                        supplemental: None,
+                    {
+                        "id": 2,
+                        "type": {
+                            "id": "catalyst-native",
+                            "description": "??"
+                        },
+                        "title": "title 2",
+                        "description": "description 2",
+                        "groups": [],
                     }
-                }
-            ])
-            .unwrap()
+                ]
+            )
         );
 
         let request = Request::builder()
@@ -155,43 +141,44 @@ mod tests {
         let response = app.clone().oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
-            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
-                .unwrap(),
-            serde_json::to_string(&vec![Objective {
-                summary: ObjectiveSummary {
-                    id: ObjectiveId(1),
-                    objective_type: ObjectiveType {
-                        id: "catalyst-simple".to_string(),
-                        description: "A Simple choice".to_string()
-                    },
-                    title: "title 1".to_string(),
-                    description: "description 1".to_string(),
-                },
-                details: ObjectiveDetails {
-                    groups: vec![
-                        VoterGroup {
-                            group: Some(VoterGroupId("direct".to_string())),
-                            voting_token: Some("voting token 1".to_string()),
+            serde_json::Value::from_str(
+                String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                    .unwrap()
+                    .as_str()
+            )
+            .unwrap(),
+            serde_json::json!(
+                [
+                    {
+                        "id": 1,
+                        "type": {
+                            "id": "catalyst-simple",
+                            "description": "A Simple choice"
                         },
-                        VoterGroup {
-                            group: Some(VoterGroupId("rep".to_string())),
-                            voting_token: Some("voting token 2".to_string()),
-                        }
-                    ],
-                    reward: Some(RewardDefintion {
-                        currency: "ADA".to_string(),
-                        value: 100
-                    }),
-                    supplemental: Some(ObjectiveSupplementalData(json!(
-                        {
+                        "title": "title 1",
+                        "description": "description 1",
+                        "groups": [
+                            {
+                                "group": "direct",
+                                "voting_token": "voting token 1"
+                            },
+                            {
+                                "group": "rep",
+                                "voting_token": "voting token 2"
+                            }
+                        ],
+                        "reward": {
+                            "currency": "ADA",
+                            "value": 100
+                        },
+                        "supplemental": {
                             "url":"objective 1 url",
                             "sponsor": "objective 1 sponsor",
                             "video": "objective 1 video"
                         }
-                    ))),
-                }
-            },])
-            .unwrap()
+                    },
+                ]
+            )
         );
 
         let request = Request::builder()
@@ -201,25 +188,26 @@ mod tests {
         let response = app.clone().oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
-            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
-                .unwrap(),
-            serde_json::to_string(&vec![Objective {
-                summary: ObjectiveSummary {
-                    id: ObjectiveId(2),
-                    objective_type: ObjectiveType {
-                        id: "catalyst-native".to_string(),
-                        description: "??".to_string()
-                    },
-                    title: "title 2".to_string(),
-                    description: "description 2".to_string(),
-                },
-                details: ObjectiveDetails {
-                    groups: Vec::new(),
-                    reward: None,
-                    supplemental: None,
-                }
-            }])
-            .unwrap()
+            serde_json::Value::from_str(
+                String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                    .unwrap()
+                    .as_str()
+            )
+            .unwrap(),
+            serde_json::json!(
+                [
+                    {
+                        "id": 2,
+                        "type": {
+                            "id": "catalyst-native",
+                            "description": "??"
+                        },
+                        "title": "title 2",
+                        "description": "description 2",
+                        "groups": [],
+                    }
+                ]
+            )
         );
 
         let request = Request::builder()

--- a/src/cat-data-service/src/service/v1/event/objective/mod.rs
+++ b/src/cat-data-service/src/service/v1/event/objective/mod.rs
@@ -10,15 +10,20 @@ use axum::{
 use event_db::types::event::{objective::Objective, EventId};
 use std::sync::Arc;
 
+mod ballots;
 mod proposal;
 mod review_type;
 
 pub fn objective(state: Arc<State>) -> Router {
     let proposal = proposal::proposal(state.clone());
     let review_type = review_type::review_type(state.clone());
+    let ballots = ballots::ballots(state.clone());
 
     Router::new()
-        .nest("/objective/:objective", proposal.merge(review_type))
+        .nest(
+            "/objective/:objective",
+            proposal.merge(review_type).merge(ballots),
+        )
         .route(
             "/objectives",
             get(move |path, query| async {

--- a/src/cat-data-service/src/service/v1/event/objective/proposal/ballot.rs
+++ b/src/cat-data-service/src/service/v1/event/objective/proposal/ballot.rs
@@ -1,0 +1,115 @@
+use crate::{
+    service::{handle_result, Error},
+    state::State,
+};
+use axum::{extract::Path, routing::get, Router};
+use event_db::types::event::{
+    ballot::Ballot, objective::ObjectiveId, proposal::ProposalId, EventId,
+};
+use std::sync::Arc;
+
+pub fn ballot(state: Arc<State>) -> Router {
+    Router::new().route(
+        "/ballot",
+        get(move |path| async { handle_result(ballot_exec(path, state).await).await }),
+    )
+}
+
+async fn ballot_exec(
+    Path((event, objective, proposal)): Path<(EventId, ObjectiveId, ProposalId)>,
+    state: Arc<State>,
+) -> Result<Ballot, Error> {
+    tracing::debug!(
+        "ballot_query, event: {0}, objective: {1}, proposal: {2}",
+        event.0,
+        objective.0,
+        proposal.0,
+    );
+
+    let ballot = state
+        .event_db
+        .get_ballot(event, objective, proposal)
+        .await?;
+    Ok(ballot)
+}
+
+/// Need to setup and run a test event db instance
+/// To do it you can use the following commands:
+/// Prepare docker images
+/// ```
+/// earthly ./containers/event-db-migrations+docker --data=test
+/// ```
+/// Run event-db container
+/// ```
+/// docker-compose -f src/event-db/docker-compose.yml up migrations
+/// ```
+/// Also need establish `EVENT_DB_URL` env variable with the following value
+/// ```
+/// EVENT_DB_URL="postgres://catalyst-event-dev:CHANGE_ME@localhost/CatalystEventDev"
+/// ```
+/// https://github.com/input-output-hk/catalyst-core/tree/main/src/event-db/Readme.md
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::service::app;
+    use axum::{
+        body::{Body, HttpBody},
+        http::{Request, StatusCode},
+    };
+    use event_db::types::{
+        event::ballot::{BallotType, GroupVotePlans, ObjectiveChoices, VotePlan},
+        registration::VoterGroupId,
+    };
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn ballot_test() {
+        let state = Arc::new(State::new(None).await.unwrap());
+        let app = app(state);
+
+        let request = Request::builder()
+            .uri(format!(
+                "/api/v1/event/{0}/objective/{1}/proposal/{2}/ballot",
+                1, 1, 1
+            ))
+            .body(Body::empty())
+            .unwrap();
+        let response = app.clone().oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        assert_eq!(
+            serde_json::to_string(&Ballot {
+                choices: ObjectiveChoices(vec!["yes".to_string(), "no".to_string()]),
+                voteplans: GroupVotePlans(vec![
+                    VotePlan {
+                        chain_proposal_index: 10,
+                        group: VoterGroupId("direct".to_string()),
+                        ballot_type: BallotType("public".to_string()),
+                        chain_voteplan_id: "1".to_string(),
+                        encryption_key: None,
+                    },
+                    VotePlan {
+                        chain_proposal_index: 12,
+                        group: VoterGroupId("rep".to_string()),
+                        ballot_type: BallotType("public".to_string()),
+                        chain_voteplan_id: "2".to_string(),
+                        encryption_key: None,
+                    }
+                ]),
+            })
+            .unwrap(),
+            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                .unwrap()
+        );
+
+        let request = Request::builder()
+            .uri(format!(
+                "/api/v1/event/{0}/objective/{1}/proposal/{2}/ballot",
+                3, 3, 3
+            ))
+            .body(Body::empty())
+            .unwrap();
+        let response = app.clone().oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+}

--- a/src/cat-data-service/src/service/v1/event/objective/proposal/mod.rs
+++ b/src/cat-data-service/src/service/v1/event/objective/proposal/mod.rs
@@ -14,10 +14,12 @@ use event_db::types::event::{
 };
 use std::sync::Arc;
 
+mod ballot;
 mod review;
 
 pub fn proposal(state: Arc<State>) -> Router {
     let review = review::review(state.clone());
+    let ballot = ballot::ballot(state.clone());
 
     Router::new()
         .nest(
@@ -30,7 +32,8 @@ pub fn proposal(state: Arc<State>) -> Router {
                         move |path| async { handle_result(proposal_exec(path, state).await).await }
                     }),
                 )
-                .merge(review),
+                .merge(review)
+                .merge(ballot),
         )
         .route(
             "/proposals",

--- a/src/cat-data-service/src/service/v1/event/objective/proposal/mod.rs
+++ b/src/cat-data-service/src/service/v1/event/objective/proposal/mod.rs
@@ -102,10 +102,7 @@ mod tests {
         body::{Body, HttpBody},
         http::{Request, StatusCode},
     };
-    use event_db::types::event::proposal::{
-        ProposalDetails, ProposalSupplementalDetails, ProposerDetails,
-    };
-    use serde_json::json;
+    use std::str::FromStr;
     use tower::ServiceExt;
 
     #[tokio::test]
@@ -122,38 +119,36 @@ mod tests {
             .unwrap();
         let response = app.clone().oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
-
         assert_eq!(
-            serde_json::to_string(&Proposal {
-                proposal_summary: ProposalSummary {
-                    id: 1,
-                    title: String::from("title 1"),
-                    summary: String::from("summary 1")
-                },
-                proposal_details: ProposalDetails {
-                    funds: 100,
-                    url: "url.xyz".to_string(),
-                    files: "files.xyz".to_string(),
-                    proposer: vec![ProposerDetails {
-                        name: "alice".to_string(),
-                        email: "alice@io".to_string(),
-                        url: "alice.prop.xyz".to_string(),
-                        payment_key:
-                            "b7a3c12dc0c8c748ab07525b701122b88bd78f600c76342d27f25e5f92444cde"
-                                .to_string()
-                    }],
-                    supplemental: Some(ProposalSupplementalDetails(json!(
-                        {
-                            "brief": "Brief explanation of a proposal",
-                            "goal": "The goal of the proposal is addressed to meet",
-                            "importance": "The importance of the proposal",
-                        }
-                    ))),
-                }
-            })
+            serde_json::Value::from_str(
+                String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                    .unwrap()
+                    .as_str()
+            )
             .unwrap(),
-            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
-                .unwrap()
+            serde_json::json!(
+                {
+                    "id": 1,
+                    "title": "title 1",
+                    "summary": "summary 1",
+                    "funds": 100,
+                    "url": "url.xyz",
+                    "files": "files.xyz",
+                    "proposer": [
+                        {
+                            "name": "alice",
+                            "email": "alice@io",
+                            "url": "alice.prop.xyz",
+                            "payment_key": "b7a3c12dc0c8c748ab07525b701122b88bd78f600c76342d27f25e5f92444cde"
+                        }
+                    ],
+                    "supplemental": {
+                        "brief": "Brief explanation of a proposal",
+                        "goal": "The goal of the proposal is addressed to meet",
+                        "importance": "The importance of the proposal",
+                    }
+                }
+            )
         );
 
         let request = Request::builder()
@@ -178,28 +173,30 @@ mod tests {
             .unwrap();
         let response = app.clone().oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
-
         assert_eq!(
-            serde_json::to_string(&vec![
-                ProposalSummary {
-                    id: 1,
-                    title: String::from("title 1"),
-                    summary: String::from("summary 1")
+            serde_json::Value::from_str(
+                String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                    .unwrap()
+                    .as_str()
+            )
+            .unwrap(),
+            serde_json::json!([
+                {
+                    "id": 1,
+                    "title": "title 1",
+                    "summary": "summary 1",
                 },
-                ProposalSummary {
-                    id: 2,
-                    title: String::from("title 2"),
-                    summary: String::from("summary 2")
+                {
+                    "id": 2,
+                    "title": "title 2",
+                    "summary": "summary 2",
                 },
-                ProposalSummary {
-                    id: 3,
-                    title: String::from("title 3"),
-                    summary: String::from("summary 3")
+                {
+                    "id": 3,
+                    "title": "title 3",
+                    "summary": "summary 3",
                 }
             ])
-            .unwrap(),
-            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
-                .unwrap()
         );
 
         let request = Request::builder()
@@ -211,23 +208,25 @@ mod tests {
             .unwrap();
         let response = app.clone().oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
-
         assert_eq!(
-            serde_json::to_string(&vec![
-                ProposalSummary {
-                    id: 1,
-                    title: String::from("title 1"),
-                    summary: String::from("summary 1")
+            serde_json::Value::from_str(
+                String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                    .unwrap()
+                    .as_str()
+            )
+            .unwrap(),
+            serde_json::json!([
+                {
+                    "id": 1,
+                    "title": "title 1",
+                    "summary": "summary 1",
                 },
-                ProposalSummary {
-                    id: 2,
-                    title: String::from("title 2"),
-                    summary: String::from("summary 2")
+                {
+                    "id": 2,
+                    "title": "title 2",
+                    "summary": "summary 2",
                 },
             ])
-            .unwrap(),
-            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
-                .unwrap()
         );
 
         let request = Request::builder()
@@ -239,23 +238,25 @@ mod tests {
             .unwrap();
         let response = app.clone().oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
-
         assert_eq!(
-            serde_json::to_string(&vec![
-                ProposalSummary {
-                    id: 2,
-                    title: String::from("title 2"),
-                    summary: String::from("summary 2")
+            serde_json::Value::from_str(
+                String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                    .unwrap()
+                    .as_str()
+            )
+            .unwrap(),
+            serde_json::json!([
+                {
+                    "id": 2,
+                    "title": "title 2",
+                    "summary": "summary 2",
                 },
-                ProposalSummary {
-                    id: 3,
-                    title: String::from("title 3"),
-                    summary: String::from("summary 3")
+                {
+                    "id": 3,
+                    "title": "title 3",
+                    "summary": "summary 3",
                 }
             ])
-            .unwrap(),
-            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
-                .unwrap()
         );
 
         let request = Request::builder()
@@ -267,16 +268,20 @@ mod tests {
             .unwrap();
         let response = app.clone().oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
-
         assert_eq!(
-            serde_json::to_string(&vec![ProposalSummary {
-                id: 2,
-                title: String::from("title 2"),
-                summary: String::from("summary 2")
-            },])
+            serde_json::Value::from_str(
+                String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                    .unwrap()
+                    .as_str()
+            )
             .unwrap(),
-            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
-                .unwrap()
+            serde_json::json!([
+                {
+                    "id": 2,
+                    "title": "title 2",
+                    "summary": "summary 2",
+                },
+            ])
         );
     }
 }

--- a/src/cat-data-service/src/service/v1/event/objective/proposal/review.rs
+++ b/src/cat-data-service/src/service/v1/event/objective/proposal/review.rs
@@ -63,7 +63,7 @@ mod tests {
         body::{Body, HttpBody},
         http::{Request, StatusCode},
     };
-    use event_db::types::event::review::Rating;
+    use std::str::FromStr;
     use tower::ServiceExt;
 
     #[tokio::test]
@@ -80,41 +80,43 @@ mod tests {
             .unwrap();
         let response = app.clone().oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
-
         assert_eq!(
-            serde_json::to_string(&vec![
-                AdvisorReview {
-                    assessor: "assessor 1".to_string(),
-                    ratings: vec![
-                        Rating {
-                            review_type: 1,
-                            score: 10,
-                            note: Some("note 1".to_string()),
-                        },
-                        Rating {
-                            review_type: 2,
-                            score: 15,
-                            note: Some("note 2".to_string()),
-                        },
-                        Rating {
-                            review_type: 5,
-                            score: 20,
-                            note: Some("note 3".to_string()),
-                        }
-                    ],
-                },
-                AdvisorReview {
-                    assessor: "assessor 2".to_string(),
-                    ratings: vec![],
-                },
-                AdvisorReview {
-                    assessor: "assessor 3".to_string(),
-                    ratings: vec![],
-                },
-            ])
+            serde_json::Value::from_str(
+                String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                    .unwrap()
+                    .as_str()
+            )
             .unwrap(),
-            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
-                .unwrap()
+            serde_json::json!([
+                {
+                    "assessor": "assessor 1",
+                    "ratings": [
+                        {
+                            "review_type": 1,
+                            "score": 10,
+                            "note": "note 1"
+                        },
+                        {
+                            "review_type": 2,
+                            "score": 15,
+                            "note": "note 2"
+                        },
+                        {
+                            "review_type": 5,
+                            "score": 20,
+                            "note": "note 3"
+                        }
+                    ]
+                },
+                {
+                    "assessor": "assessor 2",
+                    "ratings": []
+                },
+                {
+                    "assessor": "assessor 3",
+                    "ratings": []
+                }
+            ])
         );
 
         let request = Request::builder()
@@ -126,37 +128,39 @@ mod tests {
             .unwrap();
         let response = app.clone().oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
-
         assert_eq!(
-            serde_json::to_string(&vec![
-                AdvisorReview {
-                    assessor: "assessor 1".to_string(),
-                    ratings: vec![
-                        Rating {
-                            review_type: 1,
-                            score: 10,
-                            note: Some("note 1".to_string()),
+            serde_json::Value::from_str(
+                String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                    .unwrap()
+                    .as_str()
+            )
+            .unwrap(),
+            serde_json::json!([
+                {
+                    "assessor": "assessor 1",
+                    "ratings": [
+                        {
+                            "review_type": 1,
+                            "score": 10,
+                            "note": "note 1"
                         },
-                        Rating {
-                            review_type: 2,
-                            score: 15,
-                            note: Some("note 2".to_string()),
+                        {
+                            "review_type": 2,
+                            "score": 15,
+                            "note": "note 2"
                         },
-                        Rating {
-                            review_type: 5,
-                            score: 20,
-                            note: Some("note 3".to_string()),
+                        {
+                            "review_type": 5,
+                            "score": 20,
+                            "note": "note 3"
                         }
-                    ],
+                    ]
                 },
-                AdvisorReview {
-                    assessor: "assessor 2".to_string(),
-                    ratings: vec![],
+                {
+                    "assessor": "assessor 2",
+                    "ratings": []
                 },
             ])
-            .unwrap(),
-            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
-                .unwrap()
         );
 
         let request = Request::builder()
@@ -168,21 +172,23 @@ mod tests {
             .unwrap();
         let response = app.clone().oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
-
         assert_eq!(
-            serde_json::to_string(&vec![
-                AdvisorReview {
-                    assessor: "assessor 2".to_string(),
-                    ratings: vec![],
-                },
-                AdvisorReview {
-                    assessor: "assessor 3".to_string(),
-                    ratings: vec![],
-                },
-            ])
+            serde_json::Value::from_str(
+                String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                    .unwrap()
+                    .as_str()
+            )
             .unwrap(),
-            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
-                .unwrap()
+            serde_json::json!([
+                {
+                    "assessor": "assessor 2",
+                    "ratings": []
+                },
+                {
+                    "assessor": "assessor 3",
+                    "ratings": []
+                }
+            ])
         );
 
         let request = Request::builder()
@@ -194,15 +200,19 @@ mod tests {
             .unwrap();
         let response = app.clone().oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
-
         assert_eq!(
-            serde_json::to_string(&vec![AdvisorReview {
-                assessor: "assessor 2".to_string(),
-                ratings: vec![],
-            },])
+            serde_json::Value::from_str(
+                String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                    .unwrap()
+                    .as_str()
+            )
             .unwrap(),
-            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
-                .unwrap()
+            serde_json::json!([
+                {
+                    "assessor": "assessor 2",
+                    "ratings": []
+                },
+            ])
         );
     }
 }

--- a/src/cat-data-service/src/service/v1/event/objective/review_type.rs
+++ b/src/cat-data-service/src/service/v1/event/objective/review_type.rs
@@ -60,7 +60,7 @@ mod tests {
         body::{Body, HttpBody},
         http::{Request, StatusCode},
     };
-    use serde_json::json;
+    use std::str::FromStr;
     use tower::ServiceExt;
 
     #[tokio::test]
@@ -77,51 +77,51 @@ mod tests {
             .unwrap();
         let response = app.clone().oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
-
         assert_eq!(
-            serde_json::to_string(&vec![
-                ReviewType {
-                    id: 1,
-                    name: "impact".to_string(),
-                    description: Some("Impact Rating".to_string()),
-                    min: 0,
-                    max: 5,
-                    map: vec![],
-                    note: None,
-                    group: Some("review_group 1".to_string()),
-                },
-                ReviewType {
-                    id: 2,
-                    name: "feasibility".to_string(),
-                    description: Some("Feasibility Rating".to_string()),
-                    min: 0,
-                    max: 5,
-                    map: vec![],
-                    note: Some(true),
-                    group: Some("review_group 2".to_string()),
-                },
-                ReviewType {
-                    id: 5,
-                    name: "vpa_ranking".to_string(),
-                    description: Some("VPA Ranking of the review".to_string()),
-                    min: 0,
-                    max: 3,
-                    map: vec![
-                        json!(
-                            {"name":"Excellent","desc":"Excellent Review"}
-                        )
-                        .to_string(),
-                        json!({"name":"Good","desc":"Could be improved."}).to_string(),
-                        json!({"name":"FilteredOut","desc":"Exclude this review"}).to_string(),
-                        json!({"name":"NA", "desc":"Not Applicable"}).to_string()
-                    ],
-                    note: Some(false),
-                    group: None,
-                }
-            ])
+            serde_json::Value::from_str(
+                String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                    .unwrap()
+                    .as_str()
+            )
             .unwrap(),
-            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
-                .unwrap()
+            serde_json::json!(
+                [
+                    {
+                        "id": 1,
+                        "name": "impact",
+                        "description": "Impact Rating",
+                        "min": 0,
+                        "max": 5,
+                        "map": [],
+                        "group": "review_group 1",
+                        "note": null,
+                    },
+                    {
+                        "id": 2,
+                        "name": "feasibility",
+                        "description": "Feasibility Rating",
+                        "min": 0,
+                        "max": 5,
+                        "map": [],
+                        "note": true,
+                        "group": "review_group 2"
+                    },
+                    {
+                        "id": 5,
+                        "name": "vpa_ranking",
+                        "description": "VPA Ranking of the review",
+                        "min": 0,
+                        "max": 3,
+                        "map": [
+                            {"name": "Excellent", "desc": "Excellent Review"},
+                            {"name": "Good", "desc": "Could be improved."},
+                            {"name": "FilteredOut", "desc": "Exclude this review"},
+                            {"name": "NA", "desc": "Not Applicable"}
+                        ],
+                        "note": false,
+                    }
+                ]
+            )
         );
 
         let request = Request::builder()
@@ -133,33 +133,37 @@ mod tests {
             .unwrap();
         let response = app.clone().oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
-
         assert_eq!(
-            serde_json::to_string(&vec![
-                ReviewType {
-                    id: 1,
-                    name: "impact".to_string(),
-                    description: Some("Impact Rating".to_string()),
-                    min: 0,
-                    max: 5,
-                    map: vec![],
-                    note: None,
-                    group: Some("review_group 1".to_string()),
-                },
-                ReviewType {
-                    id: 2,
-                    name: "feasibility".to_string(),
-                    description: Some("Feasibility Rating".to_string()),
-                    min: 0,
-                    max: 5,
-                    map: vec![],
-                    note: Some(true),
-                    group: Some("review_group 2".to_string()),
-                },
-            ])
+            serde_json::Value::from_str(
+                String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                    .unwrap()
+                    .as_str()
+            )
             .unwrap(),
-            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
-                .unwrap()
+            serde_json::json!(
+                [
+                    {
+                        "id": 1,
+                        "name": "impact",
+                        "description": "Impact Rating",
+                        "min": 0,
+                        "max": 5,
+                        "map": [],
+                        "group": "review_group 1",
+                        "note": null,
+                    },
+                    {
+                        "id": 2,
+                        "name": "feasibility",
+                        "description": "Feasibility Rating",
+                        "min": 0,
+                        "max": 5,
+                        "map": [],
+                        "note": true,
+                        "group": "review_group 2"
+                    },
+                ]
+            )
         );
 
         let request = Request::builder()
@@ -171,41 +175,41 @@ mod tests {
             .unwrap();
         let response = app.clone().oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
-
         assert_eq!(
-            serde_json::to_string(&vec![
-                ReviewType {
-                    id: 2,
-                    name: "feasibility".to_string(),
-                    description: Some("Feasibility Rating".to_string()),
-                    min: 0,
-                    max: 5,
-                    map: vec![],
-                    note: Some(true),
-                    group: Some("review_group 2".to_string()),
-                },
-                ReviewType {
-                    id: 5,
-                    name: "vpa_ranking".to_string(),
-                    description: Some("VPA Ranking of the review".to_string()),
-                    min: 0,
-                    max: 3,
-                    map: vec![
-                        json!(
-                            {"name":"Excellent","desc":"Excellent Review"}
-                        )
-                        .to_string(),
-                        json!({"name":"Good","desc":"Could be improved."}).to_string(),
-                        json!({"name":"FilteredOut","desc":"Exclude this review"}).to_string(),
-                        json!({"name":"NA", "desc":"Not Applicable"}).to_string()
-                    ],
-                    note: Some(false),
-                    group: None,
-                }
-            ])
+            serde_json::Value::from_str(
+                String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                    .unwrap()
+                    .as_str()
+            )
             .unwrap(),
-            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
-                .unwrap()
+            serde_json::json!(
+                [
+                    {
+                        "id": 2,
+                        "name": "feasibility",
+                        "description": "Feasibility Rating",
+                        "min": 0,
+                        "max": 5,
+                        "map": [],
+                        "note": true,
+                        "group": "review_group 2"
+                    },
+                    {
+                        "id": 5,
+                        "name": "vpa_ranking",
+                        "description": "VPA Ranking of the review",
+                        "min": 0,
+                        "max": 3,
+                        "map": [
+                            {"name": "Excellent", "desc": "Excellent Review"},
+                            {"name": "Good", "desc": "Could be improved."},
+                            {"name": "FilteredOut", "desc": "Exclude this review"},
+                            {"name": "NA", "desc": "Not Applicable"}
+                        ],
+                        "note": false,
+                    }
+                ]
+            )
         );
 
         let request = Request::builder()
@@ -217,21 +221,27 @@ mod tests {
             .unwrap();
         let response = app.clone().oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
-
         assert_eq!(
-            serde_json::to_string(&vec![ReviewType {
-                id: 2,
-                name: "feasibility".to_string(),
-                description: Some("Feasibility Rating".to_string()),
-                min: 0,
-                max: 5,
-                map: vec![],
-                note: Some(true),
-                group: Some("review_group 2".to_string()),
-            },])
+            serde_json::Value::from_str(
+                String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                    .unwrap()
+                    .as_str()
+            )
             .unwrap(),
-            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
-                .unwrap()
+            serde_json::json!(
+                [
+                    {
+                        "id": 2,
+                        "name": "feasibility",
+                        "description": "Feasibility Rating",
+                        "min": 0,
+                        "max": 5,
+                        "map": [],
+                        "note": true,
+                        "group": "review_group 2"
+                    },
+                ]
+            )
         );
     }
 }

--- a/src/cat-data-service/src/service/v1/registration.rs
+++ b/src/cat-data-service/src/service/v1/registration.rs
@@ -90,14 +90,13 @@ async fn delegations_exec(
 /// https://github.com/input-output-hk/catalyst-core/tree/main/src/event-db/Readme.md
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
-
     use super::*;
     use crate::service::app;
     use axum::{
         body::{Body, HttpBody},
         http::{Request, StatusCode},
     };
+    use std::str::FromStr;
     use tower::ServiceExt;
 
     #[tokio::test]

--- a/src/cat-data-service/src/service/v1/registration.rs
+++ b/src/cat-data-service/src/service/v1/registration.rs
@@ -90,14 +90,14 @@ async fn delegations_exec(
 /// https://github.com/input-output-hk/catalyst-core/tree/main/src/event-db/Readme.md
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
     use super::*;
     use crate::service::app;
     use axum::{
         body::{Body, HttpBody},
         http::{Request, StatusCode},
     };
-    use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
-    use event_db::types::registration::{Delegation, VoterGroupId, VoterInfo};
     use tower::ServiceExt;
 
     #[tokio::test]
@@ -112,33 +112,26 @@ mod tests {
         let response = app.clone().oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
-            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
-                .unwrap(),
-            serde_json::to_string(&Voter {
-                voter_info: VoterInfo {
-                    voting_power: 250,
-                    voting_group: VoterGroupId("rep".to_string()),
-                    delegations_power: 250,
-                    delegations_count: 2,
-                    voting_power_saturation: 0.625,
-                },
-                as_at: DateTime::<Utc>::from_utc(
-                    NaiveDateTime::new(
-                        NaiveDate::from_ymd_opt(2022, 3, 31).unwrap(),
-                        NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                    ),
-                    Utc
-                ),
-                last_updated: DateTime::<Utc>::from_utc(
-                    NaiveDateTime::new(
-                        NaiveDate::from_ymd_opt(2022, 3, 31).unwrap(),
-                        NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                    ),
-                    Utc
-                ),
-                is_final: true,
-            })
-            .unwrap()
+            serde_json::Value::from_str(
+                String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                    .unwrap()
+                    .as_str()
+            )
+            .unwrap(),
+            serde_json::json!(
+                {
+                    "voter_info": {
+                        "voting_power": 250,
+                        "voting_group": "rep",
+                        "delegations_power": 250,
+                        "delegations_count": 2,
+                        "voting_power_saturation": 0.625
+                    },
+                    "as_at": "2022-03-31T12:00:00+00:00",
+                    "last_updated": "2022-03-31T12:00:00+00:00",
+                    "final": true
+                }
+            )
         );
 
         let request = Request::builder()
@@ -151,33 +144,26 @@ mod tests {
         let response = app.clone().oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
-            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
-                .unwrap(),
-            serde_json::to_string(&Voter {
-                voter_info: VoterInfo {
-                    voting_power: 250,
-                    voting_group: VoterGroupId("rep".to_string()),
-                    delegations_power: 250,
-                    delegations_count: 2,
-                    voting_power_saturation: 0.625,
-                },
-                as_at: DateTime::<Utc>::from_utc(
-                    NaiveDateTime::new(
-                        NaiveDate::from_ymd_opt(2020, 3, 31).unwrap(),
-                        NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                    ),
-                    Utc
-                ),
-                last_updated: DateTime::<Utc>::from_utc(
-                    NaiveDateTime::new(
-                        NaiveDate::from_ymd_opt(2020, 3, 31).unwrap(),
-                        NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                    ),
-                    Utc
-                ),
-                is_final: true,
-            })
-            .unwrap()
+            serde_json::Value::from_str(
+                String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                    .unwrap()
+                    .as_str()
+            )
+            .unwrap(),
+            serde_json::json!(
+                {
+                    "voter_info": {
+                        "voting_power": 250,
+                        "voting_group": "rep",
+                        "delegations_power": 250,
+                        "delegations_count": 2,
+                        "voting_power_saturation": 0.625
+                    },
+                    "as_at": "2020-03-31T12:00:00+00:00",
+                    "last_updated": "2020-03-31T12:00:00+00:00",
+                    "final": true
+                }
+            )
         );
 
         let request = Request::builder()
@@ -213,42 +199,35 @@ mod tests {
         let response = app.clone().oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
-            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
-                .unwrap(),
-            serde_json::to_string(&Delegator {
-                delegations: vec![
-                    Delegation {
-                        voting_key: "voting_key_1".to_string(),
-                        group: VoterGroupId("rep".to_string()),
-                        weight: 1,
-                        value: 140
-                    },
-                    Delegation {
-                        voting_key: "voting_key_2".to_string(),
-                        group: VoterGroupId("rep".to_string()),
-                        weight: 1,
-                        value: 100
-                    }
-                ],
-                raw_power: 240,
-                total_power: 1000,
-                as_at: DateTime::<Utc>::from_utc(
-                    NaiveDateTime::new(
-                        NaiveDate::from_ymd_opt(2022, 3, 31).unwrap(),
-                        NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                    ),
-                    Utc
-                ),
-                last_updated: DateTime::<Utc>::from_utc(
-                    NaiveDateTime::new(
-                        NaiveDate::from_ymd_opt(2022, 3, 31).unwrap(),
-                        NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                    ),
-                    Utc
-                ),
-                is_final: true
-            })
-            .unwrap()
+            serde_json::Value::from_str(
+                String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                    .unwrap()
+                    .as_str()
+            )
+            .unwrap(),
+            serde_json::json!(
+                {
+                    "delegations": [
+                        {
+                            "voting_key": "voting_key_1",
+                            "group": "rep",
+                            "weight": 1,
+                            "value": 140
+                        },
+                        {
+                            "voting_key": "voting_key_2",
+                            "group": "rep",
+                            "weight": 1,
+                            "value": 100
+                        },
+                    ],
+                    "raw_power": 240,
+                    "total_power": 1000,
+                    "as_at": "2022-03-31T12:00:00+00:00",
+                    "last_updated": "2022-03-31T12:00:00+00:00",
+                    "final": true
+                }
+            )
         );
 
         let request = Request::builder()
@@ -261,42 +240,35 @@ mod tests {
         let response = app.clone().oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
-            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
-                .unwrap(),
-            serde_json::to_string(&Delegator {
-                delegations: vec![
-                    Delegation {
-                        voting_key: "voting_key_1".to_string(),
-                        group: VoterGroupId("rep".to_string()),
-                        weight: 1,
-                        value: 140
-                    },
-                    Delegation {
-                        voting_key: "voting_key_2".to_string(),
-                        group: VoterGroupId("rep".to_string()),
-                        weight: 1,
-                        value: 100
-                    }
-                ],
-                raw_power: 240,
-                total_power: 1000,
-                as_at: DateTime::<Utc>::from_utc(
-                    NaiveDateTime::new(
-                        NaiveDate::from_ymd_opt(2020, 3, 31).unwrap(),
-                        NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                    ),
-                    Utc
-                ),
-                last_updated: DateTime::<Utc>::from_utc(
-                    NaiveDateTime::new(
-                        NaiveDate::from_ymd_opt(2020, 3, 31).unwrap(),
-                        NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                    ),
-                    Utc
-                ),
-                is_final: true
-            })
-            .unwrap()
+            serde_json::Value::from_str(
+                String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                    .unwrap()
+                    .as_str()
+            )
+            .unwrap(),
+            serde_json::json!(
+                {
+                    "delegations": [
+                        {
+                            "voting_key": "voting_key_1",
+                            "group": "rep",
+                            "weight": 1,
+                            "value": 140
+                        },
+                        {
+                            "voting_key": "voting_key_2",
+                            "group": "rep",
+                            "weight": 1,
+                            "value": 100
+                        },
+                    ],
+                    "raw_power": 240,
+                    "total_power": 1000,
+                    "as_at": "2020-03-31T12:00:00+00:00",
+                    "last_updated": "2020-03-31T12:00:00+00:00",
+                    "final": true
+                }
+            )
         );
 
         let request = Request::builder()

--- a/src/cat-data-service/src/service/v1/search.rs
+++ b/src/cat-data-service/src/service/v1/search.rs
@@ -67,16 +67,7 @@ mod tests {
         body::{Body, HttpBody},
         http::{header, Method, Request, StatusCode},
     };
-    use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
-    use event_db::types::{
-        event::{
-            objective::{ObjectiveId, ObjectiveSummary, ObjectiveType},
-            proposal::ProposalSummary,
-            EventId, EventSummary,
-        },
-        search::ValueResults,
-    };
-    use serde_json::json;
+    use std::str::FromStr;
     use tower::ServiceExt;
 
     #[tokio::test]
@@ -89,7 +80,7 @@ mod tests {
             .uri("/api/v1/search".to_string())
             .header(header::CONTENT_TYPE, "application/json")
             .body(Body::from(
-                json!({
+                serde_json::json!({
                     "table": "events",
                     "filter": [{
                         "column": "description",
@@ -105,100 +96,46 @@ mod tests {
         let response = app.clone().oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
-            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
-                .unwrap(),
-            serde_json::to_string(&SearchResult {
-                total: 4,
-                results: Some(ValueResults::Events(vec![
-                    EventSummary {
-                        id: EventId(1),
-                        name: "Test Fund 1".to_string(),
-                        starts: Some(DateTime::<Utc>::from_utc(
-                            NaiveDateTime::new(
-                                NaiveDate::from_ymd_opt(2020, 5, 1).unwrap(),
-                                NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                            ),
-                            Utc
-                        )),
-                        ends: Some(DateTime::<Utc>::from_utc(
-                            NaiveDateTime::new(
-                                NaiveDate::from_ymd_opt(2020, 6, 1).unwrap(),
-                                NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                            ),
-                            Utc
-                        )),
-                        reg_checked: Some(DateTime::<Utc>::from_utc(
-                            NaiveDateTime::new(
-                                NaiveDate::from_ymd_opt(2020, 3, 31).unwrap(),
-                                NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                            ),
-                            Utc
-                        )),
-                        is_final: true,
+            serde_json::Value::from_str(
+                String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                    .unwrap()
+                    .as_str()
+            )
+            .unwrap(),
+            serde_json::json!({
+                "total": 4,
+                "results": [
+                    {
+                        "id": 1,
+                        "name": "Test Fund 1",
+                        "starts": "2020-05-01T12:00:00+00:00",
+                        "ends": "2020-06-01T12:00:00+00:00",
+                        "reg_checked": "2020-03-31T12:00:00+00:00",
+                        "final": true
                     },
-                    EventSummary {
-                        id: EventId(2),
-                        name: "Test Fund 2".to_string(),
-                        starts: Some(DateTime::<Utc>::from_utc(
-                            NaiveDateTime::new(
-                                NaiveDate::from_ymd_opt(2021, 5, 1).unwrap(),
-                                NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                            ),
-                            Utc
-                        )),
-                        ends: Some(DateTime::<Utc>::from_utc(
-                            NaiveDateTime::new(
-                                NaiveDate::from_ymd_opt(2021, 6, 1).unwrap(),
-                                NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                            ),
-                            Utc
-                        )),
-                        reg_checked: Some(DateTime::<Utc>::from_utc(
-                            NaiveDateTime::new(
-                                NaiveDate::from_ymd_opt(2021, 3, 31).unwrap(),
-                                NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                            ),
-                            Utc
-                        )),
-                        is_final: true,
+                    {
+                        "id": 2,
+                        "name": "Test Fund 2",
+                        "starts": "2021-05-01T12:00:00+00:00",
+                        "ends": "2021-06-01T12:00:00+00:00",
+                        "reg_checked": "2021-03-31T12:00:00+00:00",
+                        "final": true
                     },
-                    EventSummary {
-                        id: EventId(3),
-                        name: "Test Fund 3".to_string(),
-                        starts: Some(DateTime::<Utc>::from_utc(
-                            NaiveDateTime::new(
-                                NaiveDate::from_ymd_opt(2022, 5, 1).unwrap(),
-                                NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                            ),
-                            Utc
-                        )),
-                        ends: Some(DateTime::<Utc>::from_utc(
-                            NaiveDateTime::new(
-                                NaiveDate::from_ymd_opt(2022, 6, 1).unwrap(),
-                                NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                            ),
-                            Utc
-                        )),
-                        reg_checked: Some(DateTime::<Utc>::from_utc(
-                            NaiveDateTime::new(
-                                NaiveDate::from_ymd_opt(2022, 3, 31).unwrap(),
-                                NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                            ),
-                            Utc
-                        )),
-                        is_final: true,
+                    {
+                        "id": 3,
+                        "name": "Test Fund 3",
+                        "starts": "2022-05-01T12:00:00+00:00",
+                        "ends": "2022-06-01T12:00:00+00:00",
+                        "reg_checked": "2022-03-31T12:00:00+00:00",
+                        "final": true
                     },
-                    EventSummary {
-                        id: EventId(4),
-                        name: "Test Fund 4".to_string(),
-                        starts: None,
-                        ends: None,
-                        reg_checked: None,
-                        is_final: false,
-                    },
-                ]))
+                    {
+                        "id": 4,
+                        "name": "Test Fund 4",
+                        "final": false
+                    }
+                ]
             })
-            .unwrap()
         );
 
         let request = Request::builder()
@@ -206,7 +143,7 @@ mod tests {
             .uri("/api/v1/search?total=true".to_string())
             .header(header::CONTENT_TYPE, "application/json")
             .body(Body::from(
-                json!({
+                serde_json::json!({
                     "table": "events",
                     "filter": [{
                         "column": "description",
@@ -222,13 +159,15 @@ mod tests {
         let response = app.clone().oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
-            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
-                .unwrap(),
-            serde_json::to_string(&SearchResult {
-                total: 4,
-                results: None
+            serde_json::Value::from_str(
+                String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                    .unwrap()
+                    .as_str()
+            )
+            .unwrap(),
+            serde_json::json!({
+                "total": 4,
             })
-            .unwrap()
         );
 
         let request = Request::builder()
@@ -236,7 +175,7 @@ mod tests {
             .uri("/api/v1/search".to_string())
             .header(header::CONTENT_TYPE, "application/json")
             .body(Body::from(
-                json!({
+                serde_json::json!({
                     "table": "events",
                     "filter": [{
                         "column": "description",
@@ -253,100 +192,46 @@ mod tests {
         let response = app.clone().oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
-            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
-                .unwrap(),
-            serde_json::to_string(&SearchResult {
-                total: 4,
-                results: Some(ValueResults::Events(vec![
-                    EventSummary {
-                        id: EventId(4),
-                        name: "Test Fund 4".to_string(),
-                        starts: None,
-                        ends: None,
-                        reg_checked: None,
-                        is_final: false,
+            serde_json::Value::from_str(
+                String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                    .unwrap()
+                    .as_str()
+            )
+            .unwrap(),
+            serde_json::json!({
+                "total": 4,
+                "results": [
+                    {
+                        "id": 4,
+                        "name": "Test Fund 4",
+                        "final": false
                     },
-                    EventSummary {
-                        id: EventId(3),
-                        name: "Test Fund 3".to_string(),
-                        starts: Some(DateTime::<Utc>::from_utc(
-                            NaiveDateTime::new(
-                                NaiveDate::from_ymd_opt(2022, 5, 1).unwrap(),
-                                NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                            ),
-                            Utc
-                        )),
-                        ends: Some(DateTime::<Utc>::from_utc(
-                            NaiveDateTime::new(
-                                NaiveDate::from_ymd_opt(2022, 6, 1).unwrap(),
-                                NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                            ),
-                            Utc
-                        )),
-                        reg_checked: Some(DateTime::<Utc>::from_utc(
-                            NaiveDateTime::new(
-                                NaiveDate::from_ymd_opt(2022, 3, 31).unwrap(),
-                                NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                            ),
-                            Utc
-                        )),
-                        is_final: true,
+                    {
+                        "id": 3,
+                        "name": "Test Fund 3",
+                        "starts": "2022-05-01T12:00:00+00:00",
+                        "ends": "2022-06-01T12:00:00+00:00",
+                        "reg_checked": "2022-03-31T12:00:00+00:00",
+                        "final": true
                     },
-                    EventSummary {
-                        id: EventId(2),
-                        name: "Test Fund 2".to_string(),
-                        starts: Some(DateTime::<Utc>::from_utc(
-                            NaiveDateTime::new(
-                                NaiveDate::from_ymd_opt(2021, 5, 1).unwrap(),
-                                NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                            ),
-                            Utc
-                        )),
-                        ends: Some(DateTime::<Utc>::from_utc(
-                            NaiveDateTime::new(
-                                NaiveDate::from_ymd_opt(2021, 6, 1).unwrap(),
-                                NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                            ),
-                            Utc
-                        )),
-                        reg_checked: Some(DateTime::<Utc>::from_utc(
-                            NaiveDateTime::new(
-                                NaiveDate::from_ymd_opt(2021, 3, 31).unwrap(),
-                                NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                            ),
-                            Utc
-                        )),
-                        is_final: true,
+                    {
+                        "id": 2,
+                        "name": "Test Fund 2",
+                        "starts": "2021-05-01T12:00:00+00:00",
+                        "ends": "2021-06-01T12:00:00+00:00",
+                        "reg_checked": "2021-03-31T12:00:00+00:00",
+                        "final": true
                     },
-                    EventSummary {
-                        id: EventId(1),
-                        name: "Test Fund 1".to_string(),
-                        starts: Some(DateTime::<Utc>::from_utc(
-                            NaiveDateTime::new(
-                                NaiveDate::from_ymd_opt(2020, 5, 1).unwrap(),
-                                NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                            ),
-                            Utc
-                        )),
-                        ends: Some(DateTime::<Utc>::from_utc(
-                            NaiveDateTime::new(
-                                NaiveDate::from_ymd_opt(2020, 6, 1).unwrap(),
-                                NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                            ),
-                            Utc
-                        )),
-                        reg_checked: Some(DateTime::<Utc>::from_utc(
-                            NaiveDateTime::new(
-                                NaiveDate::from_ymd_opt(2020, 3, 31).unwrap(),
-                                NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                            ),
-                            Utc
-                        )),
-                        is_final: true,
-                    },
-                ]))
+                    {
+                        "id": 1,
+                        "name": "Test Fund 1",
+                        "starts": "2020-05-01T12:00:00+00:00",
+                        "ends": "2020-06-01T12:00:00+00:00",
+                        "reg_checked": "2020-03-31T12:00:00+00:00",
+                        "final": true
+                    }
+                ]
             })
-            .unwrap()
         );
 
         let request = Request::builder()
@@ -354,7 +239,7 @@ mod tests {
             .uri(format!("/api/v1/search?limit={0}", 2))
             .header(header::CONTENT_TYPE, "application/json")
             .body(Body::from(
-                json!({
+                serde_json::json!({
                     "table": "events",
                     "filter": [{
                         "column": "description",
@@ -371,48 +256,32 @@ mod tests {
         let response = app.clone().oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
-            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
-                .unwrap(),
-            serde_json::to_string(&SearchResult {
-                total: 2,
-                results: Some(ValueResults::Events(vec![
-                    EventSummary {
-                        id: EventId(4),
-                        name: "Test Fund 4".to_string(),
-                        starts: None,
-                        ends: None,
-                        reg_checked: None,
-                        is_final: false,
-                    },
-                    EventSummary {
-                        id: EventId(3),
-                        name: "Test Fund 3".to_string(),
-                        starts: Some(DateTime::<Utc>::from_utc(
-                            NaiveDateTime::new(
-                                NaiveDate::from_ymd_opt(2022, 5, 1).unwrap(),
-                                NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                            ),
-                            Utc
-                        )),
-                        ends: Some(DateTime::<Utc>::from_utc(
-                            NaiveDateTime::new(
-                                NaiveDate::from_ymd_opt(2022, 6, 1).unwrap(),
-                                NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                            ),
-                            Utc
-                        )),
-                        reg_checked: Some(DateTime::<Utc>::from_utc(
-                            NaiveDateTime::new(
-                                NaiveDate::from_ymd_opt(2022, 3, 31).unwrap(),
-                                NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                            ),
-                            Utc
-                        )),
-                        is_final: true,
-                    },
-                ]))
-            })
-            .unwrap()
+            serde_json::Value::from_str(
+                String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                    .unwrap()
+                    .as_str()
+            )
+            .unwrap(),
+            serde_json::json!(
+                {
+                    "total": 2,
+                    "results": [
+                        {
+                            "id": 4,
+                            "name": "Test Fund 4",
+                            "final": false
+                        },
+                        {
+                            "id": 3,
+                            "name": "Test Fund 3",
+                            "starts": "2022-05-01T12:00:00+00:00",
+                            "ends": "2022-06-01T12:00:00+00:00",
+                            "reg_checked": "2022-03-31T12:00:00+00:00",
+                            "final": true
+                        }
+                    ]
+                }
+            ),
         );
 
         let request = Request::builder()
@@ -420,7 +289,7 @@ mod tests {
             .uri(format!("/api/v1/search?offset={0}", 2))
             .header(header::CONTENT_TYPE, "application/json")
             .body(Body::from(
-                json!({
+                serde_json::json!({
                     "table": "events",
                     "filter": [{
                         "column": "description",
@@ -437,66 +306,35 @@ mod tests {
         let response = app.clone().oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
-            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
-                .unwrap(),
-            serde_json::to_string(&SearchResult {
-                total: 2,
-                results: Some(ValueResults::Events(vec![
-                    EventSummary {
-                        id: EventId(2),
-                        name: "Test Fund 2".to_string(),
-                        starts: Some(DateTime::<Utc>::from_utc(
-                            NaiveDateTime::new(
-                                NaiveDate::from_ymd_opt(2021, 5, 1).unwrap(),
-                                NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                            ),
-                            Utc
-                        )),
-                        ends: Some(DateTime::<Utc>::from_utc(
-                            NaiveDateTime::new(
-                                NaiveDate::from_ymd_opt(2021, 6, 1).unwrap(),
-                                NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                            ),
-                            Utc
-                        )),
-                        reg_checked: Some(DateTime::<Utc>::from_utc(
-                            NaiveDateTime::new(
-                                NaiveDate::from_ymd_opt(2021, 3, 31).unwrap(),
-                                NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                            ),
-                            Utc
-                        )),
-                        is_final: true,
-                    },
-                    EventSummary {
-                        id: EventId(1),
-                        name: "Test Fund 1".to_string(),
-                        starts: Some(DateTime::<Utc>::from_utc(
-                            NaiveDateTime::new(
-                                NaiveDate::from_ymd_opt(2020, 5, 1).unwrap(),
-                                NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                            ),
-                            Utc
-                        )),
-                        ends: Some(DateTime::<Utc>::from_utc(
-                            NaiveDateTime::new(
-                                NaiveDate::from_ymd_opt(2020, 6, 1).unwrap(),
-                                NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                            ),
-                            Utc
-                        )),
-                        reg_checked: Some(DateTime::<Utc>::from_utc(
-                            NaiveDateTime::new(
-                                NaiveDate::from_ymd_opt(2020, 3, 31).unwrap(),
-                                NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                            ),
-                            Utc
-                        )),
-                        is_final: true,
-                    },
-                ]))
-            })
-            .unwrap()
+            serde_json::Value::from_str(
+                String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                    .unwrap()
+                    .as_str()
+            )
+            .unwrap(),
+            serde_json::json!(
+                {
+                    "total": 2,
+                    "results": [
+                        {
+                            "id": 2,
+                            "name": "Test Fund 2",
+                            "starts": "2021-05-01T12:00:00+00:00",
+                            "ends": "2021-06-01T12:00:00+00:00",
+                            "reg_checked": "2021-03-31T12:00:00+00:00",
+                            "final": true
+                        },
+                        {
+                            "id": 1,
+                            "name": "Test Fund 1",
+                            "starts": "2020-05-01T12:00:00+00:00",
+                            "ends": "2020-06-01T12:00:00+00:00",
+                            "reg_checked": "2020-03-31T12:00:00+00:00",
+                            "final": true
+                        }
+                    ]
+                }
+            ),
         );
 
         let request = Request::builder()
@@ -504,7 +342,7 @@ mod tests {
             .uri(format!("/api/v1/search?limit={0}&offset={1}", 1, 1))
             .header(header::CONTENT_TYPE, "application/json")
             .body(Body::from(
-                json!({
+                serde_json::json!({
                     "table": "events",
                     "filter": [{
                         "column": "description",
@@ -521,38 +359,27 @@ mod tests {
         let response = app.clone().oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
-            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
-                .unwrap(),
-            serde_json::to_string(&SearchResult {
-                total: 1,
-                results: Some(ValueResults::Events(vec![EventSummary {
-                    id: EventId(3),
-                    name: "Test Fund 3".to_string(),
-                    starts: Some(DateTime::<Utc>::from_utc(
-                        NaiveDateTime::new(
-                            NaiveDate::from_ymd_opt(2022, 5, 1).unwrap(),
-                            NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                        ),
-                        Utc
-                    )),
-                    ends: Some(DateTime::<Utc>::from_utc(
-                        NaiveDateTime::new(
-                            NaiveDate::from_ymd_opt(2022, 6, 1).unwrap(),
-                            NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                        ),
-                        Utc
-                    )),
-                    reg_checked: Some(DateTime::<Utc>::from_utc(
-                        NaiveDateTime::new(
-                            NaiveDate::from_ymd_opt(2022, 3, 31).unwrap(),
-                            NaiveTime::from_hms_opt(12, 0, 0).unwrap()
-                        ),
-                        Utc
-                    )),
-                    is_final: true,
-                },]))
-            })
-            .unwrap()
+            serde_json::Value::from_str(
+                String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                    .unwrap()
+                    .as_str()
+            )
+            .unwrap(),
+            serde_json::json!(
+                {
+                    "total": 1,
+                    "results": [
+                        {
+                            "id": 3,
+                            "name": "Test Fund 3",
+                            "starts": "2022-05-01T12:00:00+00:00",
+                            "ends": "2022-06-01T12:00:00+00:00",
+                            "reg_checked": "2022-03-31T12:00:00+00:00",
+                            "final": true
+                        }
+                    ]
+                }
+            )
         );
 
         let request = Request::builder()
@@ -560,7 +387,7 @@ mod tests {
             .uri("/api/v1/search".to_string())
             .header(header::CONTENT_TYPE, "application/json")
             .body(Body::from(
-                json!({
+                serde_json::json!({
                     "table": "events",
                     "filter": [{
                         "column": "funds",
@@ -584,7 +411,7 @@ mod tests {
             .uri("/api/v1/search".to_string())
             .header(header::CONTENT_TYPE, "application/json")
             .body(Body::from(
-                json!({
+                serde_json::json!({
                     "table": "objectives",
                     "filter": [{
                         "column": "description",
@@ -600,32 +427,37 @@ mod tests {
         let response = app.clone().oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
-            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
-                .unwrap(),
-            serde_json::to_string(&SearchResult {
-                total: 2,
-                results: Some(ValueResults::Objectives(vec![
-                    ObjectiveSummary {
-                        id: ObjectiveId(1),
-                        objective_type: ObjectiveType {
-                            id: "catalyst-simple".to_string(),
-                            description: "A Simple choice".to_string()
+            serde_json::Value::from_str(
+                String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                    .unwrap()
+                    .as_str()
+            )
+            .unwrap(),
+            serde_json::json!(
+                {
+                    "total": 2,
+                    "results": [
+                        {
+                            "id": 1,
+                            "type": {
+                                "id": "catalyst-simple",
+                                "description": "A Simple choice"
+                            },
+                            "title": "title 1",
+                            "description": "description 1"
                         },
-                        title: "title 1".to_string(),
-                        description: "description 1".to_string(),
-                    },
-                    ObjectiveSummary {
-                        id: ObjectiveId(2),
-                        objective_type: ObjectiveType {
-                            id: "catalyst-native".to_string(),
-                            description: "??".to_string()
-                        },
-                        title: "title 2".to_string(),
-                        description: "description 2".to_string(),
-                    },
-                ]))
-            })
-            .unwrap()
+                        {
+                            "id": 2,
+                            "type": {
+                                "id": "catalyst-native",
+                                "description": "??"
+                            },
+                            "title": "title 2",
+                            "description": "description 2"
+                        }
+                    ]
+                }
+            ),
         );
 
         let request = Request::builder()
@@ -633,7 +465,7 @@ mod tests {
             .uri("/api/v1/search?total=true".to_string())
             .header(header::CONTENT_TYPE, "application/json")
             .body(Body::from(
-                json!({
+                serde_json::json!({
                     "table": "objectives",
                     "filter": [{
                         "column": "description",
@@ -649,13 +481,17 @@ mod tests {
         let response = app.clone().oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
-            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
-                .unwrap(),
-            serde_json::to_string(&SearchResult {
-                total: 2,
-                results: None
-            })
-            .unwrap()
+            serde_json::Value::from_str(
+                String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                    .unwrap()
+                    .as_str()
+            )
+            .unwrap(),
+            serde_json::json!(
+                {
+                    "total": 2,
+                }
+            )
         );
 
         let request = Request::builder()
@@ -663,7 +499,7 @@ mod tests {
             .uri("/api/v1/search".to_string())
             .header(header::CONTENT_TYPE, "application/json")
             .body(Body::from(
-                json!({
+                serde_json::json!({
                     "table": "objectives",
                     "filter": [{
                         "column": "description",
@@ -680,32 +516,37 @@ mod tests {
         let response = app.clone().oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
-            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
-                .unwrap(),
-            serde_json::to_string(&SearchResult {
-                total: 2,
-                results: Some(ValueResults::Objectives(vec![
-                    ObjectiveSummary {
-                        id: ObjectiveId(2),
-                        objective_type: ObjectiveType {
-                            id: "catalyst-native".to_string(),
-                            description: "??".to_string()
+            serde_json::Value::from_str(
+                String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                    .unwrap()
+                    .as_str()
+            )
+            .unwrap(),
+            serde_json::json!(
+                {
+                    "total": 2,
+                    "results": [
+                        {
+                            "id": 2,
+                            "type": {
+                                "id": "catalyst-native",
+                                "description": "??"
+                            },
+                            "title": "title 2",
+                            "description": "description 2"
                         },
-                        title: "title 2".to_string(),
-                        description: "description 2".to_string(),
-                    },
-                    ObjectiveSummary {
-                        id: ObjectiveId(1),
-                        objective_type: ObjectiveType {
-                            id: "catalyst-simple".to_string(),
-                            description: "A Simple choice".to_string()
-                        },
-                        title: "title 1".to_string(),
-                        description: "description 1".to_string(),
-                    },
-                ]))
-            })
-            .unwrap()
+                        {
+                            "id": 1,
+                            "type": {
+                                "id": "catalyst-simple",
+                                "description": "A Simple choice"
+                            },
+                            "title": "title 1",
+                            "description": "description 1"
+                        }
+                    ]
+                }
+            )
         );
 
         let request = Request::builder()
@@ -713,7 +554,7 @@ mod tests {
             .uri(format!("/api/v1/search?limit={0}", 1))
             .header(header::CONTENT_TYPE, "application/json")
             .body(Body::from(
-                json!({
+                serde_json::json!({
                     "table": "objectives",
                     "filter": [{
                         "column": "description",
@@ -730,21 +571,29 @@ mod tests {
         let response = app.clone().oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
-            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
-                .unwrap(),
-            serde_json::to_string(&SearchResult {
-                total: 1,
-                results: Some(ValueResults::Objectives(vec![ObjectiveSummary {
-                    id: ObjectiveId(2),
-                    objective_type: ObjectiveType {
-                        id: "catalyst-native".to_string(),
-                        description: "??".to_string()
-                    },
-                    title: "title 2".to_string(),
-                    description: "description 2".to_string(),
-                },]))
-            })
-            .unwrap()
+            serde_json::Value::from_str(
+                String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                    .unwrap()
+                    .as_str()
+            )
+            .unwrap(),
+            serde_json::json!(
+                {
+                    "total": 1,
+                    "results": [
+                        {
+                            "id": 2,
+                            "type": {
+                                "id": "catalyst-native",
+                                "description": "??"
+                            },
+                            "title": "title 2",
+                            "description": "description 2"
+                        }
+                    ]
+
+                }
+            )
         );
 
         let request = Request::builder()
@@ -752,7 +601,7 @@ mod tests {
             .uri(format!("/api/v1/search?offset={0}", 1))
             .header(header::CONTENT_TYPE, "application/json")
             .body(Body::from(
-                json!({
+                serde_json::json!({
                     "table": "objectives",
                     "filter": [{
                         "column": "description",
@@ -769,21 +618,28 @@ mod tests {
         let response = app.clone().oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
-            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
-                .unwrap(),
-            serde_json::to_string(&SearchResult {
-                total: 1,
-                results: Some(ValueResults::Objectives(vec![ObjectiveSummary {
-                    id: ObjectiveId(1),
-                    objective_type: ObjectiveType {
-                        id: "catalyst-simple".to_string(),
-                        description: "A Simple choice".to_string()
-                    },
-                    title: "title 1".to_string(),
-                    description: "description 1".to_string(),
-                },]))
-            })
-            .unwrap()
+            serde_json::Value::from_str(
+                String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                    .unwrap()
+                    .as_str()
+            )
+            .unwrap(),
+            serde_json::json!(
+                {
+                    "total": 1,
+                    "results": [
+                        {
+                            "id": 1,
+                            "type": {
+                                "id": "catalyst-simple",
+                                "description": "A Simple choice"
+                            },
+                            "title": "title 1",
+                            "description": "description 1"
+                        }
+                    ]
+                }
+            )
         );
 
         let request = Request::builder()
@@ -791,7 +647,7 @@ mod tests {
             .uri("/api/v1/search".to_string())
             .header(header::CONTENT_TYPE, "application/json")
             .body(Body::from(
-                json!({
+                serde_json::json!({
                     "table": "objectives",
                     "filter": [{
                         "column": "funds",
@@ -815,7 +671,7 @@ mod tests {
             .uri("/api/v1/search".to_string())
             .header(header::CONTENT_TYPE, "application/json")
             .body(Body::from(
-                json!({
+                serde_json::json!({
                     "table": "proposals",
                     "filter": [{
                         "column": "title",
@@ -831,29 +687,34 @@ mod tests {
         let response = app.clone().oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
-            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
-                .unwrap(),
-            serde_json::to_string(&SearchResult {
-                total: 3,
-                results: Some(ValueResults::Proposals(vec![
-                    ProposalSummary {
-                        id: 1,
-                        title: String::from("title 1"),
-                        summary: String::from("summary 1")
-                    },
-                    ProposalSummary {
-                        id: 2,
-                        title: String::from("title 2"),
-                        summary: String::from("summary 2")
-                    },
-                    ProposalSummary {
-                        id: 3,
-                        title: String::from("title 3"),
-                        summary: String::from("summary 3")
-                    },
-                ]))
-            })
-            .unwrap()
+            serde_json::Value::from_str(
+                String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                    .unwrap()
+                    .as_str()
+            )
+            .unwrap(),
+            serde_json::json!(
+                {
+                    "total": 3,
+                    "results": [
+                        {
+                            "id": 1,
+                            "title": "title 1",
+                            "summary": "summary 1"
+                        },
+                        {
+                            "id": 2,
+                            "title": "title 2",
+                            "summary": "summary 2"
+                        },
+                        {
+                            "id": 3,
+                            "title": "title 3",
+                            "summary": "summary 3"
+                        }
+                    ]
+                }
+            ),
         );
 
         let request = Request::builder()
@@ -861,7 +722,7 @@ mod tests {
             .uri("/api/v1/search?total=true".to_string())
             .header(header::CONTENT_TYPE, "application/json")
             .body(Body::from(
-                json!({
+                serde_json::json!({
                     "table": "proposals",
                     "filter": [{
                         "column": "title",
@@ -877,13 +738,17 @@ mod tests {
         let response = app.clone().oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
-            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
-                .unwrap(),
-            serde_json::to_string(&SearchResult {
-                total: 3,
-                results: None
-            })
-            .unwrap()
+            serde_json::Value::from_str(
+                String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                    .unwrap()
+                    .as_str()
+            )
+            .unwrap(),
+            serde_json::json!(
+                {
+                    "total": 3,
+                }
+            )
         );
 
         let request = Request::builder()
@@ -891,7 +756,7 @@ mod tests {
             .uri("/api/v1/search".to_string())
             .header(header::CONTENT_TYPE, "application/json")
             .body(Body::from(
-                json!({
+                serde_json::json!({
                     "table": "proposals",
                     "filter": [{
                         "column": "title",
@@ -908,29 +773,34 @@ mod tests {
         let response = app.clone().oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
-            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
-                .unwrap(),
-            serde_json::to_string(&SearchResult {
-                total: 3,
-                results: Some(ValueResults::Proposals(vec![
-                    ProposalSummary {
-                        id: 3,
-                        title: String::from("title 3"),
-                        summary: String::from("summary 3")
-                    },
-                    ProposalSummary {
-                        id: 2,
-                        title: String::from("title 2"),
-                        summary: String::from("summary 2")
-                    },
-                    ProposalSummary {
-                        id: 1,
-                        title: String::from("title 1"),
-                        summary: String::from("summary 1")
-                    },
-                ]))
-            })
-            .unwrap()
+            serde_json::Value::from_str(
+                String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                    .unwrap()
+                    .as_str()
+            )
+            .unwrap(),
+            serde_json::json!(
+                {
+                    "total": 3,
+                    "results": [
+                        {
+                            "id": 3,
+                            "title": "title 3",
+                            "summary": "summary 3"
+                        },
+                        {
+                            "id": 2,
+                            "title": "title 2",
+                            "summary": "summary 2"
+                        },
+                        {
+                            "id": 1,
+                            "title": "title 1",
+                            "summary": "summary 1"
+                        }
+                    ]
+                }
+            )
         );
 
         let request = Request::builder()
@@ -938,7 +808,7 @@ mod tests {
             .uri(format!("/api/v1/search?limit={0}", 2))
             .header(header::CONTENT_TYPE, "application/json")
             .body(Body::from(
-                json!({
+                serde_json::json!({
                     "table": "proposals",
                     "filter": [{
                         "column": "title",
@@ -955,24 +825,29 @@ mod tests {
         let response = app.clone().oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
-            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
-                .unwrap(),
-            serde_json::to_string(&SearchResult {
-                total: 2,
-                results: Some(ValueResults::Proposals(vec![
-                    ProposalSummary {
-                        id: 3,
-                        title: String::from("title 3"),
-                        summary: String::from("summary 3")
-                    },
-                    ProposalSummary {
-                        id: 2,
-                        title: String::from("title 2"),
-                        summary: String::from("summary 2")
-                    },
-                ]))
-            })
-            .unwrap()
+            serde_json::Value::from_str(
+                String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                    .unwrap()
+                    .as_str()
+            )
+            .unwrap(),
+            serde_json::json!(
+                {
+                    "total": 2,
+                    "results": [
+                        {
+                            "id": 3,
+                            "title": "title 3",
+                            "summary": "summary 3"
+                        },
+                        {
+                            "id": 2,
+                            "title": "title 2",
+                            "summary": "summary 2"
+                        }
+                    ]
+                }
+            ),
         );
 
         let request = Request::builder()
@@ -980,7 +855,7 @@ mod tests {
             .uri(format!("/api/v1/search?offset={0}", 1))
             .header(header::CONTENT_TYPE, "application/json")
             .body(Body::from(
-                json!({
+                serde_json::json!({
                     "table": "proposals",
                     "filter": [{
                         "column": "title",
@@ -997,24 +872,29 @@ mod tests {
         let response = app.clone().oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
-            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
-                .unwrap(),
-            serde_json::to_string(&SearchResult {
-                total: 2,
-                results: Some(ValueResults::Proposals(vec![
-                    ProposalSummary {
-                        id: 2,
-                        title: String::from("title 2"),
-                        summary: String::from("summary 2")
-                    },
-                    ProposalSummary {
-                        id: 1,
-                        title: String::from("title 1"),
-                        summary: String::from("summary 1")
-                    },
-                ]))
-            })
-            .unwrap()
+            serde_json::Value::from_str(
+                String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                    .unwrap()
+                    .as_str()
+            )
+            .unwrap(),
+            serde_json::json!(
+                {
+                    "total": 2,
+                    "results": [
+                        {
+                            "id": 2,
+                            "title": "title 2",
+                            "summary": "summary 2"
+                        },
+                        {
+                            "id": 1,
+                            "title": "title 1",
+                            "summary": "summary 1"
+                        }
+                    ]
+                }
+            ),
         );
 
         let request = Request::builder()
@@ -1022,7 +902,7 @@ mod tests {
             .uri(format!("/api/v1/search?limit={0}&offset={1}", 1, 1))
             .header(header::CONTENT_TYPE, "application/json")
             .body(Body::from(
-                json!({
+                serde_json::json!({
                     "table": "proposals",
                     "filter": [{
                         "column": "title",
@@ -1039,17 +919,24 @@ mod tests {
         let response = app.clone().oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
-            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
-                .unwrap(),
-            serde_json::to_string(&SearchResult {
-                total: 1,
-                results: Some(ValueResults::Proposals(vec![ProposalSummary {
-                    id: 2,
-                    title: String::from("title 2"),
-                    summary: String::from("summary 2")
-                },]))
-            })
-            .unwrap()
+            serde_json::Value::from_str(
+                String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                    .unwrap()
+                    .as_str()
+            )
+            .unwrap(),
+            serde_json::json!(
+                {
+                    "total": 1,
+                    "results": [
+                        {
+                            "id": 2,
+                            "title": "title 2",
+                            "summary": "summary 2"
+                        }
+                    ]
+                }
+            )
         );
 
         let request = Request::builder()
@@ -1057,7 +944,7 @@ mod tests {
             .uri("/api/v1/search".to_string())
             .header(header::CONTENT_TYPE, "application/json")
             .body(Body::from(
-                json!({
+                serde_json::json!({
                     "table": "proposals",
                     "filter": [{
                         "column": "description",

--- a/src/event-db/migrations/V4__proposal_tables.sql
+++ b/src/event-db/migrations/V4__proposal_tables.sql
@@ -127,7 +127,7 @@ CREATE TABLE review_metric (
   description VARCHAR NULL,
   min INTEGER NOT NULL,
   max INTEGER NOT NULL,
-  map JSONB NULL
+  map JSONB ARRAY NULL
 );
 COMMENT ON TABLE review_metric IS 'Definition of all possible review metrics.';
 COMMENT ON COLUMN review_metric.row_id IS 'The synthetic ID of this metric.';
@@ -155,11 +155,11 @@ VALUES
     ('feasibility','Feasibility Rating', 0, 5, NULL),
     ('auditability','Auditability Rating', 0, 5, NULL),
     ('value','Value Proposition Rating', 0, 5, NULL),
-    ('vpa_ranking','VPA Ranking of the review',0,3,
-      '[{"name":"Excellent","desc":"Excellent Review"},
-         {"name":"Good","desc":"Could be improved."},
-         {"name":"FilteredOut","desc":"Exclude this review"},
-         {"name":"NA", "desc":"Not Applicable"}]');
+    ('vpa_ranking','VPA Ranking of the review',0,3, ARRAY [
+            '{"name":"Excellent","desc":"Excellent Review"}',
+            '{"name":"Good","desc":"Could be improved."}',
+            '{"name":"FilteredOut","desc":"Exclude this review"}',
+            '{"name":"NA", "desc":"Not Applicable"}']::JSON[]);
 
 CREATE TABLE objective_review_metric (
   row_id SERIAL PRIMARY KEY,

--- a/src/event-db/src/queries/event/review.rs
+++ b/src/event-db/src/queries/event/review.rs
@@ -118,12 +118,8 @@ impl ReviewQueries for EventDB {
             .await?;
         let mut review_types = Vec::new();
         for row in rows {
-            let map = row.try_get::<_, Option<serde_json::Value>>("map")?;
-            let map = map
-                .and_then(|map| {
-                    map.as_array()
-                        .map(|array| array.iter().map(|el| el.to_string()).collect())
-                })
+            let map = row
+                .try_get::<_, Option<Vec<serde_json::Value>>>("map")?
                 .unwrap_or_default();
 
             review_types.push(ReviewType {
@@ -315,11 +311,10 @@ mod tests {
                     map: vec![
                         json!(
                             {"name":"Excellent","desc":"Excellent Review"}
-                        )
-                        .to_string(),
-                        json!({"name":"Good","desc":"Could be improved."}).to_string(),
-                        json!({"name":"FilteredOut","desc":"Exclude this review"}).to_string(),
-                        json!({"name":"NA", "desc":"Not Applicable"}).to_string()
+                        ),
+                        json!({"name":"Good","desc":"Could be improved."}),
+                        json!({"name":"FilteredOut","desc":"Exclude this review"}),
+                        json!({"name":"NA", "desc":"Not Applicable"})
                     ],
                     note: Some(false),
                     group: None,
@@ -385,11 +380,10 @@ mod tests {
                     map: vec![
                         json!(
                             {"name":"Excellent","desc":"Excellent Review"}
-                        )
-                        .to_string(),
-                        json!({"name":"Good","desc":"Could be improved."}).to_string(),
-                        json!({"name":"FilteredOut","desc":"Exclude this review"}).to_string(),
-                        json!({"name":"NA", "desc":"Not Applicable"}).to_string()
+                        ),
+                        json!({"name":"Good","desc":"Could be improved."}),
+                        json!({"name":"FilteredOut","desc":"Exclude this review"}),
+                        json!({"name":"NA", "desc":"Not Applicable"})
                     ],
                     note: Some(false),
                     group: None,

--- a/src/event-db/src/types/event/review.rs
+++ b/src/event-db/src/types/event/review.rs
@@ -1,18 +1,20 @@
 use serde::Serialize;
+use serde_json::Value;
 
-#[derive(Debug, Serialize, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
 pub struct ReviewType {
     pub id: i32,
     pub name: String,
     pub description: Option<String>,
     pub min: i32,
     pub max: i32,
-    pub map: Vec<String>,
+    pub map: Vec<Value>,
     pub note: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub group: Option<String>,
 }
 
-#[derive(Debug, Serialize, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
 pub struct Rating {
     pub review_type: i32,
     pub score: i32,
@@ -20,7 +22,7 @@ pub struct Rating {
     pub note: Option<String>,
 }
 
-#[derive(Debug, Serialize, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
 pub struct AdvisorReview {
     pub assessor: String,
     pub ratings: Vec<Rating>,
@@ -40,7 +42,7 @@ mod tests {
             min: 1,
             max: 2,
             note: Some(true),
-            map: vec!["map".to_string()],
+            map: vec![json!({})],
             group: Some("group".to_string()),
         };
         let json = serde_json::to_value(&review_type).unwrap();
@@ -54,7 +56,7 @@ mod tests {
                 "min": 1,
                 "max": 2,
                 "note": true,
-                "map": ["map"],
+                "map": [{}],
                 "group": "group",
             })
         )


### PR DESCRIPTION
# Description

Refactored cat-data-service tests, updated assertions checks with the json representation of the returning object without using explicit Rust db types. It allows to test precisely by our API specification, instead of using our Rust internal db types serde.
Also updated `map` field of the `ReviewType` from string to object.
Updated `review_metric` chema, `map` column from `JSONB` to `JSONB ARRAY`