### PR TITLE
refactor: Replace the usage of some vit-ss types inside catalyst-toolbox | NPG-6766

### DIFF
--- a/src/catalyst-toolbox/catalyst-toolbox/src/bin/cli/rewards/dreps.rs
+++ b/src/catalyst-toolbox/catalyst-toolbox/src/bin/cli/rewards/dreps.rs
@@ -1,12 +1,11 @@
 use catalyst_toolbox::rewards::voters::calc_voter_rewards;
 use catalyst_toolbox::rewards::{Rewards, Threshold};
+use catalyst_toolbox::types::proposal::FullProposalInfo;
 use clap::Parser;
 use color_eyre::Report;
 use jcli_lib::jcli_lib::block::Common;
 use jormungandr_lib::{crypto::account::Identifier, interfaces::AccountVotes};
 use snapshot_lib::{registration::MainnetRewardAddress, SnapshotInfo};
-use vit_servicing_station_lib::db::models::proposals::FullProposalInfo;
-
 use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
 

--- a/src/catalyst-toolbox/catalyst-toolbox/src/bin/cli/rewards/mod.rs
+++ b/src/catalyst-toolbox/catalyst-toolbox/src/bin/cli/rewards/mod.rs
@@ -5,8 +5,7 @@ mod proposers;
 mod veterans;
 mod voters;
 
-use std::{collections::HashMap, path::PathBuf};
-
+use catalyst_toolbox::types::proposal::FullProposalInfo;
 use catalyst_toolbox::{
     http::default_http_client,
     rewards::{proposers as proposers_lib, VoteCount},
@@ -17,7 +16,7 @@ use jormungandr_lib::{
     crypto::{account::Identifier, hash::Hash},
     interfaces::AccountVotes,
 };
-use vit_servicing_station_lib::db::models::proposals::FullProposalInfo;
+use std::{collections::HashMap, path::PathBuf};
 
 #[derive(Parser)]
 #[clap(rename_all = "kebab-case")]

--- a/src/catalyst-toolbox/catalyst-toolbox/src/lib.rs
+++ b/src/catalyst-toolbox/catalyst-toolbox/src/lib.rs
@@ -11,6 +11,7 @@ pub mod recovery;
 pub mod rewards;
 pub mod stats;
 pub mod testing;
+mod types;
 pub mod utils;
 pub mod vca_reviews;
 pub mod vote_check;

--- a/src/catalyst-toolbox/catalyst-toolbox/src/lib.rs
+++ b/src/catalyst-toolbox/catalyst-toolbox/src/lib.rs
@@ -11,7 +11,7 @@ pub mod recovery;
 pub mod rewards;
 pub mod stats;
 pub mod testing;
-mod types;
+pub mod types;
 pub mod utils;
 pub mod vca_reviews;
 pub mod vote_check;

--- a/src/catalyst-toolbox/catalyst-toolbox/src/rewards/dreps.rs
+++ b/src/catalyst-toolbox/catalyst-toolbox/src/rewards/dreps.rs
@@ -218,7 +218,12 @@ mod tests {
             votes_count,
             String::new(),
             voters.len(),
-            Threshold::new(1, per_challenge_threshold.clone(), proposals.clone()).unwrap(),
+            Threshold::new(
+                1,
+                per_challenge_threshold.clone(),
+                proposals.clone().into_iter().map(Into::into).collect(),
+            )
+            .unwrap(),
             Rewards::ONE,
         )
         .unwrap();
@@ -228,7 +233,12 @@ mod tests {
             only_active,
             String::new(),
             voters.len(),
-            Threshold::new(1, per_challenge_threshold, proposals).unwrap(),
+            Threshold::new(
+                1,
+                per_challenge_threshold,
+                proposals.into_iter().map(Into::into).collect(),
+            )
+            .unwrap(),
             Rewards::ONE,
         )
         .unwrap();

--- a/src/catalyst-toolbox/catalyst-toolbox/src/rewards/mod.rs
+++ b/src/catalyst-toolbox/catalyst-toolbox/src/rewards/mod.rs
@@ -10,12 +10,12 @@ pub type Funds = Decimal;
 pub type Rewards = Decimal;
 pub type VoteCount = HashMap<Identifier, HashSet<Hash>>;
 
+use crate::types::proposal::FullProposalInfo;
 use chain_impl_mockchain::certificate::ExternalProposalId;
 use jormungandr_lib::crypto::{account::Identifier, hash::Hash};
 use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
 use thiserror::Error;
-use vit_servicing_station_lib::db::models::proposals::FullProposalInfo;
 
 #[derive(Debug, Error)]
 pub enum Error {

--- a/src/catalyst-toolbox/catalyst-toolbox/src/rewards/proposers/io.rs
+++ b/src/catalyst-toolbox/catalyst-toolbox/src/rewards/proposers/io.rs
@@ -1,16 +1,16 @@
-use crate::http::HttpClient;
+use super::{build_path_for_challenge, Calculation, OutputFormat};
+use crate::{
+    http::HttpClient,
+    types::{challenge::Challenge, proposal::Proposal},
+};
 use color_eyre::eyre::Result;
 use jormungandr_lib::{
     crypto::hash::Hash,
     interfaces::{VotePlanStatus, VoteProposalStatus},
 };
+use serde::Deserialize;
 use std::{collections::HashMap, fs::File, io::BufWriter, path::Path};
 use tracing::{info, warn};
-use vit_servicing_station_lib::db::models::{challenges::Challenge, proposals::Proposal};
-
-use serde::Deserialize;
-
-use super::{build_path_for_challenge, Calculation, OutputFormat};
 
 type VitSSData = (Vec<Proposal>, Vec<VotePlanStatus>, Vec<Challenge>);
 type CleanedVitSSData = (

--- a/src/catalyst-toolbox/catalyst-toolbox/src/rewards/proposers/mod.rs
+++ b/src/catalyst-toolbox/catalyst-toolbox/src/rewards/proposers/mod.rs
@@ -1,5 +1,5 @@
-use std::collections::{HashMap, HashSet};
-
+use self::{io::vecs_to_maps, types::NotFundedReason};
+use crate::types::{challenge::Challenge, proposal::Proposal};
 use chain_impl_mockchain::value::Value;
 use color_eyre::{
     eyre::{bail, eyre},
@@ -12,13 +12,10 @@ use jormungandr_lib::{
         Address, Block0Configuration, Initial, Tally, VotePlanStatus, VoteProposalStatus,
     },
 };
+use std::collections::{HashMap, HashSet};
 use tracing::debug;
-use vit_servicing_station_lib::db::models::{challenges::Challenge, proposals::Proposal};
-
 pub use types::*;
 pub use util::build_path_for_challenge;
-
-use self::{io::vecs_to_maps, types::NotFundedReason};
 
 pub mod io;
 mod types;

--- a/src/catalyst-toolbox/catalyst-toolbox/src/rewards/voters.rs
+++ b/src/catalyst-toolbox/catalyst-toolbox/src/rewards/voters.rs
@@ -451,7 +451,7 @@ mod tests {
             Threshold::new(
                 DEFAULT_TEST_THRESHOLD,
                 per_challenge_threshold.clone(),
-                proposals.clone(),
+                proposals.clone().into_iter().map(Into::into).collect(),
             )
             .unwrap(),
             Rewards::ONE,
@@ -461,7 +461,12 @@ mod tests {
         let rewards_only_active = calc_voter_rewards(
             only_active,
             voters,
-            Threshold::new(DEFAULT_TEST_THRESHOLD, per_challenge_threshold, proposals).unwrap(),
+            Threshold::new(
+                DEFAULT_TEST_THRESHOLD,
+                per_challenge_threshold,
+                proposals.into_iter().map(Into::into).collect(),
+            )
+            .unwrap(),
             Rewards::ONE,
         )
         .unwrap();

--- a/src/catalyst-toolbox/catalyst-toolbox/src/types/challenge.rs
+++ b/src/catalyst-toolbox/catalyst-toolbox/src/types/challenge.rs
@@ -1,0 +1,39 @@
+use serde::{Serialize, Deserialize};
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct Challenge {
+    pub id: i32,
+    pub title: String,
+    #[serde(alias = "rewardsTotal")]
+    pub rewards_total: i64,
+    #[serde(alias = "proposersRewards")]
+    pub proposers_rewards: i64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn challenge_json_test() {
+        let json = serde_json::json!({
+            "id": 1,
+            "title": "test",
+            "rewards_total": 1,
+            "proposers_rewards": 1,
+            "not_challenge_data": "some"
+        });
+
+        let challenge: Challenge = serde_json::from_value(json).unwrap();
+
+        assert_eq!(
+            challenge,
+            Challenge {
+                id: 1,
+                title: "test".to_string(),
+                rewards_total: 1,
+                proposers_rewards: 1,
+            }
+        );
+    }
+}

--- a/src/catalyst-toolbox/catalyst-toolbox/src/types/challenge.rs
+++ b/src/catalyst-toolbox/catalyst-toolbox/src/types/challenge.rs
@@ -1,4 +1,4 @@
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct Challenge {

--- a/src/catalyst-toolbox/catalyst-toolbox/src/types/mod.rs
+++ b/src/catalyst-toolbox/catalyst-toolbox/src/types/mod.rs
@@ -1,2 +1,2 @@
-pub mod proposal;
 pub mod challenge;
+pub mod proposal;

--- a/src/catalyst-toolbox/catalyst-toolbox/src/types/mod.rs
+++ b/src/catalyst-toolbox/catalyst-toolbox/src/types/mod.rs
@@ -1,0 +1,2 @@
+pub mod proposal;
+pub mod challenge;

--- a/src/catalyst-toolbox/catalyst-toolbox/src/types/proposal.rs
+++ b/src/catalyst-toolbox/catalyst-toolbox/src/types/proposal.rs
@@ -1,0 +1,67 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
+pub struct VoteOptions(pub HashMap<String, u8>);
+
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+pub struct Proposal {
+    #[serde(alias = "internalId")]
+    pub internal_id: i32,
+    #[serde(alias = "proposalId")]
+    pub proposal_id: String,
+    #[serde(alias = "proposalTitle")]
+    pub proposal_title: String,
+    #[serde(alias = "proposalFunds")]
+    pub proposal_funds: i64,
+    #[serde(alias = "proposalUrl")]
+    pub proposal_url: String,
+    #[serde(alias = "proposalImpactScore")]
+    pub proposal_impact_score: i64,
+    #[serde(alias = "chainProposalId")]
+    pub chain_proposal_id: Vec<u8>,
+    #[serde(alias = "chainVoteOptions")]
+    pub chain_vote_options: VoteOptions,
+    #[serde(alias = "challengeId")]
+    pub challenge_id: i32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn proposal_json_test() {
+        let json = serde_json::json!({
+            "internal_id": 1,
+            "proposal_id": "1",
+            "proposal_title": "test",
+            "proposal_funds": 1,
+            "proposal_url": "test",
+            "proposal_impact_score": 1,
+            "chain_proposal_id": [1],
+            "chain_vote_options": {
+                "1": 1
+            },
+            "challenge_id": 1,
+            "not_proposal_data": "some",
+        });
+
+        let proposal: Proposal = serde_json::from_value(json).unwrap();
+
+        assert_eq!(
+            proposal,
+            Proposal{
+                internal_id: 1,
+                proposal_id: "1".to_string(),
+                proposal_title: "test".to_string(),
+                proposal_funds: 1,
+                proposal_url: "test".to_string(),
+                proposal_impact_score: 1,
+                chain_proposal_id: vec![1],
+                chain_vote_options: VoteOptions(HashMap::from([("1".to_string(), 1)])),
+                challenge_id: 1
+            }
+        );
+    }
+}

--- a/src/catalyst-toolbox/catalyst-toolbox/src/types/proposal.rs
+++ b/src/catalyst-toolbox/catalyst-toolbox/src/types/proposal.rs
@@ -26,6 +26,47 @@ pub struct Proposal {
     pub challenge_id: i32,
 }
 
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+pub struct ProposalVotePlanCommon {
+    #[serde(alias = "chainVoteplanId")]
+    pub chain_voteplan_id: String,
+    #[serde(alias = "chainProposalIndex")]
+    pub chain_proposal_index: i64,
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+pub struct FullProposalInfo {
+    #[serde(flatten)]
+    pub proposal: Proposal,
+    #[serde(flatten)]
+    pub voteplan: ProposalVotePlanCommon,
+    #[serde(alias = "groupId")]
+    pub group_id: String,
+}
+
+impl From<vit_servicing_station_lib::db::models::proposals::FullProposalInfo> for FullProposalInfo {
+    fn from(val: vit_servicing_station_lib::db::models::proposals::FullProposalInfo) -> Self {
+        Self {
+            proposal: Proposal {
+                internal_id: val.proposal.internal_id,
+                proposal_id: val.proposal.proposal_id,
+                proposal_title: val.proposal.proposal_title,
+                proposal_funds: val.proposal.proposal_funds,
+                proposal_url: val.proposal.proposal_url,
+                proposal_impact_score: val.proposal.proposal_impact_score,
+                chain_proposal_id: val.proposal.chain_proposal_id,
+                chain_vote_options: VoteOptions(val.proposal.chain_vote_options.0),
+                challenge_id: val.proposal.challenge_id,
+            },
+            voteplan: ProposalVotePlanCommon {
+                chain_voteplan_id: val.voteplan.chain_voteplan_id,
+                chain_proposal_index: val.voteplan.chain_proposal_index,
+            },
+            group_id: val.group_id,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -51,7 +92,7 @@ mod tests {
 
         assert_eq!(
             proposal,
-            Proposal{
+            Proposal {
                 internal_id: 1,
                 proposal_id: "1".to_string(),
                 proposal_title: "test".to_string(),

--- a/src/vit-testing/integration-tests/src/e2e/local/active_voters_rewards.rs
+++ b/src/vit-testing/integration-tests/src/e2e/local/active_voters_rewards.rs
@@ -145,7 +145,7 @@ pub fn voters_with_at_least_one_vote() {
                 .iter()
                 .map(|x| (x.id, x.proposers_rewards as usize))
                 .collect(),
-            proposals,
+            proposals.into_iter().map(Into::into).collect(),
         )
         .unwrap(),
         1_000_000u32.into(),

--- a/src/vit-testing/integration-tests/src/e2e/rewards/drep_rewards.rs
+++ b/src/vit-testing/integration-tests/src/e2e/rewards/drep_rewards.rs
@@ -220,7 +220,7 @@ pub fn drep_rewards_happy_path() {
                 .iter()
                 .map(|x| (x.id, VOTE_THRESHOLD_PER_CHALLENGE as usize))
                 .collect(),
-            proposals,
+            proposals.into_iter().map(Into::into).collect(),
         )
         .unwrap(),
         TOTAL_REWARD.into(),

--- a/src/vit-testing/integration-tests/src/e2e/rewards/rewards_scenarios.rs
+++ b/src/vit-testing/integration-tests/src/e2e/rewards/rewards_scenarios.rs
@@ -216,7 +216,7 @@ pub fn mixed_rewards_happy_path() {
                 .iter()
                 .map(|x| (x.id, VOTE_THRESHOLD_PER_CHALLENGE as usize))
                 .collect(),
-            proposals.clone(),
+            proposals.clone().into_iter().map(Into::into).collect(),
         )
         .unwrap(),
         TOTAL_REWARD.into(),
@@ -234,7 +234,7 @@ pub fn mixed_rewards_happy_path() {
                 .iter()
                 .map(|x| (x.id, VOTE_THRESHOLD_PER_CHALLENGE as usize))
                 .collect(),
-            proposals,
+            proposals.into_iter().map(Into::into).collect(),
         )
         .unwrap(),
         TOTAL_REWARD.into(),

--- a/src/vit-testing/integration-tests/src/e2e/rewards/voter_rewards.rs
+++ b/src/vit-testing/integration-tests/src/e2e/rewards/voter_rewards.rs
@@ -159,7 +159,7 @@ pub fn voter_rewards_happy_path() {
                 .iter()
                 .map(|x| (x.id, VOTE_THRESHOLD_PER_CHALLENGE as usize))
                 .collect(),
-            proposals,
+            proposals.into_iter().map(Into::into).collect(),
         )
         .unwrap(),
         TOTAL_REWARD.into(),


### PR DESCRIPTION
# Description

Removed usage of some vit-ss types as `Proposal`, `Challenge`, `FullProposalInfo`, replaced it with the new corresponded internal catalyst-toolbox types