### PR TITLE
feat: Add new voting status endpoint | NPG-6955

### DIFF
--- a/book/src/07_web_api/openapi/core_backend_api.yaml
+++ b/book/src/07_web_api/openapi/core_backend_api.yaml
@@ -179,7 +179,33 @@ paths:
                       x-stoplight:
                         id: mdciat4uo1xu8
         '404':
-          description: The requested challenge was not found
+          description: The requested objectives was not found
+      parameters:
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+        - $ref: '#/components/parameters/voter_groups_filter'
+  /api/v1/event/{id}/objectives/voting_status:
+    parameters:
+      - $ref: '#/components/parameters/event_id'
+    get:
+      operationId: getObjectiveVoteStatuses
+      summary: Get objective`s voting statuses for a Voting Event.
+      tags:
+        - objective
+      description: |-
+        Get all current objective`s voting statuses with the voting settings for the voting event.
+      responses:
+        '200':
+          description: Valid response
+          content:
+            application/json:
+              schema:
+                description: List of objective`s voting statuses.
+                type: array
+                item:
+                 - $ref: '#/components/schemas/VotingStatus'
+        '404':
+          description: The requested objective`s voting statuses was not found
       parameters:
         - $ref: '#/components/parameters/limit'
         - $ref: '#/components/parameters/offset'
@@ -1169,6 +1195,21 @@ components:
         supplemental:
           $ref: '#/components/schemas/ObjectiveSupplementalData'
       required:
+    VotingStatus:
+      title: Objective`s voting status
+      description: Individual objective`s voting status info
+      type: object
+      properties:
+        objective_id:
+          type: integer
+          format: int32
+          description: The ID of this objective.
+        open:
+          type: boolean
+          description: Whether this objective is open for voting or not.
+        settings:
+          type: string
+          description: voting settings
     VotePlan:
       title: Vote Plan
       type: object

--- a/book/src/07_web_api/openapi/core_backend_api.yaml
+++ b/book/src/07_web_api/openapi/core_backend_api.yaml
@@ -1209,7 +1209,10 @@ components:
           description: Whether this objective is open for voting or not.
         settings:
           type: string
-          description: voting settings
+          description: voting settings data, empty if `open` is false
+      required:
+        - objective_id
+        - open
     VotePlan:
       title: Vote Plan
       type: object

--- a/src/cat-data-service/Cargo.toml
+++ b/src/cat-data-service/Cargo.toml
@@ -13,6 +13,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["fmt"]}
 
 serde = { version = "1.0", features = ["derive"] }
+serde_json = { version = "1.0" }
 
 tokio = { version = "1.8", features = ["rt", "macros", "rt-multi-thread"] }
 thiserror = { version = "1.0" }
@@ -23,7 +24,6 @@ metrics-exporter-prometheus = { version = "0.8" }
 tower-http = { version = "0.4", features = ["cors"] }
 
 [dev-dependencies]
-serde_json = { version = "1.0" }
 tower = { version = "0.4", features = ["util"] }
 chrono = { workspace = true }
 rust_decimal = {  workspace = true }

--- a/src/cat-data-service/Cargo.toml
+++ b/src/cat-data-service/Cargo.toml
@@ -23,8 +23,9 @@ metrics-exporter-prometheus = { version = "0.8" }
 
 tower-http = { version = "0.4", features = ["cors"] }
 
+chrono = { workspace = true }
+
 [dev-dependencies]
 tower = { version = "0.4", features = ["util"] }
-chrono = { workspace = true }
 rust_decimal = {  workspace = true }
 

--- a/src/cat-data-service/src/service/v1/event/objective/mod.rs
+++ b/src/cat-data-service/src/service/v1/event/objective/mod.rs
@@ -111,7 +111,7 @@ async fn objectives_voting_statuses_exec(
         .into_iter()
         .map(|objective| VotingStatus {
             objective_id: objective.summary.id,
-            open: data.0.clone(),
+            open: data.0,
             settings: data.1.clone(),
         })
         .collect();

--- a/src/cat-data-service/src/service/v1/event/objective/mod.rs
+++ b/src/cat-data-service/src/service/v1/event/objective/mod.rs
@@ -7,7 +7,7 @@ use axum::{
     routing::get,
     Router,
 };
-use event_db::types::event::{objective::Objective, EventId};
+use event_db::types::event::{objective::Objective, voting_status::VotingStatus, EventId};
 use std::sync::Arc;
 
 mod ballots;
@@ -24,10 +24,16 @@ pub fn objective(state: Arc<State>) -> Router {
             "/objective/:objective",
             proposal.merge(review_type).merge(ballots),
         )
-        .route(
-            "/objectives",
+        .route("/objectives", {
+            let state = state.clone();
             get(move |path, query| async {
                 handle_result(objectives_exec(path, query, state).await)
+            })
+        })
+        .route(
+            "/objectives/voting_status",
+            get(move |path, query| async {
+                handle_result(objectives_voting_statuses_exec(path, query, state).await)
             }),
         )
 }
@@ -39,11 +45,66 @@ async fn objectives_exec(
 ) -> Result<Vec<Objective>, Error> {
     tracing::debug!("objectives_query, event: {0}", event.0);
 
-    let event = state
+    let objectives = state
         .event_db
         .get_objectives(event, lim_ofs.limit, lim_ofs.offset)
         .await?;
-    Ok(event)
+    Ok(objectives)
+}
+
+// TODO:
+// mocked data, will be replaced when we will add this into event-db
+fn mocked_settings_data() -> String {
+    let settings = serde_json::json!(
+        {
+            "purpose": 0,
+            "ver": 0,
+            "fees":
+                {
+                    "constant": 10,
+                    "coefficient": 2,
+                    "certificate": 100
+                },
+            "discrimination": "production",
+            "block0_initial_hash":
+                {
+                    "hash": "baf6b54817cf2a3e865f432c3922d28ac5be641e66662c66d445f141e409183e"
+                },
+            "block0_date": 1586637936,
+            "slot_duration": 20,
+            "time_era":
+                {
+                    "epoch_start": 0,
+                    "slot_start": 0,
+                    "slots_per_epoch": 180
+                },
+            "transaction_max_expiry_epochs":1
+        }
+    );
+    settings.to_string()
+}
+
+async fn objectives_voting_statuses_exec(
+    Path(event): Path<EventId>,
+    lim_ofs: Query<LimitOffset>,
+    state: Arc<State>,
+) -> Result<Vec<VotingStatus>, Error> {
+    tracing::debug!("objectives_voting_statuses_query, event: {0}", event.0);
+
+    let objectives = state
+        .event_db
+        .get_objectives(event, lim_ofs.limit, lim_ofs.offset)
+        .await?;
+
+    let voting_statuses: Vec<_> = objectives
+        .into_iter()
+        .map(|objective| VotingStatus {
+            objective_id: objective.summary.id,
+            open: true,
+            settings: Some(mocked_settings_data()),
+        })
+        .collect();
+    Ok(voting_statuses)
 }
 
 /// Need to setup and run a test event db instance
@@ -197,6 +258,94 @@ mod tests {
         let request = Request::builder()
             .uri(format!(
                 "/api/v1/event/{0}/objectives?limit={1}&offset={2}",
+                1, 1, 2
+            ))
+            .body(Body::empty())
+            .unwrap();
+        let response = app.clone().oneshot(request).await.unwrap();
+        assert_eq!(
+            String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
+                .unwrap(),
+            serde_json::to_string(&Vec::<Objective>::new()).unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn objectives_voting_status_test() {
+        let state = Arc::new(State::new(None).await.unwrap());
+        let app = app(state);
+
+        let request = Request::builder()
+            .uri(format!("/api/v1/event/{0}/objectives/voting_status", 1))
+            .body(Body::empty())
+            .unwrap();
+        let response = app.clone().oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(body_data_json_check(
+            response.into_body().data().await.unwrap().unwrap().to_vec(),
+            serde_json::json!(
+                [
+                    {
+                        "objective_id": 1,
+                        "open": true,
+                        "settings": mocked_settings_data(),
+                    },
+                    {
+                        "objective_id": 2,
+                        "open": true,
+                        "settings": mocked_settings_data(),
+                    }
+                ]
+            )
+        ));
+
+        let request = Request::builder()
+            .uri(format!(
+                "/api/v1/event/{0}/objectives/voting_status?limit={1}",
+                1, 1
+            ))
+            .body(Body::empty())
+            .unwrap();
+        let response = app.clone().oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(body_data_json_check(
+            response.into_body().data().await.unwrap().unwrap().to_vec(),
+            serde_json::json!(
+                [
+                    {
+                        "objective_id": 1,
+                        "open": true,
+                        "settings": mocked_settings_data(),
+                    },
+                ]
+            )
+        ));
+
+        let request = Request::builder()
+            .uri(format!(
+                "/api/v1/event/{0}/objectives/voting_status?offset={1}",
+                1, 1
+            ))
+            .body(Body::empty())
+            .unwrap();
+        let response = app.clone().oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(body_data_json_check(
+            response.into_body().data().await.unwrap().unwrap().to_vec(),
+            serde_json::json!(
+                [
+                    {
+                        "objective_id": 2,
+                        "open": true,
+                        "settings": mocked_settings_data(),
+                    }
+                ]
+            )
+        ));
+
+        let request = Request::builder()
+            .uri(format!(
+                "/api/v1/event/{0}/objectives/voting_status?limit={1}&offset={2}",
                 1, 1, 2
             ))
             .body(Body::empty())

--- a/src/cat-data-service/src/service/v1/event/objective/mod.rs
+++ b/src/cat-data-service/src/service/v1/event/objective/mod.rs
@@ -295,20 +295,35 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
         assert!(body_data_json_check(
             response.into_body().data().await.unwrap().unwrap().to_vec(),
-            serde_json::json!(
-                [
-                    {
-                        "objective_id": 1,
-                        "open": data.0.clone(),
-                        "settings": data.1.clone(),
-                    },
-                    {
-                        "objective_id": 2,
-                        "open": data.0,
-                        "settings": data.1,
-                    }
-                ]
-            )
+            if let Some(settings) = data.1.clone() {
+                serde_json::json!(
+                    [
+                        {
+                            "objective_id": 1,
+                            "open": data.0,
+                            "settings": settings,
+                        },
+                        {
+                            "objective_id": 2,
+                            "open": data.0,
+                            "settings": settings,
+                        }
+                    ]
+                )
+            } else {
+                serde_json::json!(
+                    [
+                        {
+                            "objective_id": 1,
+                            "open": data.0,
+                        },
+                        {
+                            "objective_id": 2,
+                            "open": data.0,
+                        }
+                    ]
+                )
+            }
         ));
 
         let request = Request::builder()
@@ -322,15 +337,26 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
         assert!(body_data_json_check(
             response.into_body().data().await.unwrap().unwrap().to_vec(),
-            serde_json::json!(
-                [
-                    {
-                        "objective_id": 1,
-                        "open": data.0.clone(),
-                        "settings": data.1.clone(),
-                    },
-                ]
-            )
+            if let Some(settings) = data.1.clone() {
+                serde_json::json!(
+                    [
+                        {
+                            "objective_id": 1,
+                            "open": data.0,
+                            "settings": settings,
+                        }
+                    ]
+                )
+            } else {
+                serde_json::json!(
+                    [
+                        {
+                            "objective_id": 1,
+                            "open": data.0,
+                        }
+                    ]
+                )
+            }
         ));
 
         let request = Request::builder()
@@ -344,15 +370,26 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
         assert!(body_data_json_check(
             response.into_body().data().await.unwrap().unwrap().to_vec(),
-            serde_json::json!(
-                [
-                    {
-                        "objective_id": 2,
-                        "open": data.0.clone(),
-                        "settings": data.1.clone(),
-                    }
-                ]
-            )
+            if let Some(settings) = data.1.clone() {
+                serde_json::json!(
+                    [
+                        {
+                            "objective_id": 2,
+                            "open": data.0,
+                            "settings": settings,
+                        }
+                    ]
+                )
+            } else {
+                serde_json::json!(
+                    [
+                        {
+                            "objective_id": 2,
+                            "open": data.0,
+                        }
+                    ]
+                )
+            }
         ));
 
         let request = Request::builder()

--- a/src/event-db/src/types/event/mod.rs
+++ b/src/event-db/src/types/event/mod.rs
@@ -7,6 +7,7 @@ pub mod ballot;
 pub mod objective;
 pub mod proposal;
 pub mod review;
+pub mod voting_status;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct EventId(pub i32);

--- a/src/event-db/src/types/event/voting_status.rs
+++ b/src/event-db/src/types/event/voting_status.rs
@@ -5,6 +5,7 @@ use serde::Serialize;
 pub struct VotingStatus {
     pub objective_id: ObjectiveId,
     pub open: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub settings: Option<String>,
 }
 

--- a/src/event-db/src/types/event/voting_status.rs
+++ b/src/event-db/src/types/event/voting_status.rs
@@ -1,0 +1,35 @@
+use super::objective::ObjectiveId;
+use serde::Serialize;
+
+#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
+pub struct VotingStatus {
+    pub objective_id: ObjectiveId,
+    pub open: bool,
+    pub settings: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn voting_status_json_test() {
+        let voting_status = VotingStatus {
+            objective_id: ObjectiveId(1),
+            open: false,
+            settings: None,
+        };
+
+        let json = serde_json::to_value(&voting_status).unwrap();
+        assert_eq!(
+            json,
+            json!(
+                {
+                    "objective_id": 1,
+                    "open": false,
+                }
+            )
+        )
+    }
+}


### PR DESCRIPTION
# Description

Added `/api/v1/event/{id}/objectives/voting_status` new endpoint, which returns all votings statuses related to each objective per provided event_id. Currently this endpoint returns a mocked data, because right now we dont have it inside event db, it will be updated later.
