### PR TITLE
feat: Add delegators addresses list as a response to the `/api/v1/registration/voter/{vkey}` endpoint | NPG-6804

### DIFF
--- a/book/src/07_web_api/openapi/core_backend_api.yaml
+++ b/book/src/07_web_api/openapi/core_backend_api.yaml
@@ -331,7 +331,7 @@ paths:
         - $ref: '#/components/parameters/offset'
         - $ref: '#/components/parameters/total'
     parameters: []
-  /api/v1/registration/voter/{vkey}:
+  /api/v1/registration/voter/{vkey}?event_id={eid}&with_delegators={flag}:
     parameters:
       - name: vkey
         in: path
@@ -339,6 +339,13 @@ paths:
         schema:
           type: string
         description: A Voting Key.
+      - $ref: '#/components/parameters/event_id_filter'
+      - name: with_delegators
+        in: query
+        required: false
+        schema:
+          type: boolean
+        description: Flag to include delegators list in the response.
     get:
       operationId: getVoterInfo
       summary: Get voter's info by voting key
@@ -346,7 +353,8 @@ paths:
         - registration
       description: |
         Get voter's registration and voting power by their voting key.\
-        If the `eid` query parameter is omitted, then the latest voting power is retrieved.
+        If the `event_id` query parameter is omitted, then the latest voting power is retrieved.
+        If the `with_delegators` query parameter is ommitted, then `delegator_addresses` field of `VoterInfo` type does not provided.
       responses:
         '200':
           description: Success
@@ -358,11 +366,10 @@ paths:
           description: There is an error with the request.
         '404':
           description: Voting Key not found for requested event.
-      parameters:
-        - $ref: '#/components/parameters/event_id_filter'
-  /api/v1/registration/delegations/{sp_key}:
+  /api/v1/registration/delegations/{sp_key}?event_id={eid}:
     parameters:
       - $ref: '#/components/parameters/stake_public_key'
+      - $ref: '#/components/parameters/event_id_filter'
     get:
       operationId: getDelegatorInfo
       summary: Get voters info by stake public key
@@ -382,8 +389,6 @@ paths:
           description: An error occurred
         '404':
           description: Stake Address for the event was not found in the snapshot.
-      parameters:
-        - $ref: '#/components/parameters/event_id_filter'
   /api/v1/event/{id}/objective/{obj_id}/proposal/{prop_id}/ballot:
     parameters:
       - $ref: '#/components/parameters/event_id'
@@ -1839,7 +1844,7 @@ components:
         type: string
       description: Stake Public key
     event_id_filter:
-      name: eid
+      name: event_id
       in: query
       required: false
       schema:

--- a/book/src/07_web_api/openapi/core_backend_api.yaml
+++ b/book/src/07_web_api/openapi/core_backend_api.yaml
@@ -1613,6 +1613,14 @@ components:
           format: float
           minimum: 0
           maximum: 100
+        delegator_addresses:
+          description: |-
+            List of stake public key addresses which delegated to this voting key.
+          type: array
+          items:
+            type: string
+            pattern: '[0-9a-f]{64}'
+            description: Hex string of stake public key address.
       required:
         - voting_power
         - voting_group

--- a/src/cat-data-service/src/service/v1/registration.rs
+++ b/src/cat-data-service/src/service/v1/registration.rs
@@ -116,7 +116,8 @@ mod tests {
                         "voting_group": "rep",
                         "delegations_power": 250,
                         "delegations_count": 2,
-                        "voting_power_saturation": 0.625
+                        "voting_power_saturation": 0.625,
+                        "delegator_addresses": [],
                     },
                     "as_at": "2022-03-31T12:00:00+00:00",
                     "last_updated": "2022-03-31T12:00:00+00:00",
@@ -143,7 +144,8 @@ mod tests {
                         "voting_group": "rep",
                         "delegations_power": 250,
                         "delegations_count": 2,
-                        "voting_power_saturation": 0.625
+                        "voting_power_saturation": 0.625,
+                        "delegator_addresses": [],
                     },
                     "as_at": "2020-03-31T12:00:00+00:00",
                     "last_updated": "2020-03-31T12:00:00+00:00",

--- a/src/cat-data-service/src/service/v1/registration.rs
+++ b/src/cat-data-service/src/service/v1/registration.rs
@@ -140,6 +140,34 @@ mod tests {
 
         let request = Request::builder()
             .uri(format!(
+                "/api/v1/registration/voter/{0}?with_delegators=true",
+                "voting_key_1"
+            ))
+            .body(Body::empty())
+            .unwrap();
+        let response = app.clone().oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(body_data_json_check(
+            response.into_body().data().await.unwrap().unwrap().to_vec(),
+            serde_json::json!(
+                {
+                    "voter_info": {
+                        "voting_power": 250,
+                        "voting_group": "rep",
+                        "delegations_power": 250,
+                        "delegations_count": 2,
+                        "voting_power_saturation": 0.625,
+                        "delegator_addresses": ["stake_public_key_1", "stake_public_key_2"]
+                    },
+                    "as_at": "2022-03-31T12:00:00+00:00",
+                    "last_updated": "2022-03-31T12:00:00+00:00",
+                    "final": true
+                }
+            )
+        ));
+
+        let request = Request::builder()
+            .uri(format!(
                 "/api/v1/registration/voter/{0}?event_id={1}",
                 "voting_key_1", 1
             ))
@@ -157,6 +185,34 @@ mod tests {
                         "delegations_power": 250,
                         "delegations_count": 2,
                         "voting_power_saturation": 0.625,
+                    },
+                    "as_at": "2020-03-31T12:00:00+00:00",
+                    "last_updated": "2020-03-31T12:00:00+00:00",
+                    "final": true
+                }
+            )
+        ));
+
+        let request = Request::builder()
+            .uri(format!(
+                "/api/v1/registration/voter/{0}?event_id={1}&with_delegators=true",
+                "voting_key_1", 1
+            ))
+            .body(Body::empty())
+            .unwrap();
+        let response = app.clone().oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(body_data_json_check(
+            response.into_body().data().await.unwrap().unwrap().to_vec(),
+            serde_json::json!(
+                {
+                    "voter_info": {
+                        "voting_power": 250,
+                        "voting_group": "rep",
+                        "delegations_power": 250,
+                        "delegations_count": 2,
+                        "voting_power_saturation": 0.625,
+                        "delegator_addresses": ["stake_public_key_1", "stake_public_key_2"]
                     },
                     "as_at": "2020-03-31T12:00:00+00:00",
                     "last_updated": "2020-03-31T12:00:00+00:00",

--- a/src/cat-data-service/src/service/v1/registration.rs
+++ b/src/cat-data-service/src/service/v1/registration.rs
@@ -49,7 +49,10 @@ async fn voter_exec(
         eid_query.eid
     );
 
-    let voter = state.event_db.get_voter(&eid_query.eid, voting_key).await?;
+    let voter = state
+        .event_db
+        .get_voter(&eid_query.eid, voting_key, false)
+        .await?;
     Ok(voter)
 }
 

--- a/src/event-db/src/queries/registration.rs
+++ b/src/event-db/src/queries/registration.rs
@@ -131,6 +131,7 @@ impl RegistrationQueries for EventDB {
                 voting_power_saturation,
                 voting_power,
                 voting_group,
+                delegator_addresses: vec![],
             },
             as_at: voter
                 .try_get::<_, NaiveDateTime>("as_at")?
@@ -253,6 +254,7 @@ mod tests {
                     delegations_power: 250,
                     delegations_count: 2,
                     voting_power_saturation: 0.625,
+                    delegator_addresses: vec![],
                 },
                 as_at: DateTime::<Utc>::from_utc(
                     NaiveDateTime::new(
@@ -286,6 +288,7 @@ mod tests {
                     delegations_power: 250,
                     delegations_count: 2,
                     voting_power_saturation: 0.625,
+                    delegator_addresses: vec![],
                 },
                 as_at: DateTime::<Utc>::from_utc(
                     NaiveDateTime::new(

--- a/src/event-db/src/queries/registration.rs
+++ b/src/event-db/src/queries/registration.rs
@@ -14,6 +14,7 @@ pub trait RegistrationQueries: Sync + Send + 'static {
         &self,
         version: &Option<EventId>,
         voting_key: String,
+        with_delegations: bool,
     ) -> Result<Voter, Error>;
     async fn get_delegator(
         &self,
@@ -30,12 +31,17 @@ impl EventDB {
                                             WHERE voter.voting_key = $1 AND contribution.voting_key = $1 AND snapshot.event = $2
                                             GROUP BY voter.voting_key, voter.voting_group, voter.voting_power, snapshot.as_at, snapshot.last_updated, snapshot.final;";
 
-    const VOTER_BY_LAST_EVENT_QUERY: &'static str = "SELECT voter.voting_key, voter.voting_group, voter.voting_power, snapshot.as_at, snapshot.last_updated, snapshot.final, SUM(contribution.value)::BIGINT as delegations_power, COUNT(contribution.value) AS delegations_count
+    const VOTER_BY_LAST_EVENT_QUERY: &'static str = "SELECT snapshot.event, voter.voting_key, voter.voting_group, voter.voting_power, snapshot.as_at, snapshot.last_updated, snapshot.final, SUM(contribution.value)::BIGINT as delegations_power, COUNT(contribution.value) AS delegations_count
                                                 FROM voter
                                                 INNER JOIN snapshot ON voter.snapshot_id = snapshot.row_id
                                                 INNER JOIN contribution ON contribution.snapshot_id = snapshot.row_id
                                                 WHERE voter.voting_key = $1 AND contribution.voting_key = $1 AND snapshot.last_updated = (SELECT MAX(snapshot.last_updated) as last_updated from snapshot)
-                                                GROUP BY voter.voting_key, voter.voting_group, voter.voting_power, snapshot.as_at, snapshot.last_updated, snapshot.final;";
+                                                GROUP BY snapshot.event, voter.voting_key, voter.voting_group, voter.voting_power, snapshot.as_at, snapshot.last_updated, snapshot.final;";
+
+    const VOTER_DELEGATORS_LIST_QUERY: &'static str = "SELECT contribution.stake_public_key
+                                                FROM contribution
+                                                INNER JOIN snapshot ON contribution.snapshot_id = snapshot.row_id
+                                                WHERE contribution.voting_key = $1 AND snapshot.event = $2;";
 
     const TOTAL_BY_EVENT_VOTING_QUERY: &'static str =
         "SELECT SUM(voter.voting_power)::BIGINT as total_voting_power
@@ -84,7 +90,12 @@ impl EventDB {
 
 #[async_trait]
 impl RegistrationQueries for EventDB {
-    async fn get_voter(&self, event: &Option<EventId>, voting_key: String) -> Result<Voter, Error> {
+    async fn get_voter(
+        &self,
+        event: &Option<EventId>,
+        voting_key: String,
+        with_delegations: bool,
+    ) -> Result<Voter, Error> {
         let conn = self.pool.get().await?;
 
         let rows = if let Some(event) = event {
@@ -124,6 +135,28 @@ impl RegistrationQueries for EventDB {
         } else {
             0_f64
         };
+
+        let delegator_addresses = if with_delegations {
+            let rows = if let Some(event) = event {
+                conn.query(Self::VOTER_DELEGATORS_LIST_QUERY, &[&voting_key, &event.0])
+                    .await?
+            } else {
+                conn.query(
+                    Self::VOTER_DELEGATORS_LIST_QUERY,
+                    &[&voting_key, &voter.try_get::<_, i32>("event")?],
+                )
+                .await?
+            };
+
+            let mut delegator_addresses = Vec::new();
+            for row in rows {
+                delegator_addresses.push(row.try_get("stake_public_key")?);
+            }
+            Some(delegator_addresses)
+        } else {
+            None
+        };
+
         Ok(Voter {
             voter_info: VoterInfo {
                 delegations_power: voter.try_get("delegations_power")?,
@@ -131,7 +164,7 @@ impl RegistrationQueries for EventDB {
                 voting_power_saturation,
                 voting_power,
                 voting_group,
-                delegator_addresses: vec![],
+                delegator_addresses,
             },
             as_at: voter
                 .try_get::<_, NaiveDateTime>("as_at")?
@@ -241,7 +274,7 @@ mod tests {
         let event_db = establish_connection(None).await.unwrap();
 
         let voter = event_db
-            .get_voter(&Some(EventId(1)), "voting_key_1".to_string())
+            .get_voter(&Some(EventId(1)), "voting_key_1".to_string(), true)
             .await
             .unwrap();
 
@@ -254,7 +287,10 @@ mod tests {
                     delegations_power: 250,
                     delegations_count: 2,
                     voting_power_saturation: 0.625,
-                    delegator_addresses: vec![],
+                    delegator_addresses: Some(vec![
+                        "stake_public_key_1".to_string(),
+                        "stake_public_key_2".to_string()
+                    ]),
                 },
                 as_at: DateTime::<Utc>::from_utc(
                     NaiveDateTime::new(
@@ -275,7 +311,7 @@ mod tests {
         );
 
         let voter = event_db
-            .get_voter(&None, "voting_key_1".to_string())
+            .get_voter(&Some(EventId(1)), "voting_key_1".to_string(), false)
             .await
             .unwrap();
 
@@ -288,7 +324,78 @@ mod tests {
                     delegations_power: 250,
                     delegations_count: 2,
                     voting_power_saturation: 0.625,
-                    delegator_addresses: vec![],
+                    delegator_addresses: None,
+                },
+                as_at: DateTime::<Utc>::from_utc(
+                    NaiveDateTime::new(
+                        NaiveDate::from_ymd_opt(2020, 3, 31).unwrap(),
+                        NaiveTime::from_hms_opt(12, 0, 0).unwrap()
+                    ),
+                    Utc
+                ),
+                last_updated: DateTime::<Utc>::from_utc(
+                    NaiveDateTime::new(
+                        NaiveDate::from_ymd_opt(2020, 3, 31).unwrap(),
+                        NaiveTime::from_hms_opt(12, 0, 0).unwrap()
+                    ),
+                    Utc
+                ),
+                is_final: true,
+            }
+        );
+
+        let voter = event_db
+            .get_voter(&None, "voting_key_1".to_string(), true)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            voter,
+            Voter {
+                voter_info: VoterInfo {
+                    voting_power: 250,
+                    voting_group: VoterGroupId("rep".to_string()),
+                    delegations_power: 250,
+                    delegations_count: 2,
+                    voting_power_saturation: 0.625,
+                    delegator_addresses: Some(vec![
+                        "stake_public_key_1".to_string(),
+                        "stake_public_key_2".to_string()
+                    ]),
+                },
+                as_at: DateTime::<Utc>::from_utc(
+                    NaiveDateTime::new(
+                        NaiveDate::from_ymd_opt(2022, 3, 31).unwrap(),
+                        NaiveTime::from_hms_opt(12, 0, 0).unwrap()
+                    ),
+                    Utc
+                ),
+                last_updated: DateTime::<Utc>::from_utc(
+                    NaiveDateTime::new(
+                        NaiveDate::from_ymd_opt(2022, 3, 31).unwrap(),
+                        NaiveTime::from_hms_opt(12, 0, 0).unwrap()
+                    ),
+                    Utc
+                ),
+                is_final: true,
+            }
+        );
+
+        let voter = event_db
+            .get_voter(&None, "voting_key_1".to_string(), false)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            voter,
+            Voter {
+                voter_info: VoterInfo {
+                    voting_power: 250,
+                    voting_group: VoterGroupId("rep".to_string()),
+                    delegations_power: 250,
+                    delegations_count: 2,
+                    voting_power_saturation: 0.625,
+                    delegator_addresses: None,
                 },
                 as_at: DateTime::<Utc>::from_utc(
                     NaiveDateTime::new(
@@ -309,7 +416,9 @@ mod tests {
         );
 
         assert_eq!(
-            event_db.get_voter(&None, "voting_key".to_string()).await,
+            event_db
+                .get_voter(&None, "voting_key".to_string(), true)
+                .await,
             Err(Error::NotFound("can not find voter value".to_string()))
         );
     }

--- a/src/event-db/src/types/registration.rs
+++ b/src/event-db/src/types/registration.rs
@@ -12,7 +12,8 @@ pub struct VoterInfo {
     pub delegations_power: i64,
     pub delegations_count: i64,
     pub voting_power_saturation: f64,
-    pub delegator_addresses: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub delegator_addresses: Option<Vec<String>>,
 }
 
 #[derive(Debug, Serialize, Clone, PartialEq)]
@@ -62,7 +63,7 @@ mod tests {
                 delegations_power: 100,
                 delegations_count: 1,
                 voting_power_saturation: 0.4,
-                delegator_addresses: vec!["stake_public_key_1".to_string()],
+                delegator_addresses: Some(vec!["stake_public_key_1".to_string()]),
             },
             as_at: DateTime::from_utc(NaiveDateTime::default(), Utc),
             last_updated: DateTime::from_utc(NaiveDateTime::default(), Utc),

--- a/src/event-db/src/types/registration.rs
+++ b/src/event-db/src/types/registration.rs
@@ -12,6 +12,7 @@ pub struct VoterInfo {
     pub delegations_power: i64,
     pub delegations_count: i64,
     pub voting_power_saturation: f64,
+    pub delegator_addresses: Vec<String>,
 }
 
 #[derive(Debug, Serialize, Clone, PartialEq)]
@@ -61,6 +62,7 @@ mod tests {
                 delegations_power: 100,
                 delegations_count: 1,
                 voting_power_saturation: 0.4,
+                delegator_addresses: vec!["stake_public_key_1".to_string()],
             },
             as_at: DateTime::from_utc(NaiveDateTime::default(), Utc),
             last_updated: DateTime::from_utc(NaiveDateTime::default(), Utc),
@@ -76,7 +78,8 @@ mod tests {
                             "voting_group": "rep",
                             "delegations_power": 100,
                             "delegations_count": 1,
-                            "voting_power_saturation": 0.4
+                            "voting_power_saturation": 0.4,
+                            "delegator_addresses": ["stake_public_key_1"]
                         },
                     "as_at": "1970-01-01T00:00:00+00:00",
                     "last_updated": "1970-01-01T00:00:00+00:00",


### PR DESCRIPTION
# Description

Added a new optional query parameter `with_delegators` for ` /api/v1/registration/voter/{vkey}` endpoint. Which returns `delegators_addresses` list in response if enabled.