### PR TITLE
fix: Fix get_proposal query, updated responded error message | NPG-6702

### DIFF
--- a/src/cat-data-service/src/service/v1/event/ballots.rs
+++ b/src/cat-data-service/src/service/v1/event/ballots.rs
@@ -73,7 +73,7 @@ mod tests {
                     "objective_id": 1,
                     "ballots": [
                         {
-                            "proposal_id": 1,
+                            "proposal_id": 10,
                             "ballot": {
                                 "choices": ["yes", "no"],
                                 "voteplans": [
@@ -93,7 +93,7 @@ mod tests {
                             }
                         },
                         {
-                            "proposal_id": 2,
+                            "proposal_id": 20,
                             "ballot": {
                                 "choices": ["yes", "no"],
                                 "voteplans": [
@@ -113,7 +113,7 @@ mod tests {
                             }
                         },
                         {
-                            "proposal_id": 3,
+                            "proposal_id": 30,
                             "ballot": {
                                 "choices": ["yes", "no"],
                                 "voteplans": []

--- a/src/cat-data-service/src/service/v1/event/objective/ballots.rs
+++ b/src/cat-data-service/src/service/v1/event/objective/ballots.rs
@@ -78,7 +78,7 @@ mod tests {
             serde_json::json!(
                 [
                     {
-                        "proposal_id": 1,
+                        "proposal_id": 10,
                         "ballot": {
                             "choices": ["yes", "no"],
                             "voteplans": [
@@ -98,7 +98,7 @@ mod tests {
                         }
                     },
                     {
-                        "proposal_id": 2,
+                        "proposal_id": 20,
                         "ballot": {
                             "choices": ["yes", "no"],
                             "voteplans": [
@@ -118,7 +118,7 @@ mod tests {
                         }
                     },
                     {
-                        "proposal_id": 3,
+                        "proposal_id": 30,
                         "ballot": {
                             "choices": ["yes", "no"],
                             "voteplans": []

--- a/src/cat-data-service/src/service/v1/event/objective/proposal/ballot.rs
+++ b/src/cat-data-service/src/service/v1/event/objective/proposal/ballot.rs
@@ -67,7 +67,7 @@ mod tests {
         let request = Request::builder()
             .uri(format!(
                 "/api/v1/event/{0}/objective/{1}/proposal/{2}/ballot",
-                1, 1, 1
+                1, 1, 10
             ))
             .body(Body::empty())
             .unwrap();

--- a/src/cat-data-service/src/service/v1/event/objective/proposal/mod.rs
+++ b/src/cat-data-service/src/service/v1/event/objective/proposal/mod.rs
@@ -113,7 +113,7 @@ mod tests {
         let request = Request::builder()
             .uri(format!(
                 "/api/v1/event/{0}/objective/{1}/proposal/{2}",
-                1, 1, 1
+                1, 1, 10
             ))
             .body(Body::empty())
             .unwrap();
@@ -128,7 +128,7 @@ mod tests {
             .unwrap(),
             serde_json::json!(
                 {
-                    "id": 1,
+                    "id": 10,
                     "title": "title 1",
                     "summary": "summary 1",
                     "funds": 100,
@@ -182,17 +182,17 @@ mod tests {
             .unwrap(),
             serde_json::json!([
                 {
-                    "id": 1,
+                    "id": 10,
                     "title": "title 1",
                     "summary": "summary 1",
                 },
                 {
-                    "id": 2,
+                    "id": 20,
                     "title": "title 2",
                     "summary": "summary 2",
                 },
                 {
-                    "id": 3,
+                    "id": 30,
                     "title": "title 3",
                     "summary": "summary 3",
                 }
@@ -217,12 +217,12 @@ mod tests {
             .unwrap(),
             serde_json::json!([
                 {
-                    "id": 1,
+                    "id": 10,
                     "title": "title 1",
                     "summary": "summary 1",
                 },
                 {
-                    "id": 2,
+                    "id": 20,
                     "title": "title 2",
                     "summary": "summary 2",
                 },
@@ -247,12 +247,12 @@ mod tests {
             .unwrap(),
             serde_json::json!([
                 {
-                    "id": 2,
+                    "id": 20,
                     "title": "title 2",
                     "summary": "summary 2",
                 },
                 {
-                    "id": 3,
+                    "id": 30,
                     "title": "title 3",
                     "summary": "summary 3",
                 }
@@ -277,7 +277,7 @@ mod tests {
             .unwrap(),
             serde_json::json!([
                 {
-                    "id": 2,
+                    "id": 20,
                     "title": "title 2",
                     "summary": "summary 2",
                 },

--- a/src/cat-data-service/src/service/v1/event/objective/proposal/review.rs
+++ b/src/cat-data-service/src/service/v1/event/objective/proposal/review.rs
@@ -74,7 +74,7 @@ mod tests {
         let request = Request::builder()
             .uri(format!(
                 "/api/v1/event/{0}/objective/{1}/proposal/{2}/reviews",
-                1, 1, 1
+                1, 1, 10
             ))
             .body(Body::empty())
             .unwrap();
@@ -122,7 +122,7 @@ mod tests {
         let request = Request::builder()
             .uri(format!(
                 "/api/v1/event/{0}/objective/{1}/proposal/{2}/reviews?limit={3}",
-                1, 1, 1, 2
+                1, 1, 10, 2
             ))
             .body(Body::empty())
             .unwrap();
@@ -166,7 +166,7 @@ mod tests {
         let request = Request::builder()
             .uri(format!(
                 "/api/v1/event/{0}/objective/{1}/proposal/{2}/reviews?offset={3}",
-                1, 1, 1, 1
+                1, 1, 10, 1
             ))
             .body(Body::empty())
             .unwrap();
@@ -194,7 +194,7 @@ mod tests {
         let request = Request::builder()
             .uri(format!(
                 "/api/v1/event/{0}/objective/{1}/proposal/{2}/reviews?limit={3}&offset={4}",
-                1, 1, 1, 1, 1
+                1, 1, 10, 1, 1
             ))
             .body(Body::empty())
             .unwrap();

--- a/src/cat-data-service/src/service/v1/search.rs
+++ b/src/cat-data-service/src/service/v1/search.rs
@@ -698,17 +698,17 @@ mod tests {
                     "total": 3,
                     "results": [
                         {
-                            "id": 1,
+                            "id": 10,
                             "title": "title 1",
                             "summary": "summary 1"
                         },
                         {
-                            "id": 2,
+                            "id": 20,
                             "title": "title 2",
                             "summary": "summary 2"
                         },
                         {
-                            "id": 3,
+                            "id": 30,
                             "title": "title 3",
                             "summary": "summary 3"
                         }
@@ -784,17 +784,17 @@ mod tests {
                     "total": 3,
                     "results": [
                         {
-                            "id": 3,
+                            "id": 30,
                             "title": "title 3",
                             "summary": "summary 3"
                         },
                         {
-                            "id": 2,
+                            "id": 20,
                             "title": "title 2",
                             "summary": "summary 2"
                         },
                         {
-                            "id": 1,
+                            "id": 10,
                             "title": "title 1",
                             "summary": "summary 1"
                         }
@@ -836,12 +836,12 @@ mod tests {
                     "total": 2,
                     "results": [
                         {
-                            "id": 3,
+                            "id": 30,
                             "title": "title 3",
                             "summary": "summary 3"
                         },
                         {
-                            "id": 2,
+                            "id": 20,
                             "title": "title 2",
                             "summary": "summary 2"
                         }
@@ -883,12 +883,12 @@ mod tests {
                     "total": 2,
                     "results": [
                         {
-                            "id": 2,
+                            "id": 20,
                             "title": "title 2",
                             "summary": "summary 2"
                         },
                         {
-                            "id": 1,
+                            "id": 10,
                             "title": "title 1",
                             "summary": "summary 1"
                         }
@@ -930,7 +930,7 @@ mod tests {
                     "total": 1,
                     "results": [
                         {
-                            "id": 2,
+                            "id": 20,
                             "title": "title 2",
                             "summary": "summary 2"
                         }

--- a/src/event-db/src/queries/event/ballot.rs
+++ b/src/event-db/src/queries/event/ballot.rs
@@ -230,7 +230,7 @@ mod tests {
         let event_db = establish_connection(None).await.unwrap();
 
         let ballot = event_db
-            .get_ballot(EventId(1), ObjectiveId(1), ProposalId(1))
+            .get_ballot(EventId(1), ObjectiveId(1), ProposalId(10))
             .await
             .unwrap();
 
@@ -270,7 +270,7 @@ mod tests {
         assert_eq!(
             vec![
                 ProposalBallot {
-                    proposal_id: ProposalId(1),
+                    proposal_id: ProposalId(10),
                     ballot: Ballot {
                         choices: ObjectiveChoices(vec!["yes".to_string(), "no".to_string()]),
                         voteplans: GroupVotePlans(vec![
@@ -292,7 +292,7 @@ mod tests {
                     },
                 },
                 ProposalBallot {
-                    proposal_id: ProposalId(2),
+                    proposal_id: ProposalId(20),
                     ballot: Ballot {
                         choices: ObjectiveChoices(vec!["yes".to_string(), "no".to_string()]),
                         voteplans: GroupVotePlans(vec![
@@ -314,7 +314,7 @@ mod tests {
                     },
                 },
                 ProposalBallot {
-                    proposal_id: ProposalId(3),
+                    proposal_id: ProposalId(30),
                     ballot: Ballot {
                         choices: ObjectiveChoices(vec!["yes".to_string(), "no".to_string()]),
                         voteplans: GroupVotePlans(vec![]),
@@ -336,7 +336,7 @@ mod tests {
                 objective_id: ObjectiveId(1),
                 ballots: vec![
                     ProposalBallot {
-                        proposal_id: ProposalId(1),
+                        proposal_id: ProposalId(10),
                         ballot: Ballot {
                             choices: ObjectiveChoices(vec!["yes".to_string(), "no".to_string()]),
                             voteplans: GroupVotePlans(vec![
@@ -358,7 +358,7 @@ mod tests {
                         },
                     },
                     ProposalBallot {
-                        proposal_id: ProposalId(2),
+                        proposal_id: ProposalId(20),
                         ballot: Ballot {
                             choices: ObjectiveChoices(vec!["yes".to_string(), "no".to_string()]),
                             voteplans: GroupVotePlans(vec![
@@ -380,7 +380,7 @@ mod tests {
                         },
                     },
                     ProposalBallot {
-                        proposal_id: ProposalId(3),
+                        proposal_id: ProposalId(30),
                         ballot: Ballot {
                             choices: ObjectiveChoices(vec!["yes".to_string(), "no".to_string()]),
                             voteplans: GroupVotePlans(vec![]),

--- a/src/event-db/src/queries/event/review.rs
+++ b/src/event-db/src/queries/event/review.rs
@@ -165,7 +165,7 @@ mod tests {
         let event_db = establish_connection(None).await.unwrap();
 
         let reviews = event_db
-            .get_reviews(EventId(1), ObjectiveId(1), ProposalId(1), None, None)
+            .get_reviews(EventId(1), ObjectiveId(1), ProposalId(10), None, None)
             .await
             .unwrap();
 
@@ -204,7 +204,7 @@ mod tests {
         );
 
         let reviews = event_db
-            .get_reviews(EventId(1), ObjectiveId(1), ProposalId(1), Some(2), None)
+            .get_reviews(EventId(1), ObjectiveId(1), ProposalId(10), Some(2), None)
             .await
             .unwrap();
 
@@ -239,7 +239,7 @@ mod tests {
         );
 
         let reviews = event_db
-            .get_reviews(EventId(1), ObjectiveId(1), ProposalId(1), None, Some(1))
+            .get_reviews(EventId(1), ObjectiveId(1), ProposalId(10), None, Some(1))
             .await
             .unwrap();
 
@@ -258,7 +258,7 @@ mod tests {
         );
 
         let reviews = event_db
-            .get_reviews(EventId(1), ObjectiveId(1), ProposalId(1), Some(1), Some(1))
+            .get_reviews(EventId(1), ObjectiveId(1), ProposalId(10), Some(1), Some(1))
             .await
             .unwrap();
 

--- a/src/event-db/src/queries/search.rs
+++ b/src/event-db/src/queries/search.rs
@@ -2,7 +2,7 @@ use crate::{
     types::{
         event::{
             objective::{ObjectiveId, ObjectiveSummary, ObjectiveType},
-            proposal::ProposalSummary,
+            proposal::{ProposalId, ProposalSummary},
             EventId, EventSummary,
         },
         search::{
@@ -227,7 +227,7 @@ impl SearchQueries for EventDB {
                     let mut proposals = Vec::new();
                     for row in rows {
                         let summary = ProposalSummary {
-                            id: row.try_get("id")?,
+                            id: ProposalId(row.try_get("id")?),
                             title: row.try_get("title")?,
                             summary: row.try_get("summary")?,
                         };
@@ -822,17 +822,17 @@ mod tests {
             query_result.results,
             Some(ValueResults::Proposals(vec![
                 ProposalSummary {
-                    id: 1,
+                    id: ProposalId(10),
                     title: String::from("title 1"),
                     summary: String::from("summary 1")
                 },
                 ProposalSummary {
-                    id: 2,
+                    id: ProposalId(20),
                     title: String::from("title 2"),
                     summary: String::from("summary 2")
                 },
                 ProposalSummary {
-                    id: 3,
+                    id: ProposalId(30),
                     title: String::from("title 3"),
                     summary: String::from("summary 3")
                 },
@@ -866,17 +866,17 @@ mod tests {
             query_result.results,
             Some(ValueResults::Proposals(vec![
                 ProposalSummary {
-                    id: 3,
+                    id: ProposalId(30),
                     title: String::from("title 3"),
                     summary: String::from("summary 3")
                 },
                 ProposalSummary {
-                    id: 2,
+                    id: ProposalId(20),
                     title: String::from("title 2"),
                     summary: String::from("summary 2")
                 },
                 ProposalSummary {
-                    id: 1,
+                    id: ProposalId(10),
                     title: String::from("title 1"),
                     summary: String::from("summary 1")
                 },
@@ -892,12 +892,12 @@ mod tests {
             query_result.results,
             Some(ValueResults::Proposals(vec![
                 ProposalSummary {
-                    id: 3,
+                    id: ProposalId(30),
                     title: String::from("title 3"),
                     summary: String::from("summary 3")
                 },
                 ProposalSummary {
-                    id: 2,
+                    id: ProposalId(20),
                     title: String::from("title 2"),
                     summary: String::from("summary 2")
                 },
@@ -913,12 +913,12 @@ mod tests {
             query_result.results,
             Some(ValueResults::Proposals(vec![
                 ProposalSummary {
-                    id: 2,
+                    id: ProposalId(20),
                     title: String::from("title 2"),
                     summary: String::from("summary 2")
                 },
                 ProposalSummary {
-                    id: 1,
+                    id: ProposalId(10),
                     title: String::from("title 1"),
                     summary: String::from("summary 1")
                 },
@@ -933,7 +933,7 @@ mod tests {
         assert_eq!(
             query_result.results,
             Some(ValueResults::Proposals(vec![ProposalSummary {
-                id: 2,
+                id: ProposalId(20),
                 title: String::from("title 2"),
                 summary: String::from("summary 2")
             },]))

--- a/src/event-db/src/types/event/proposal.rs
+++ b/src/event-db/src/types/event/proposal.rs
@@ -27,7 +27,7 @@ pub struct ProposalDetails {
 
 #[derive(Debug, Serialize, Clone, PartialEq, Eq)]
 pub struct ProposalSummary {
-    pub id: i32,
+    pub id: ProposalId,
     pub title: String,
     pub summary: String,
 }

--- a/src/event-db/test_data/08_proposal_table.sql
+++ b/src/event-db/test_data/08_proposal_table.sql
@@ -20,7 +20,7 @@ INSERT INTO
     )
 VALUES (
         1,
-        1,
+        10,
         1,
         'title 1',
         'summary 1',
@@ -38,7 +38,7 @@ VALUES (
         '70726f706f73616c'
     ), (
         2,
-        2,
+        20,
         1,
         'title 2',
         'summary 2',
@@ -56,7 +56,7 @@ VALUES (
         '70726f706f73616c'
     ), (
         3,
-        3,
+        30,
         1,
         'title 3',
         'summary 3',
@@ -74,7 +74,7 @@ VALUES (
         '70726f706f73616c'
     ), (
         4,
-        1,
+        10,
         2,
         'title 1',
         'summary 1',
@@ -92,7 +92,7 @@ VALUES (
         '70726f706f73616c'
     ), (
         5,
-        2,
+        20,
         2,
         'title 2',
         'summary 2',
@@ -110,7 +110,7 @@ VALUES (
         '70726f706f73616c'
     ), (
         6,
-        3,
+        30,
         2,
         'title 3',
         'summary 3',


### PR DESCRIPTION
# Description

- Fixed `get_proposal` query, slightly updated tests
- Updated responded error message from the cat-data-service, so now instead of returning just a string, it  returns a `{error: "some error" }` json object.