### PR TITLE
feat: Add `reward_address` field for the Delegation endpoint | NPG-6785

### DIFF
--- a/book/src/07_web_api/openapi/core_backend_api.yaml
+++ b/book/src/07_web_api/openapi/core_backend_api.yaml
@@ -1665,6 +1665,10 @@ components:
           type: number
           format: u64
           description: Raw voting power distributed to this voting key.
+        reward_address:
+          type: string
+          pattern: '[0-9a-f]{64}'
+          description: Hex encoded reward address for this delegation.
       required:
         - voting_key
         - group

--- a/book/src/07_web_api/openapi/core_backend_api.yaml
+++ b/book/src/07_web_api/openapi/core_backend_api.yaml
@@ -1665,10 +1665,6 @@ components:
           type: number
           format: u64
           description: Raw voting power distributed to this voting key.
-        reward_address:
-          type: string
-          pattern: '[0-9a-f]{64}'
-          description: Hex encoded reward address for this delegation.
       required:
         - voting_key
         - group
@@ -1691,6 +1687,10 @@ components:
           description: |-
             List off delegations made by this stake address.
             In the order as presented in the voters registration.
+        reward_address:
+          type: string
+          pattern: '[0-9a-f]{64}'
+          description: Hex encoded reward address for this delegation.
         raw_power:
           type: number
           description: Raw total voting power from stake address

--- a/src/cat-data-service/src/service/v1/registration.rs
+++ b/src/cat-data-service/src/service/v1/registration.rs
@@ -193,13 +193,15 @@ mod tests {
                             "voting_key": "voting_key_1",
                             "group": "rep",
                             "weight": 1,
-                            "value": 140
+                            "value": 140,
+                            "reward_address": "reward_address_1"
                         },
                         {
                             "voting_key": "voting_key_2",
                             "group": "rep",
                             "weight": 1,
-                            "value": 100
+                            "value": 100,
+                            "reward_address": "reward_address_3"
                         },
                     ],
                     "raw_power": 240,
@@ -229,13 +231,15 @@ mod tests {
                             "voting_key": "voting_key_1",
                             "group": "rep",
                             "weight": 1,
-                            "value": 140
+                            "value": 140,
+                            "reward_address": "reward_address_1"
                         },
                         {
                             "voting_key": "voting_key_2",
                             "group": "rep",
                             "weight": 1,
-                            "value": 100
+                            "value": 100,
+                            "reward_address": "reward_address_3"
                         },
                     ],
                     "raw_power": 240,

--- a/src/cat-data-service/src/service/v1/registration.rs
+++ b/src/cat-data-service/src/service/v1/registration.rs
@@ -194,16 +194,15 @@ mod tests {
                             "group": "rep",
                             "weight": 1,
                             "value": 140,
-                            "reward_address": "reward_address_1"
                         },
                         {
                             "voting_key": "voting_key_2",
                             "group": "rep",
                             "weight": 1,
                             "value": 100,
-                            "reward_address": "reward_address_3"
                         },
                     ],
+                    "reward_address": "reward_address_1",
                     "raw_power": 240,
                     "total_power": 1000,
                     "as_at": "2022-03-31T12:00:00+00:00",
@@ -232,16 +231,15 @@ mod tests {
                             "group": "rep",
                             "weight": 1,
                             "value": 140,
-                            "reward_address": "reward_address_1"
                         },
                         {
                             "voting_key": "voting_key_2",
                             "group": "rep",
                             "weight": 1,
                             "value": 100,
-                            "reward_address": "reward_address_3"
                         },
                     ],
+                    "reward_address": "reward_address_1",
                     "raw_power": 240,
                     "total_power": 1000,
                     "as_at": "2020-03-31T12:00:00+00:00",

--- a/src/event-db/migrations/V6__snapshot_tables.sql
+++ b/src/event-db/migrations/V6__snapshot_tables.sql
@@ -102,6 +102,7 @@ CREATE TABLE contribution (
 
     voting_group TEXT NOT NULL,
 
+    -- each unique stake_public_key should have the same reward_address
     reward_address TEXT NULL,
 
     FOREIGN KEY(snapshot_id) REFERENCES snapshot(row_id) ON DELETE CASCADE

--- a/src/event-db/src/queries/registration.rs
+++ b/src/event-db/src/queries/registration.rs
@@ -60,7 +60,7 @@ impl EventDB {
                                                 WHERE snapshot.last_updated = (SELECT MAX(snapshot.last_updated) as last_updated from snapshot)
                                                 LIMIT 1;";
 
-    const DELEGATIONS_BY_EVENT_QUERY: &'static str = "SELECT contribution.voting_key, contribution.voting_group, contribution.voting_weight, contribution.value
+    const DELEGATIONS_BY_EVENT_QUERY: &'static str = "SELECT contribution.voting_key, contribution.voting_group, contribution.voting_weight, contribution.value, contribution.reward_address
                                                 FROM contribution
                                                 INNER JOIN snapshot ON contribution.snapshot_id = snapshot.row_id
                                                 WHERE contribution.stake_public_key = $1 AND snapshot.event = $2;";
@@ -182,6 +182,7 @@ impl RegistrationQueries for EventDB {
                 group: VoterGroupId(row.try_get("voting_group")?),
                 weight: row.try_get("voting_weight")?,
                 value: row.try_get("value")?,
+                reward_address: row.try_get("reward_address")?,
             })
         }
 
@@ -328,13 +329,15 @@ mod tests {
                         voting_key: "voting_key_1".to_string(),
                         group: VoterGroupId("rep".to_string()),
                         weight: 1,
-                        value: 140
+                        value: 140,
+                        reward_address: "reward_address_1".to_string()
                     },
                     Delegation {
                         voting_key: "voting_key_2".to_string(),
                         group: VoterGroupId("rep".to_string()),
                         weight: 1,
-                        value: 100
+                        value: 100,
+                        reward_address: "reward_address_3".to_string()
                     }
                 ],
                 raw_power: 240,
@@ -370,13 +373,15 @@ mod tests {
                         voting_key: "voting_key_1".to_string(),
                         group: VoterGroupId("rep".to_string()),
                         weight: 1,
-                        value: 140
+                        value: 140,
+                        reward_address: "reward_address_1".to_string()
                     },
                     Delegation {
                         voting_key: "voting_key_2".to_string(),
                         group: VoterGroupId("rep".to_string()),
                         weight: 1,
-                        value: 100
+                        value: 100,
+                        reward_address: "reward_address_3".to_string()
                     }
                 ],
                 raw_power: 240,

--- a/src/event-db/src/queries/registration.rs
+++ b/src/event-db/src/queries/registration.rs
@@ -49,27 +49,21 @@ impl EventDB {
         INNER JOIN snapshot ON voter.snapshot_id = snapshot.row_id AND snapshot.last_updated = (SELECT MAX(snapshot.last_updated) as last_updated from snapshot)
         WHERE voter.voting_group = $1;";
 
-    const DELEGATOR_BY_EVENT_QUERY: &'static str = "SELECT contribution.voting_key, contribution.voting_group, snapshot.as_at, snapshot.last_updated, snapshot.final
-                                                FROM contribution
-                                                INNER JOIN snapshot ON contribution.snapshot_id = snapshot.row_id
-                                                WHERE contribution.stake_public_key = $1 AND snapshot.event = $2
+    const DELEGATOR_SNAPSHOT_INFO_BY_EVENT_QUERY: &'static str = "
+                                                SELECT snapshot.as_at, snapshot.last_updated, snapshot.final
+                                                FROM snapshot
+                                                WHERE snapshot.event = $1
                                                 LIMIT 1;";
 
-    const DELEGATOR_BY_LAST_EVENT_QUERY: &'static str = "SELECT contribution.voting_key, contribution.voting_group, snapshot.as_at, snapshot.last_updated, snapshot.final
-                                                FROM contribution
-                                                INNER JOIN snapshot ON contribution.snapshot_id = snapshot.row_id
-                                                WHERE contribution.stake_public_key = $1 AND snapshot.last_updated = (SELECT MAX(snapshot.last_updated) as last_updated from snapshot)
+    const DELEGATOR_SNAPSHOT_INFO_BY_LAST_EVENT_QUERY: &'static str = "SELECT snapshot.event, snapshot.as_at, snapshot.last_updated, snapshot.final
+                                                FROM snapshot
+                                                WHERE snapshot.last_updated = (SELECT MAX(snapshot.last_updated) as last_updated from snapshot)
                                                 LIMIT 1;";
 
-    const DELEGATIONS_BY_EVENT_QUERY: &'static str = "SELECT contribution.voting_key, contribution.voting_group, contribution.voting_weight, contribution.value,  snapshot.as_at, snapshot.last_updated, snapshot.final
+    const DELEGATIONS_BY_EVENT_QUERY: &'static str = "SELECT contribution.voting_key, contribution.voting_group, contribution.voting_weight, contribution.value
                                                 FROM contribution
                                                 INNER JOIN snapshot ON contribution.snapshot_id = snapshot.row_id
                                                 WHERE contribution.stake_public_key = $1 AND snapshot.event = $2;";
-
-    const DELEGATIONS_BY_LAST_EVENT_QUERY: &'static str = "SELECT contribution.voting_key, contribution.voting_group, contribution.voting_weight, contribution.value,  snapshot.as_at, snapshot.last_updated, snapshot.final
-                                                FROM contribution
-                                                INNER JOIN snapshot ON contribution.snapshot_id = snapshot.row_id
-                                                WHERE contribution.stake_public_key = $1 AND snapshot.last_updated = (SELECT MAX(snapshot.last_updated) as last_updated from snapshot);";
 
     const TOTAL_POWER_BY_EVENT_QUERY: &'static str = "SELECT SUM(voter.voting_power)::BIGINT as total_voting_power
                                                 FROM voter
@@ -151,16 +145,13 @@ impl RegistrationQueries for EventDB {
     ) -> Result<Delegator, Error> {
         let conn = self.pool.get().await?;
         let rows = if let Some(event) = event {
-            conn.query(
-                Self::DELEGATOR_BY_EVENT_QUERY,
-                &[&stake_public_key, &event.0],
-            )
-            .await?
+            conn.query(Self::DELEGATOR_SNAPSHOT_INFO_BY_EVENT_QUERY, &[&event.0])
+                .await?
         } else {
-            conn.query(Self::DELEGATOR_BY_LAST_EVENT_QUERY, &[&stake_public_key])
+            conn.query(Self::DELEGATOR_SNAPSHOT_INFO_BY_LAST_EVENT_QUERY, &[])
                 .await?
         };
-        let delegator = rows
+        let delegator_snapshot_info = rows
             .get(0)
             .ok_or_else(|| Error::NotFound("can not find delegator value".to_string()))?;
 
@@ -171,9 +162,18 @@ impl RegistrationQueries for EventDB {
             )
             .await?
         } else {
-            conn.query(Self::DELEGATIONS_BY_LAST_EVENT_QUERY, &[&stake_public_key])
-                .await?
+            conn.query(
+                Self::DELEGATIONS_BY_EVENT_QUERY,
+                &[
+                    &stake_public_key,
+                    &delegator_snapshot_info.try_get::<_, i32>("event")?,
+                ],
+            )
+            .await?
         };
+        if delegation_rows.is_empty() {
+            return Err(Error::NotFound("can not find delegator value".to_string()));
+        }
 
         let mut delegations = Vec::new();
         for row in delegation_rows {
@@ -199,15 +199,15 @@ impl RegistrationQueries for EventDB {
 
         Ok(Delegator {
             raw_power: delegations.iter().map(|delegation| delegation.value).sum(),
-            as_at: delegator
+            as_at: delegator_snapshot_info
                 .try_get::<_, NaiveDateTime>("as_at")?
                 .and_local_timezone(Utc)
                 .unwrap(),
-            last_updated: delegator
+            last_updated: delegator_snapshot_info
                 .try_get::<_, NaiveDateTime>("last_updated")?
                 .and_local_timezone(Utc)
                 .unwrap(),
-            is_final: delegator.try_get("final")?,
+            is_final: delegator_snapshot_info.try_get("final")?,
             delegations,
             total_power,
         })

--- a/src/event-db/src/queries/registration.rs
+++ b/src/event-db/src/queries/registration.rs
@@ -176,13 +176,12 @@ impl RegistrationQueries for EventDB {
         }
 
         let mut delegations = Vec::new();
-        for row in delegation_rows {
+        for row in &delegation_rows {
             delegations.push(Delegation {
                 voting_key: row.try_get("voting_key")?,
                 group: VoterGroupId(row.try_get("voting_group")?),
                 weight: row.try_get("voting_weight")?,
                 value: row.try_get("value")?,
-                reward_address: row.try_get("reward_address")?,
             })
         }
 
@@ -200,6 +199,7 @@ impl RegistrationQueries for EventDB {
 
         Ok(Delegator {
             raw_power: delegations.iter().map(|delegation| delegation.value).sum(),
+            reward_address: delegation_rows[0].try_get("reward_address")?,
             as_at: delegator_snapshot_info
                 .try_get::<_, NaiveDateTime>("as_at")?
                 .and_local_timezone(Utc)
@@ -330,16 +330,15 @@ mod tests {
                         group: VoterGroupId("rep".to_string()),
                         weight: 1,
                         value: 140,
-                        reward_address: "reward_address_1".to_string()
                     },
                     Delegation {
                         voting_key: "voting_key_2".to_string(),
                         group: VoterGroupId("rep".to_string()),
                         weight: 1,
                         value: 100,
-                        reward_address: "reward_address_3".to_string()
                     }
                 ],
+                reward_address: "reward_address_1".to_string(),
                 raw_power: 240,
                 total_power: 1000,
                 as_at: DateTime::<Utc>::from_utc(
@@ -374,16 +373,15 @@ mod tests {
                         group: VoterGroupId("rep".to_string()),
                         weight: 1,
                         value: 140,
-                        reward_address: "reward_address_1".to_string()
                     },
                     Delegation {
                         voting_key: "voting_key_2".to_string(),
                         group: VoterGroupId("rep".to_string()),
                         weight: 1,
                         value: 100,
-                        reward_address: "reward_address_3".to_string()
                     }
                 ],
+                reward_address: "reward_address_1".to_string(),
                 raw_power: 240,
                 total_power: 1000,
                 as_at: DateTime::<Utc>::from_utc(

--- a/src/event-db/src/types/registration.rs
+++ b/src/event-db/src/types/registration.rs
@@ -31,6 +31,7 @@ pub struct Delegation {
     pub group: VoterGroupId,
     pub weight: i32,
     pub value: i64,
+    pub reward_address: String,
 }
 
 #[derive(Debug, Serialize, Clone, PartialEq, Eq)]
@@ -94,6 +95,7 @@ mod tests {
                 group: VoterGroupId("rep".to_string()),
                 weight: 5,
                 value: 100,
+                reward_address: "reward address 1".to_string(),
             }],
             raw_power: 100,
             total_power: 1000,
@@ -106,7 +108,7 @@ mod tests {
             json,
             json!(
                 {
-                    "delegations": [{"voting_key": "voter","group": "rep","weight": 5,"value": 100}],
+                    "delegations": [{"voting_key": "voter","group": "rep","weight": 5,"value": 100,"reward_address": "reward address 1"}],
                     "raw_power": 100,
                     "total_power": 1000,
                     "as_at": "1970-01-01T00:00:00+00:00",

--- a/src/event-db/src/types/registration.rs
+++ b/src/event-db/src/types/registration.rs
@@ -31,12 +31,12 @@ pub struct Delegation {
     pub group: VoterGroupId,
     pub weight: i32,
     pub value: i64,
-    pub reward_address: String,
 }
 
 #[derive(Debug, Serialize, Clone, PartialEq, Eq)]
 pub struct Delegator {
     pub delegations: Vec<Delegation>,
+    pub reward_address: String,
     pub raw_power: i64,
     pub total_power: i64,
     #[serde(serialize_with = "serialize_datetime_as_rfc3339")]
@@ -95,8 +95,8 @@ mod tests {
                 group: VoterGroupId("rep".to_string()),
                 weight: 5,
                 value: 100,
-                reward_address: "reward address 1".to_string(),
             }],
+            reward_address: "reward address 1".to_string(),
             raw_power: 100,
             total_power: 1000,
             as_at: DateTime::from_utc(NaiveDateTime::default(), Utc),
@@ -108,7 +108,8 @@ mod tests {
             json,
             json!(
                 {
-                    "delegations": [{"voting_key": "voter","group": "rep","weight": 5,"value": 100,"reward_address": "reward address 1"}],
+                    "delegations": [{"voting_key": "voter","group": "rep","weight": 5,"value": 100}],
+                    "reward_address": "reward address 1",
                     "raw_power": 100,
                     "total_power": 1000,
                     "as_at": "1970-01-01T00:00:00+00:00",

--- a/src/event-db/test_data/04_contribution_table.sql
+++ b/src/event-db/test_data/04_contribution_table.sql
@@ -3,21 +3,21 @@ INSERT INTO contribution
 VALUES 
 (1, 'stake_public_key_1', 1, 'voting_key_1', 1, 1, 140, 'rep', 'reward_address_1'),
 (2, 'stake_public_key_2', 1, 'voting_key_1', 1, 1, 110, 'rep', 'reward_address_2'),
-(3, 'stake_public_key_1', 1, 'voting_key_2', 1, 1, 100, 'rep', 'reward_address_3'),
-(4, 'stake_public_key_4', 1, 'voting_key_2', 1, 1, 50, 'rep', 'reward_address_4'),
-(5, 'stake_public_key_5', 1, 'voting_key_3', 1, 1, 350, 'direct', 'reward_address_5'),
-(6, 'stake_public_key_5', 1, 'voting_key_5', 1, 1, 250, 'direct', 'reward_address_6'),
+(3, 'stake_public_key_1', 1, 'voting_key_2', 1, 1, 100, 'rep', 'reward_address_1'),
+(4, 'stake_public_key_3', 1, 'voting_key_2', 1, 1, 50, 'rep', 'reward_address_3'),
+(5, 'stake_public_key_4', 1, 'voting_key_3', 1, 1, 350, 'direct', 'reward_address_4'),
+(6, 'stake_public_key_5', 1, 'voting_key_5', 1, 1, 250, 'direct', 'reward_address_5'),
 
 (7, 'stake_public_key_1', 2, 'voting_key_1', 1, 1, 140, 'rep', 'reward_address_1'),
 (8, 'stake_public_key_2', 2, 'voting_key_1', 1, 1, 110, 'rep', 'reward_address_2'),
-(9, 'stake_public_key_1', 2, 'voting_key_2', 1, 1, 100, 'rep', 'reward_address_3'),
-(10, 'stake_public_key_3', 2, 'voting_key_2', 1, 1, 50, 'rep', 'reward_address_4'),
-(11, 'stake_public_key_4', 2, 'voting_key_3', 1, 1, 350, 'direct', 'reward_address_5'),
-(12, 'stake_public_key_5', 2, 'voting_key_5', 1, 1, 250, 'direct', 'reward_address_6'),
+(9, 'stake_public_key_1', 2, 'voting_key_2', 1, 1, 100, 'rep', 'reward_address_1'),
+(10, 'stake_public_key_3', 2, 'voting_key_2', 1, 1, 50, 'rep', 'reward_address_3'),
+(11, 'stake_public_key_4', 2, 'voting_key_3', 1, 1, 350, 'direct', 'reward_address_4'),
+(12, 'stake_public_key_5', 2, 'voting_key_5', 1, 1, 250, 'direct', 'reward_address_5'),
 
 (13, 'stake_public_key_1', 3, 'voting_key_1', 1, 1, 140, 'rep', 'reward_address_1'),
 (14, 'stake_public_key_2', 3, 'voting_key_1', 1, 1, 110, 'rep', 'reward_address_2'),
-(15, 'stake_public_key_1', 3, 'voting_key_2', 1, 1, 100, 'rep', 'reward_address_3'),
+(15, 'stake_public_key_1', 3, 'voting_key_2', 1, 1, 100, 'rep', 'reward_address_1'),
 (16, 'stake_public_key_3', 3, 'voting_key_2', 1, 1, 50, 'rep', 'reward_address_4'),
 (17, 'stake_public_key_4', 3, 'voting_key_3', 1, 1, 350, 'direct', 'reward_address_5'),
-(18, 'stake_public_key_5', 3, 'voting_key_5', 1, 1, 250, 'direct', 'reward_address_6');
+(18, 'stake_public_key_5', 3, 'voting_key_5', 1, 1, 250, 'direct', 'reward_address_5');


### PR DESCRIPTION
# Description

Added a new `reward_address` field for the delegation type for the `/api/v1/registration/delegations/{sp_key}` endpoint.
Fixed and improved delegation's queries.