### PR TITLE
refactor: Move serde definiton from event-db to cat-data-service (Part 1) | NPG-7002

### DIFF
--- a/src/cat-data-service/src/main.rs
+++ b/src/cat-data-service/src/main.rs
@@ -1,11 +1,11 @@
 use clap::Parser;
 
 mod cli;
-// mod db;
 mod logger;
 mod service;
 mod settings;
 mod state;
+mod types;
 
 #[tokio::main]
 async fn main() -> Result<(), cli::Error> {

--- a/src/cat-data-service/src/service/v1/event/objective/mod.rs
+++ b/src/cat-data-service/src/service/v1/event/objective/mod.rs
@@ -43,13 +43,16 @@ async fn objectives_exec(
     Path(event): Path<EventId>,
     lim_ofs: Query<LimitOffset>,
     state: Arc<State>,
-) -> Result<Vec<Objective>, Error> {
+) -> Result<Vec<SerdeType<Objective>>, Error> {
     tracing::debug!("objectives_query, event: {0}", event.0);
 
     let objectives = state
         .event_db
         .get_objectives(event, lim_ofs.limit, lim_ofs.offset)
-        .await?;
+        .await?
+        .into_iter()
+        .map(Into::into)
+        .collect();
     Ok(objectives)
 }
 
@@ -281,7 +284,7 @@ mod tests {
         assert_eq!(
             String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
                 .unwrap(),
-            serde_json::to_string(&Vec::<Objective>::new()).unwrap()
+            serde_json::to_string(&Vec::<SerdeType<Objective>>::new()).unwrap()
         );
     }
 
@@ -407,7 +410,7 @@ mod tests {
         assert_eq!(
             String::from_utf8(response.into_body().data().await.unwrap().unwrap().to_vec())
                 .unwrap(),
-            serde_json::to_string(&Vec::<Objective>::new()).unwrap()
+            serde_json::to_string(&Vec::<SerdeType<Objective>>::new()).unwrap()
         );
     }
 }

--- a/src/cat-data-service/src/service/v1/event/objective/mod.rs
+++ b/src/cat-data-service/src/service/v1/event/objective/mod.rs
@@ -1,6 +1,7 @@
 use crate::{
     service::{handle_result, v1::LimitOffset, Error},
     state::State,
+    types::SerdeType,
 };
 use axum::{
     extract::{Path, Query},
@@ -97,7 +98,7 @@ async fn objectives_voting_statuses_exec(
     Path(event): Path<EventId>,
     lim_ofs: Query<LimitOffset>,
     state: Arc<State>,
-) -> Result<Vec<VotingStatus>, Error> {
+) -> Result<Vec<SerdeType<VotingStatus>>, Error> {
     tracing::debug!("objectives_voting_statuses_query, event: {0}", event.0);
 
     let objectives = state
@@ -109,10 +110,13 @@ async fn objectives_voting_statuses_exec(
 
     let voting_statuses: Vec<_> = objectives
         .into_iter()
-        .map(|objective| VotingStatus {
-            objective_id: objective.summary.id,
-            open: data.0,
-            settings: data.1.clone(),
+        .map(|objective| {
+            VotingStatus {
+                objective_id: objective.summary.id,
+                open: data.0,
+                settings: data.1.clone(),
+            }
+            .into()
         })
         .collect();
     Ok(voting_statuses)

--- a/src/cat-data-service/src/types/mod.rs
+++ b/src/cat-data-service/src/types/mod.rs
@@ -1,0 +1,10 @@
+pub mod voting_status;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SerdeType<T>(pub T);
+
+impl<T> From<T> for SerdeType<T> {
+    fn from(val: T) -> Self {
+        Self(val)
+    }
+}

--- a/src/cat-data-service/src/types/mod.rs
+++ b/src/cat-data-service/src/types/mod.rs
@@ -1,3 +1,5 @@
+use std::ops::Deref;
+pub mod objective;
 pub mod voting_status;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -6,5 +8,12 @@ pub struct SerdeType<T>(pub T);
 impl<T> From<T> for SerdeType<T> {
     fn from(val: T) -> Self {
         Self(val)
+    }
+}
+
+impl<T> Deref for SerdeType<T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }

--- a/src/cat-data-service/src/types/objective.rs
+++ b/src/cat-data-service/src/types/objective.rs
@@ -1,0 +1,374 @@
+use super::SerdeType;
+use event_db::types::event::objective::{
+    Objective, ObjectiveDetails, ObjectiveId, ObjectiveSummary, ObjectiveType, RewardDefintion,
+    VoterGroup,
+};
+use serde::{
+    de::Deserializer,
+    ser::{SerializeStruct, Serializer},
+    Deserialize, Serialize,
+};
+
+impl Serialize for SerdeType<&ObjectiveId> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.0 .0.serialize(serializer)
+    }
+}
+
+impl Serialize for SerdeType<ObjectiveId> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        SerdeType(&self.0).serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for SerdeType<ObjectiveId> {
+    fn deserialize<D>(deserializer: D) -> Result<SerdeType<ObjectiveId>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(ObjectiveId(i32::deserialize(deserializer)?).into())
+    }
+}
+
+impl Serialize for SerdeType<&ObjectiveType> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut serializer = serializer.serialize_struct("ObjectiveType", 2)?;
+        serializer.serialize_field("id", &self.0.id)?;
+        serializer.serialize_field("description", &self.0.description)?;
+        serializer.end()
+    }
+}
+
+impl Serialize for SerdeType<ObjectiveType> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        SerdeType(&self.0).serialize(serializer)
+    }
+}
+
+impl Serialize for SerdeType<&ObjectiveSummary> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut serializer = serializer.serialize_struct("ObjectiveSummary", 4)?;
+        serializer.serialize_field("id", &self.0.id)?;
+        serializer.serialize_field("type", &SerdeType(&self.0.objective_type))?;
+        serializer.serialize_field("title", &self.0.title)?;
+        serializer.serialize_field("description", &self.0.description)?;
+        serializer.end()
+    }
+}
+
+impl Serialize for SerdeType<ObjectiveSummary> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        SerdeType(&self.0).serialize(serializer)
+    }
+}
+
+impl Serialize for SerdeType<&RewardDefintion> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut serializer = serializer.serialize_struct("RewardDefintion", 2)?;
+        serializer.serialize_field("currency", &self.0.currency)?;
+        serializer.serialize_field("value", &self.0.value)?;
+        serializer.end()
+    }
+}
+
+impl Serialize for SerdeType<RewardDefintion> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        SerdeType(&self.0).serialize(serializer)
+    }
+}
+
+impl Serialize for SerdeType<&VoterGroup> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut serializer = serializer.serialize_struct("VoterGroup", 2)?;
+        if let Some(group) = &self.0.group {
+            serializer.serialize_field("group", group)?;
+        }
+        if let Some(voting_token) = &self.0.voting_token {
+            serializer.serialize_field("voting_token", voting_token)?;
+        }
+        serializer.end()
+    }
+}
+
+impl Serialize for SerdeType<VoterGroup> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        SerdeType(&self.0).serialize(serializer)
+    }
+}
+
+impl Serialize for SerdeType<&ObjectiveDetails> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut serializer = serializer.serialize_struct("ObjectiveDetails", 3)?;
+        serializer.serialize_field(
+            "groups",
+            &self
+                .0
+                .groups
+                .iter()
+                .map(|el| SerdeType(el))
+                .collect::<Vec<_>>(),
+        )?;
+        if let Some(reward) = &self.0.reward {
+            serializer.serialize_field("reward", &SerdeType(reward))?;
+        }
+        if let Some(supplemental) = &self.0.supplemental {
+            serializer.serialize_field("supplemental", &supplemental)?;
+        }
+        serializer.end()
+    }
+}
+
+impl Serialize for SerdeType<ObjectiveDetails> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        SerdeType(&self.0).serialize(serializer)
+    }
+}
+
+impl Serialize for SerdeType<Objective> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        #[derive(Serialize)]
+        pub struct ObjectiveImpl<'a> {
+            #[serde(flatten)]
+            summary: SerdeType<&'a ObjectiveSummary>,
+            #[serde(flatten)]
+            details: SerdeType<&'a ObjectiveDetails>,
+        }
+
+        let val = ObjectiveImpl {
+            summary: SerdeType(&self.summary),
+            details: SerdeType(&self.details),
+        };
+        val.serialize(serializer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use event_db::types::registration::VoterGroupId;
+    use serde_json::json;
+
+    #[test]
+    fn objective_id_json_test() {
+        let objective_id = SerdeType(ObjectiveId(1));
+
+        let json = serde_json::to_value(&objective_id).unwrap();
+        assert_eq!(json, json!(1));
+
+        let expected: SerdeType<ObjectiveId> = serde_json::from_value(json).unwrap();
+        assert_eq!(expected, objective_id);
+    }
+
+    #[test]
+    fn objective_type_json_test() {
+        let objective_type = SerdeType(ObjectiveType {
+            id: "catalyst-native".to_string(),
+            description: "catalyst native type".to_string(),
+        });
+
+        let json = serde_json::to_value(&objective_type).unwrap();
+        assert_eq!(
+            json,
+            json!(
+                {
+                    "id": "catalyst-native",
+                    "description": "catalyst native type",
+                }
+            )
+        );
+    }
+
+    #[test]
+    fn objective_summary_json_test() {
+        let objective_summary = SerdeType(ObjectiveSummary {
+            id: ObjectiveId(1),
+
+            objective_type: ObjectiveType {
+                id: "catalyst-native".to_string(),
+                description: "catalyst native type".to_string(),
+            },
+            title: "objective 1".to_string(),
+            description: "description 1".to_string(),
+        });
+
+        let json = serde_json::to_value(&objective_summary).unwrap();
+        assert_eq!(
+            json,
+            json!(
+                {
+                    "id": 1,
+                    "type": {
+                        "id": "catalyst-native",
+                        "description": "catalyst native type",
+                    },
+                    "title": "objective 1",
+                    "description": "description 1",
+                }
+            )
+        );
+    }
+
+    #[test]
+    fn reward_definition_json_test() {
+        let reward_definition = SerdeType(RewardDefintion {
+            currency: "ADA".to_string(),
+            value: 100,
+        });
+
+        let json = serde_json::to_value(&reward_definition).unwrap();
+        assert_eq!(
+            json,
+            json!(
+                {
+                    "currency": "ADA",
+                    "value": 100
+                }
+            )
+        )
+    }
+
+    #[test]
+    fn voter_group_json_test() {
+        let voter_group = SerdeType(VoterGroup {
+            group: Some(VoterGroupId("group".to_string())),
+            voting_token: Some("token".to_string()),
+        });
+
+        let json = serde_json::to_value(&voter_group).unwrap();
+        assert_eq!(
+            json,
+            json!(
+                {
+                    "group": "group",
+                    "voting_token": "token"
+                }
+            )
+        );
+    }
+
+    #[test]
+    fn objective_details_json_test() {
+        let objective_details = SerdeType(ObjectiveDetails {
+            groups: vec![VoterGroup {
+                group: Some(VoterGroupId("group".to_string())),
+                voting_token: Some("token".to_string()),
+            }],
+            reward: Some(RewardDefintion {
+                currency: "ADA".to_string(),
+                value: 100,
+            }),
+            supplemental: None,
+        });
+
+        let json = serde_json::to_value(&objective_details).unwrap();
+        assert_eq!(
+            json,
+            json!(
+                {
+                    "groups": [
+                        {
+                            "group": "group",
+                            "voting_token": "token"
+                        }
+                    ],
+                    "reward": {
+                        "currency": "ADA",
+                        "value": 100
+                    }
+                }
+            )
+        )
+    }
+
+    #[test]
+    fn objective_json_test() {
+        let objective = SerdeType(Objective {
+            summary: ObjectiveSummary {
+                id: ObjectiveId(1),
+
+                objective_type: ObjectiveType {
+                    id: "catalyst-native".to_string(),
+                    description: "catalyst native type".to_string(),
+                },
+                title: "objective 1".to_string(),
+                description: "description 1".to_string(),
+            },
+            details: ObjectiveDetails {
+                groups: vec![VoterGroup {
+                    group: Some(VoterGroupId("group".to_string())),
+                    voting_token: Some("token".to_string()),
+                }],
+                reward: Some(RewardDefintion {
+                    currency: "ADA".to_string(),
+                    value: 100,
+                }),
+                supplemental: None,
+            },
+        });
+
+        let json = serde_json::to_value(&objective).unwrap();
+        assert_eq!(
+            json,
+            json!(
+                {
+                    "id": 1,
+                    "type": {
+                        "id": "catalyst-native",
+                        "description": "catalyst native type",
+                    },
+                    "title": "objective 1",
+                    "description": "description 1",
+                    "groups": [
+                        {
+                            "group": "group",
+                            "voting_token": "token"
+                        }
+                    ],
+                    "reward": {
+                        "currency": "ADA",
+                        "value": 100
+                    }
+                }
+            )
+        )
+    }
+}

--- a/src/cat-data-service/src/types/objective.rs
+++ b/src/cat-data-service/src/types/objective.rs
@@ -134,12 +134,7 @@ impl Serialize for SerdeType<&ObjectiveDetails> {
         let mut serializer = serializer.serialize_struct("ObjectiveDetails", 3)?;
         serializer.serialize_field(
             "groups",
-            &self
-                .0
-                .groups
-                .iter()
-                .map(|el| SerdeType(el))
-                .collect::<Vec<_>>(),
+            &self.0.groups.iter().map(SerdeType).collect::<Vec<_>>(),
         )?;
         if let Some(reward) = &self.0.reward {
             serializer.serialize_field("reward", &SerdeType(reward))?;

--- a/src/cat-data-service/src/types/voting_status.rs
+++ b/src/cat-data-service/src/types/voting_status.rs
@@ -1,11 +1,11 @@
 use super::SerdeType;
 use event_db::types::event::voting_status::VotingStatus;
-use serde::ser::{Serialize, SerializeStruct};
+use serde::ser::{Serialize, SerializeStruct, Serializer};
 
 impl Serialize for SerdeType<VotingStatus> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer,
+        S: Serializer,
     {
         let mut serializer = serializer.serialize_struct("VotingStatus", 3)?;
         serializer.serialize_field("objective_id", &self.0.objective_id)?;

--- a/src/cat-data-service/src/types/voting_status.rs
+++ b/src/cat-data-service/src/types/voting_status.rs
@@ -1,0 +1,63 @@
+use super::SerdeType;
+use event_db::types::event::voting_status::VotingStatus;
+use serde::ser::{Serialize, SerializeStruct};
+
+impl Serialize for SerdeType<VotingStatus> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut serializer = serializer.serialize_struct("VotingStatus", 3)?;
+        serializer.serialize_field("objective_id", &self.0.objective_id)?;
+        serializer.serialize_field("open", &self.0.open)?;
+        if let Some(settings) = &self.0.settings {
+            serializer.serialize_field("settings", settings)?;
+        }
+        serializer.end()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use event_db::types::event::objective::ObjectiveId;
+    use serde_json::json;
+
+    #[test]
+    fn voting_status_json_test() {
+        let voting_status = SerdeType(VotingStatus {
+            objective_id: ObjectiveId(1),
+            open: false,
+            settings: None,
+        });
+
+        let json = serde_json::to_value(&voting_status).unwrap();
+        assert_eq!(
+            json,
+            json!(
+                {
+                    "objective_id": 1,
+                    "open": false,
+                }
+            )
+        );
+
+        let voting_status = SerdeType(VotingStatus {
+            objective_id: ObjectiveId(1),
+            open: true,
+            settings: Some("some settings".to_string()),
+        });
+
+        let json = serde_json::to_value(&voting_status).unwrap();
+        assert_eq!(
+            json,
+            json!(
+                {
+                    "objective_id": 1,
+                    "open": true,
+                    "settings": "some settings",
+                }
+            )
+        );
+    }
+}

--- a/src/event-db/src/queries/event/objective.rs
+++ b/src/event-db/src/queries/event/objective.rs
@@ -3,8 +3,8 @@ use crate::{
     types::{
         event::{
             objective::{
-                Objective, ObjectiveDetails, ObjectiveId, ObjectiveSummary,
-                ObjectiveSupplementalData, ObjectiveType, RewardDefintion, VoterGroup,
+                Objective, ObjectiveDetails, ObjectiveId, ObjectiveSummary, ObjectiveType,
+                RewardDefintion, VoterGroup,
             },
             EventId,
         },
@@ -92,9 +92,7 @@ impl ObjectiveQueries for EventDB {
             let details = ObjectiveDetails {
                 groups,
                 reward,
-                supplemental: row
-                    .try_get::<_, Option<serde_json::Value>>("extra")?
-                    .map(ObjectiveSupplementalData),
+                supplemental: row.try_get::<_, Option<serde_json::Value>>("extra")?,
             };
             objectives.push(Objective { summary, details });
         }
@@ -161,13 +159,13 @@ mod tests {
                             currency: "ADA".to_string(),
                             value: 100
                         }),
-                        supplemental: Some(ObjectiveSupplementalData(json!(
+                        supplemental: Some(json!(
                         {
                             "url": "objective 1 url",
                             "sponsor": "objective 1 sponsor",
                             "video": "objective 1 video"
                         }
-                        ))),
+                        )),
                     }
                 },
                 Objective {
@@ -220,13 +218,13 @@ mod tests {
                         currency: "ADA".to_string(),
                         value: 100
                     }),
-                    supplemental: Some(ObjectiveSupplementalData(json!(
+                    supplemental: Some(json!(
                     {
                         "url": "objective 1 url",
                         "sponsor": "objective 1 sponsor",
                         "video": "objective 1 video"
                     }
-                    ))),
+                    )),
                 }
             },]
         );

--- a/src/event-db/src/types/event/objective.rs
+++ b/src/event-db/src/types/event/objective.rs
@@ -1,6 +1,5 @@
 use crate::types::registration::VoterGroupId;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct ObjectiveId(pub i32);
@@ -20,172 +19,27 @@ pub struct ObjectiveSummary {
     pub description: String,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RewardDefintion {
     pub currency: String,
     pub value: i64,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VoterGroup {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub group: Option<VoterGroupId>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub voting_token: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
-pub struct ObjectiveSupplementalData(pub Value);
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ObjectiveDetails {
     pub groups: Vec<VoterGroup>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub reward: Option<RewardDefintion>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub supplemental: Option<ObjectiveSupplementalData>,
+    pub supplemental: Option<serde_json::Value>,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Objective {
-    #[serde(flatten)]
     pub summary: ObjectiveSummary,
-    #[serde(flatten)]
     pub details: ObjectiveDetails,
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use serde_json::json;
-
-    #[test]
-    fn objective_type_json_test() {
-        let objective_type = ObjectiveType {
-            id: "catalyst-native".to_string(),
-            description: "catalyst native type".to_string(),
-        };
-
-        let json = serde_json::to_value(&objective_type).unwrap();
-        assert_eq!(
-            json,
-            json!(
-                {
-                    "id": "catalyst-native",
-                    "description": "catalyst native type",
-                }
-            )
-        );
-    }
-
-    #[test]
-    fn objective_summary_json_test() {
-        let objective_summary = ObjectiveSummary {
-            id: ObjectiveId(1),
-            objective_type: ObjectiveType {
-                id: "catalyst-native".to_string(),
-                description: "catalyst native type".to_string(),
-            },
-            title: "objective 1".to_string(),
-            description: "description 1".to_string(),
-        };
-
-        let json = serde_json::to_value(&objective_summary).unwrap();
-        assert_eq!(
-            json,
-            json!(
-                {
-                    "id": 1,
-                    "type": {
-                        "id": "catalyst-native",
-                        "description": "catalyst native type",
-                    },
-                    "title": "objective 1",
-                    "description": "description 1",
-                }
-            )
-        );
-    }
-
-    #[test]
-    fn reward_definition_json_test() {
-        let reward_definition = RewardDefintion {
-            currency: "ADA".to_string(),
-            value: 100,
-        };
-
-        let json = serde_json::to_value(&reward_definition).unwrap();
-        assert_eq!(
-            json,
-            json!(
-                {
-                    "currency": "ADA",
-                    "value": 100,
-                }
-            )
-        );
-    }
-
-    #[test]
-    fn voter_group_json_test() {
-        let voter_group = VoterGroup {
-            group: Some(VoterGroupId("rep".to_string())),
-            voting_token: Some("voting token 1".to_string()),
-        };
-
-        let json = serde_json::to_value(&voter_group).unwrap();
-        assert_eq!(
-            json,
-            json!(
-                {
-                    "group": "rep",
-                    "voting_token": "voting token 1",
-                }
-            )
-        );
-    }
-
-    #[test]
-    fn objective_details_json_test() {
-        let objective_details = ObjectiveDetails {
-            groups: vec![VoterGroup {
-                group: Some(VoterGroupId("rep".to_string())),
-                voting_token: Some("voting token 1".to_string()),
-            }],
-            reward: Some(RewardDefintion {
-                currency: "ADA".to_string(),
-                value: 100,
-            }),
-            supplemental: Some(ObjectiveSupplementalData(json!(
-                {
-                    "url": "objective url 1",
-                    "sponsor": "sponsor 1",
-                    "video": "video url 1",
-                }
-            ))),
-        };
-
-        let json = serde_json::to_value(&objective_details).unwrap();
-        assert_eq!(
-            json,
-            json!(
-                {
-                    "groups": [
-                        {
-                            "group": "rep",
-                            "voting_token": "voting token 1",
-                        }
-                    ],
-                    "reward": {
-                        "currency": "ADA",
-                        "value": 100,
-                    },
-                    "supplemental": {
-                        "url": "objective url 1",
-                        "sponsor": "sponsor 1",
-                        "video": "video url 1",
-                    },
-                }
-            )
-        );
-    }
 }

--- a/src/event-db/src/types/event/voting_status.rs
+++ b/src/event-db/src/types/event/voting_status.rs
@@ -1,36 +1,8 @@
 use super::objective::ObjectiveId;
-use serde::Serialize;
 
-#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VotingStatus {
     pub objective_id: ObjectiveId,
     pub open: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub settings: Option<String>,
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use serde_json::json;
-
-    #[test]
-    fn voting_status_json_test() {
-        let voting_status = VotingStatus {
-            objective_id: ObjectiveId(1),
-            open: false,
-            settings: None,
-        };
-
-        let json = serde_json::to_value(&voting_status).unwrap();
-        assert_eq!(
-            json,
-            json!(
-                {
-                    "objective_id": 1,
-                    "open": false,
-                }
-            )
-        )
-    }
 }


### PR DESCRIPTION
# Description

Moving serde implementation of the types which are cunsumed by the cat-data-service directly into the cat-data-service from event-db. 
It makes cat-data-service independent from the event-db of how represent the data while we are returning it in responses.