### PR TITLE
refactor: Remove vit-ss server usage from catalyst-toolbox | NPG-6766

### DIFF
--- a/src/catalyst-toolbox/catalyst-toolbox/src/bin/cli/rewards/community_advisors.rs
+++ b/src/catalyst-toolbox/catalyst-toolbox/src/bin/cli/rewards/community_advisors.rs
@@ -1,23 +1,21 @@
-use serde::{Deserialize, Serialize};
-use std::collections::{BTreeMap, BTreeSet};
-use std::path::{Path, PathBuf};
-use std::str::FromStr;
-
+use catalyst_toolbox::community_advisors::models::{
+    AdvisorReviewRow, ApprovedProposalRow, ProposalStatus,
+};
 use catalyst_toolbox::rewards::community_advisors::{
     calculate_ca_rewards, ApprovedProposals, CommunityAdvisor, FundSetting, Funds,
     ProposalRewardSlots, ProposalsReviews, Rewards, Seed,
 };
 use catalyst_toolbox::utils;
+use catalyst_toolbox::utils::csv::dump_data_to_csv;
 use chain_crypto::digest::DigestOf;
+use clap::Parser;
 use color_eyre::eyre::{bail, eyre};
 use color_eyre::Report;
 use rust_decimal::prelude::ToPrimitive;
-
-use catalyst_toolbox::community_advisors::models::{
-    AdvisorReviewRow, ApprovedProposalRow, ProposalStatus,
-};
-use catalyst_toolbox::utils::csv::dump_data_to_csv;
-use clap::Parser;
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
 
 #[derive(Debug, Deserialize, Parser)]
 pub struct FundSettingOpt {

--- a/src/catalyst-toolbox/catalyst-toolbox/src/bin/cli/rewards/dreps.rs
+++ b/src/catalyst-toolbox/catalyst-toolbox/src/bin/cli/rewards/dreps.rs
@@ -1,20 +1,23 @@
 use catalyst_toolbox::rewards::voters::calc_voter_rewards;
 use catalyst_toolbox::rewards::{Rewards, Threshold};
+use catalyst_toolbox::utils::csv::dump_to_csv_or_print;
 use clap::Parser;
 use color_eyre::Report;
-use jcli_lib::jcli_lib::block::Common;
 use jormungandr_lib::{crypto::account::Identifier, interfaces::AccountVotes};
+use serde::Serialize;
 use snapshot_lib::{registration::MainnetRewardAddress, SnapshotInfo};
-use vit_servicing_station_lib::db::models::proposals::FullProposalInfo;
-
 use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
+use vit_servicing_station_lib::db::models::proposals::FullProposalInfo;
 
 #[derive(Parser)]
 #[clap(rename_all = "kebab-case")]
 pub struct DrepsRewards {
-    #[clap(flatten)]
-    common: Common,
+    /// Path to the output file
+    /// print to stdout if not provided
+    #[clap(long)]
+    output: Option<PathBuf>,
+
     /// Reward (in dollars) to be distributed proportionally to delegated stake with respect to total stake.
     /// The total amount will only be awarded if dreps control all of the stake.
     #[clap(long)]
@@ -46,18 +49,23 @@ pub struct DrepsRewards {
 }
 
 fn write_rewards_results(
-    common: Common,
-    rewards: &BTreeMap<MainnetRewardAddress, Rewards>,
+    output: &Option<PathBuf>,
+    rewards: BTreeMap<MainnetRewardAddress, Rewards>,
 ) -> Result<(), Report> {
-    let writer = common.open_output()?;
-    let header = ["Address", "Reward for the voter (lovelace)"];
-    let mut csv_writer = csv::Writer::from_writer(writer);
-    csv_writer.write_record(header)?;
-
-    for (address, rewards) in rewards.iter() {
-        let record = [address.to_string(), rewards.trunc().to_string()];
-        csv_writer.write_record(&record)?;
+    #[derive(Serialize, Debug)]
+    struct Entry {
+        #[serde(rename = "Address")]
+        address: MainnetRewardAddress,
+        #[serde(rename = "Reward for the voter (lovelace)")]
+        reward: Rewards,
     }
+
+    dump_to_csv_or_print(
+        &output,
+        rewards
+            .into_iter()
+            .map(|(address, reward)| Entry { address, reward }),
+    )?;
 
     Ok(())
 }
@@ -65,7 +73,7 @@ fn write_rewards_results(
 impl DrepsRewards {
     pub fn exec(self) -> Result<(), Report> {
         let DrepsRewards {
-            common,
+            output,
             total_rewards,
             snapshot_info_path,
             votes_count_path,
@@ -109,7 +117,7 @@ impl DrepsRewards {
             Rewards::from(total_rewards),
         )?;
 
-        write_rewards_results(common, &results)?;
+        write_rewards_results(&output, results)?;
         Ok(())
     }
 }

--- a/src/catalyst-toolbox/catalyst-toolbox/src/bin/cli/rewards/dreps.rs
+++ b/src/catalyst-toolbox/catalyst-toolbox/src/bin/cli/rewards/dreps.rs
@@ -61,7 +61,7 @@ fn write_rewards_results(
     }
 
     dump_to_csv_or_print(
-        &output,
+        output,
         rewards
             .into_iter()
             .map(|(address, reward)| Entry { address, reward }),

--- a/src/catalyst-toolbox/catalyst-toolbox/src/bin/cli/rewards/mod.rs
+++ b/src/catalyst-toolbox/catalyst-toolbox/src/bin/cli/rewards/mod.rs
@@ -5,18 +5,14 @@ mod proposers;
 mod veterans;
 mod voters;
 
-use std::{collections::HashMap, path::PathBuf};
-
-use catalyst_toolbox::{
-    http::default_http_client,
-    rewards::{proposers as proposers_lib, VoteCount},
-};
+use catalyst_toolbox::rewards::{proposers as proposers_lib, VoteCount};
 use clap::Parser;
 use color_eyre::{eyre::eyre, Report};
 use jormungandr_lib::{
     crypto::{account::Identifier, hash::Hash},
     interfaces::AccountVotes,
 };
+use std::{collections::HashMap, path::PathBuf};
 use vit_servicing_station_lib::db::models::proposals::FullProposalInfo;
 
 #[derive(Parser)]
@@ -49,9 +45,7 @@ impl Rewards {
             Rewards::Veterans(cmd) => cmd.exec(),
             Rewards::Dreps(cmd) => cmd.exec(),
             Rewards::Full { path } => full::full_rewards(&path),
-            Rewards::Proposers(proposers) => {
-                proposers::rewards(&proposers, &default_http_client(None))
-            }
+            Rewards::Proposers(proposers) => proposers::rewards(&proposers),
         }
     }
 }

--- a/src/catalyst-toolbox/catalyst-toolbox/src/bin/cli/rewards/proposers/mod.rs
+++ b/src/catalyst-toolbox/catalyst-toolbox/src/bin/cli/rewards/proposers/mod.rs
@@ -1,13 +1,11 @@
-use std::{collections::HashSet, fs::File};
-
 use catalyst_toolbox::{
-    http::HttpClient,
     rewards::proposers::{
-        io::{load_data, write_results},
-        proposer_rewards, ProposerRewards, ProposerRewardsInputs,
+        io::write_results, proposer_rewards, ProposerRewards, ProposerRewardsInputs,
     },
+    utils::json_from_file,
 };
 use color_eyre::eyre::Result;
+use std::{collections::HashSet, fs::File};
 
 pub fn rewards(
     ProposerRewards {
@@ -21,26 +19,20 @@ pub fn rewards(
         total_stake_threshold,
         approval_threshold,
         output_format,
-        vit_station_url,
     }: &ProposerRewards,
-    http: &impl HttpClient,
 ) -> Result<()> {
-    let (proposals, voteplans, challenges) = load_data(
-        http,
-        vit_station_url,
-        proposals.as_deref(),
-        active_voteplans.as_deref(),
-        challenges.as_deref(),
-    )?;
+    let proposals = json_from_file(proposals)?;
+    let voteplans = json_from_file(active_voteplans)?;
+    let challenges = json_from_file(challenges)?;
 
     let block0_config = serde_yaml::from_reader(File::open(block0)?)?;
 
     let excluded_proposals = match excluded_proposals {
-        Some(path) => serde_json::from_reader(File::open(path)?)?,
+        Some(path) => json_from_file(path)?,
         None => HashSet::new(),
     };
     let committee_keys = match committee_keys {
-        Some(path) => serde_json::from_reader(File::open(path)?)?,
+        Some(path) => json_from_file(path)?,
         None => vec![],
     };
 

--- a/src/catalyst-toolbox/catalyst-toolbox/src/bin/cli/stats/archive.rs
+++ b/src/catalyst-toolbox/catalyst-toolbox/src/bin/cli/stats/archive.rs
@@ -43,27 +43,27 @@ impl ArchiveCommand {
                 let result = archiver.number_of_votes_per_caster();
                 if self.calculate_distribution {
                     let dist = ArchiveStats::calculate_distribution(&result);
-                    dump_to_csv_or_print(self.output, dist.values())?;
+                    dump_to_csv_or_print(&self.output, dist.values())?;
                 } else {
-                    dump_to_csv_or_print(self.output, result.values())?;
+                    dump_to_csv_or_print(&self.output, result.values())?;
                 }
             }
             Command::VotesBySlot => {
                 let result = archiver.number_of_tx_per_slot();
                 if self.calculate_distribution {
                     let dist = ArchiveStats::calculate_distribution(&result);
-                    dump_to_csv_or_print(self.output, dist.values())?;
+                    dump_to_csv_or_print(&self.output, dist.values())?;
                 } else {
-                    dump_to_csv_or_print(self.output, result.values())?;
+                    dump_to_csv_or_print(&self.output, result.values())?;
                 }
             }
             Command::BatchSizeByCaster(batch_size_by_caster) => {
                 let result = batch_size_by_caster.exec(archiver)?;
                 if self.calculate_distribution {
                     let dist = ArchiveStats::calculate_distribution(&result);
-                    dump_to_csv_or_print(self.output, dist.values())?;
+                    dump_to_csv_or_print(&self.output, dist.values())?;
                 } else {
-                    dump_to_csv_or_print(self.output, result.values())?;
+                    dump_to_csv_or_print(&self.output, result.values())?;
                 }
             }
         };

--- a/src/catalyst-toolbox/catalyst-toolbox/src/rewards/proposers/io.rs
+++ b/src/catalyst-toolbox/catalyst-toolbox/src/rewards/proposers/io.rs
@@ -1,18 +1,13 @@
-use crate::http::HttpClient;
 use color_eyre::eyre::Result;
 use jormungandr_lib::{
     crypto::hash::Hash,
     interfaces::{VotePlanStatus, VoteProposalStatus},
 };
 use std::{collections::HashMap, fs::File, io::BufWriter, path::Path};
-use tracing::{info, warn};
 use vit_servicing_station_lib::db::models::{challenges::Challenge, proposals::Proposal};
-
-use serde::Deserialize;
 
 use super::{build_path_for_challenge, Calculation, OutputFormat};
 
-type VitSSData = (Vec<Proposal>, Vec<VotePlanStatus>, Vec<Challenge>);
 type CleanedVitSSData = (
     HashMap<Hash, Proposal>,
     HashMap<Hash, VoteProposalStatus>,
@@ -53,32 +48,6 @@ fn write_csv(path: &Path, results: &[Calculation]) -> Result<()> {
     Ok(())
 }
 
-pub fn load_data(
-    http: &impl HttpClient,
-    vit_station_url: &str,
-    proposals: Option<&Path>,
-    active_voteplans: Option<&Path>,
-    challenges: Option<&Path>,
-) -> Result<VitSSData> {
-    let data = match (proposals, active_voteplans, challenges) {
-        (Some(p), Some(vp), Some(c)) => {
-            info!("loading data from files");
-            get_data_from_files(p, vp, c)?
-        }
-        (None, None, None) => {
-            info!("loading data from network: {vit_station_url}");
-            get_data_from_network(http, vit_station_url)?
-        }
-        _else => {
-            warn!("warning: not all of --proposals, --active-voteplans and --challenges were set, falling back to network");
-            info!("loading data from network: {vit_station_url}");
-            get_data_from_network(http, vit_station_url)?
-        }
-    };
-
-    Ok(data)
-}
-
 pub fn vecs_to_maps(
     proposals: Vec<Proposal>,
     voteplans: Vec<VotePlanStatus>,
@@ -104,49 +73,12 @@ pub fn vecs_to_maps(
     Ok((proposals_map, voteplan_proposals, challenge_map))
 }
 
-fn get_data_from_network(http: &impl HttpClient, vit_station_url: &str) -> Result<VitSSData> {
-    let proposals = json_from_network(http, format!("{vit_station_url}/api/v0/proposals"))?;
-    let voteplans = json_from_network(http, format!("{vit_station_url}/api/v0/vote/active/plans"))?;
-    let challenges = json_from_network(http, format!("{vit_station_url}/api/v0/challenges"))?;
-
-    Ok((proposals, voteplans, challenges))
-}
-
-pub fn json_from_file<T: for<'a> Deserialize<'a>>(path: impl AsRef<Path>) -> Result<T> {
-    Ok(serde_json::from_reader(File::open(path)?)?)
-}
-
-pub fn json_from_network<T: for<'a> Deserialize<'a>>(
-    http: &impl HttpClient,
-    url: impl AsRef<str>,
-) -> Result<T> {
-    http.get(url.as_ref())?.json()
-}
-
-fn get_data_from_files(
-    proposals: &Path,
-    active_voteplans: &Path,
-    challenges: &Path,
-) -> Result<VitSSData> {
-    let proposals = json_from_file(proposals)?;
-    let voteplans = json_from_file(active_voteplans)?;
-    let challenges = json_from_file(challenges)?;
-
-    Ok((proposals, voteplans, challenges))
-}
-
 #[cfg(test)]
 mod tests {
-    use std::fs::read_to_string;
-
     use super::*;
+    use crate::{rewards::proposers::Calculation, utils::json_from_file};
     use assert_fs::TempDir;
-    use reqwest::StatusCode;
-
-    use crate::{
-        http::mock::{Method, MockClient, Spec},
-        rewards::proposers::Calculation,
-    };
+    use std::fs::read_to_string;
 
     #[test]
     fn write_csv_adds_header() {
@@ -190,33 +122,9 @@ mod tests {
         std::fs::write(&voteplans_file, empty).unwrap();
         std::fs::write(&challenges_file, empty).unwrap();
 
-        let (proposals, voteplans, challenges) =
-            get_data_from_files(&proposals_file, &voteplans_file, &challenges_file).unwrap();
-
-        assert_eq!(proposals, vec![]);
-        assert_eq!(voteplans, vec![]);
-        assert_eq!(challenges, vec![]);
-    }
-
-    #[test]
-    fn can_read_data_from_network() {
-        let mock_client = MockClient::new(|spec| match spec {
-            Spec {
-                method: Method::Get,
-                path: "/api/v0/proposals",
-            } => ("[]".to_string(), StatusCode::OK),
-            Spec {
-                method: Method::Get,
-                path: "/api/v0/vote/active/plans",
-            } => ("[]".to_string(), StatusCode::OK),
-            Spec {
-                method: Method::Get,
-                path: "/api/v0/challenges",
-            } => ("[]".to_string(), StatusCode::OK),
-            _ => ("not found".to_string(), StatusCode::NOT_FOUND),
-        });
-
-        let (proposals, voteplans, challenges) = get_data_from_network(&mock_client, "").unwrap();
+        let proposals: Vec<Proposal> = json_from_file(proposals_file).unwrap();
+        let voteplans: Vec<VotePlanStatus> = json_from_file(voteplans_file).unwrap();
+        let challenges: Vec<Challenge> = json_from_file(challenges_file).unwrap();
 
         assert_eq!(proposals, vec![]);
         assert_eq!(voteplans, vec![]);

--- a/src/catalyst-toolbox/catalyst-toolbox/src/rewards/proposers/types.rs
+++ b/src/catalyst-toolbox/catalyst-toolbox/src/rewards/proposers/types.rs
@@ -58,16 +58,13 @@ pub struct ProposerRewards {
     pub output_format: OutputFormat,
 
     #[clap(long = "proposals-path")]
-    pub proposals: Option<PathBuf>,
+    pub proposals: PathBuf,
     #[clap(long = "excluded-proposals-path")]
     pub excluded_proposals: Option<PathBuf>,
     #[clap(long = "active-voteplan-path")]
-    pub active_voteplans: Option<PathBuf>,
+    pub active_voteplans: PathBuf,
     #[clap(long = "challenges-path")]
-    pub challenges: Option<PathBuf>,
-
-    #[clap(default_value = "https://servicing-station.vit.iohk.io")]
-    pub vit_station_url: String,
+    pub challenges: PathBuf,
 
     #[clap(long = "committee-keys-path")]
     pub committee_keys: Option<PathBuf>,

--- a/src/catalyst-toolbox/catalyst-toolbox/src/testing.rs
+++ b/src/catalyst-toolbox/catalyst-toolbox/src/testing.rs
@@ -22,7 +22,6 @@ pub struct ProposerRewardsCommand {
     excluded_proposals_path: Option<String>,
     active_voteplan_path: Option<String>,
     challenges_path: Option<String>,
-    vit_station_url: Option<String>,
 }
 
 #[derive(Debug, Error)]
@@ -45,7 +44,6 @@ impl Default for ProposerRewardsCommand {
             excluded_proposals_path: None,
             active_voteplan_path: None,
             challenges_path: None,
-            vit_station_url: None,
         }
     }
 }
@@ -98,10 +96,6 @@ impl ProposerRewardsCommand {
         self.challenges_path = Some(challenges_path);
         self
     }
-    pub fn vit_station_url(mut self, vit_station_url: String) -> Self {
-        self.vit_station_url = Some(vit_station_url);
-        self
-    }
 
     pub fn cmd(self, temp_dir: &TempDir) -> Result<Command, Error> {
         let script_content = include_str!("../scripts/python/proposers_rewards.py");
@@ -147,9 +141,6 @@ impl ProposerRewardsCommand {
             command
                 .arg("--committee-keys-path")
                 .arg(committee_keys_path);
-        }
-        if let Some(vit_station_url) = self.vit_station_url {
-            command.arg("--vit-station-url").arg(vit_station_url);
         }
 
         Ok(command)

--- a/src/catalyst-toolbox/catalyst-toolbox/src/utils/csv.rs
+++ b/src/catalyst-toolbox/catalyst-toolbox/src/utils/csv.rs
@@ -12,8 +12,8 @@ pub fn load_data_from_csv<T: DeserializeOwned, const DELIMITER: u8>(
     csv_reader.deserialize().collect::<Result<Vec<T>, _>>()
 }
 
-pub fn dump_data_to_csv<'a, T: 'a + Serialize>(
-    data: impl IntoIterator<Item = &'a T>,
+pub fn dump_data_to_csv<T: Serialize>(
+    data: impl IntoIterator<Item = T>,
     file_path: &Path,
 ) -> Result<(), csv::Error> {
     let mut writer = csv::WriterBuilder::new()
@@ -25,11 +25,11 @@ pub fn dump_data_to_csv<'a, T: 'a + Serialize>(
     Ok(())
 }
 
-pub fn dump_to_csv_or_print<'a, T: 'a + Serialize + Debug>(
-    output: Option<PathBuf>,
-    result: impl Iterator<Item = &'a T> + Debug,
+pub fn dump_to_csv_or_print<T: Serialize + Debug>(
+    output: &Option<PathBuf>,
+    result: impl Iterator<Item = T> + Debug,
 ) -> Result<(), std::io::Error> {
-    if let Some(output) = &output {
+    if let Some(output) = output {
         dump_data_to_csv(result, output)?;
     } else {
         let mut writer = csv::WriterBuilder::new()

--- a/src/catalyst-toolbox/catalyst-toolbox/src/utils/mod.rs
+++ b/src/catalyst-toolbox/catalyst-toolbox/src/utils/mod.rs
@@ -1,7 +1,9 @@
 pub mod csv;
 pub mod serde;
 
+use ::serde::Deserialize;
 use rust_decimal::Decimal;
+use std::{fs::File, path::Path};
 
 const DEFAULT_DECIMAL_PRECISION: u32 = 10;
 
@@ -11,4 +13,8 @@ pub fn assert_are_close(a: Decimal, b: Decimal) {
         a.round_dp(DEFAULT_DECIMAL_PRECISION),
         b.round_dp(DEFAULT_DECIMAL_PRECISION)
     );
+}
+
+pub fn json_from_file<T: for<'a> Deserialize<'a>>(path: impl AsRef<Path>) -> color_eyre::Result<T> {
+    Ok(serde_json::from_reader(File::open(path)?)?)
 }


### PR DESCRIPTION
# Description

Removed vit-ss server usage from catalyst-toolbox cli tool for gathering proposer's rewards. So right now all needed information should be passed by files