### PR TITLE
feat: Cat-data-service health endpoints | NPG-6603

### DIFF
--- a/book/src/07_web_api/openapi/core_backend_api.yaml
+++ b/book/src/07_web_api/openapi/core_backend_api.yaml
@@ -45,6 +45,32 @@ servers:
   - url: 'https://prod.xxxxxxxxxxxxxx.io'
     description: Production Environment
 paths:
+  /health/ready:
+    get:
+      operationId: healthReady
+      summary: readiness of the service to accept incoming requests
+      description: readiness of the service to accept incoming requests
+      responses:
+        '200':
+          content:
+            description: Valid response
+            application/json:
+              schema:
+                type: boolean
+                description: returns 'true' if service is ready
+  /health/live:
+    get:
+      operationId: healthLive
+      summary: liveness of the service
+      description: liveness of the service
+      responses:
+        '200':
+          content:
+            description: Valid response
+            application/json:
+              schema:
+                type: boolean
+                description: returns 'true' if service is live
   /api/v1/events:
     get:
       operationId: getEvents

--- a/src/cat-data-service/src/service/health.rs
+++ b/src/cat-data-service/src/service/health.rs
@@ -1,0 +1,92 @@
+use crate::service::Error;
+use axum::{routing::get, Router};
+
+use super::handle_result;
+
+pub fn health() -> Router {
+    Router::new()
+        .route(
+            "/health/ready",
+            get(|| async { handle_result(ready_exec().await).await }),
+        )
+        .route(
+            "/health/live",
+            get(|| async { handle_result(live_exec().await).await }),
+        )
+}
+
+async fn ready_exec() -> Result<bool, Error> {
+    tracing::debug!("health ready exec");
+
+    Ok(true)
+}
+
+async fn live_exec() -> Result<bool, Error> {
+    tracing::debug!("health live exec");
+
+    Ok(true)
+}
+
+/// Need to setup and run a test event db instance
+/// To do it you can use the following commands:
+/// Prepare docker images
+/// ```
+/// earthly ./containers/event-db-migrations+docker --data=test
+/// ```
+/// Run event-db container
+/// ```
+/// docker-compose -f src/event-db/docker-compose.yml up migrations
+/// ```
+/// Also need establish `EVENT_DB_URL` env variable with the following value
+/// ```
+/// EVENT_DB_URL="postgres://catalyst-event-dev:CHANGE_ME@localhost/CatalystEventDev"
+/// ```
+/// https://github.com/input-output-hk/catalyst-core/tree/main/src/event-db/Readme.md
+#[cfg(test)]
+mod tests {
+    use crate::{service::app, state::State};
+    use axum::{
+        body::{Body, HttpBody},
+        http::{Request, StatusCode},
+    };
+    use std::sync::Arc;
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn health_ready_test() {
+        let state = Arc::new(State::new(None).await.unwrap());
+        let app = app(state);
+
+        let request = Request::builder()
+            .uri("/health/ready".to_string())
+            .body(Body::empty())
+            .unwrap();
+        let response = app.clone().oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                .unwrap()
+                .as_str(),
+            r#"true"#
+        );
+    }
+
+    #[tokio::test]
+    async fn health_live_test() {
+        let state = Arc::new(State::new(None).await.unwrap());
+        let app = app(state);
+
+        let request = Request::builder()
+            .uri("/health/live".to_string())
+            .body(Body::empty())
+            .unwrap();
+        let response = app.clone().oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                .unwrap()
+                .as_str(),
+            r#"true"#
+        );
+    }
+}

--- a/src/cat-data-service/src/service/mod.rs
+++ b/src/cat-data-service/src/service/mod.rs
@@ -7,6 +7,7 @@ use axum::{
 use serde::Serialize;
 use std::{net::SocketAddr, sync::Arc};
 
+mod health;
 mod v1;
 
 #[derive(thiserror::Error, Debug)]
@@ -20,7 +21,8 @@ pub enum Error {
 pub fn app(state: Arc<State>) -> Router {
     // build our application with a route
     let v1 = v1::v1(state);
-    Router::new().nest("/api", v1)
+    let health = health::health();
+    Router::new().nest("/api", v1).merge(health)
 }
 
 pub async fn run_service(addr: &SocketAddr, state: Arc<State>) -> Result<(), Error> {


### PR DESCRIPTION
# Description

Added health check endpoints for cat-data-service:
- `/health/live` - liveness of the service endpoint
- `/health/ready` - readiness of the service to accept incoming requests endpoint