### PR TITLE
fix: IdeaScale importer no longer one exception for each worker when fetching stage ideas | NPG-6949

### DIFF
--- a/utilities/ideascale-importer/ideascale_importer/utils.py
+++ b/utilities/ideascale-importer/ideascale_importer/utils.py
@@ -136,9 +136,11 @@ class BadResponse(Exception):
 class GetFailed(Exception):
     """Raised when a GET request fails."""
 
-    def __init__(self, status, reason, content):
+    def __init__(self, status: int, content: str):
         """Initialize a new instance of GetFailed."""
-        super().__init__(f"{status} {reason}\n{content})")
+        super().__init__(f"Get request failed status={status} content={content}")
+        self.status = status
+        self.content = content
 
 
 class JsonHttpClient:
@@ -183,7 +185,7 @@ class JsonHttpClient:
                     snake_case_keys(parsed_json)
                     return parsed_json
                 else:
-                    raise GetFailed(r.status, r.reason, content)
+                    raise GetFailed(r.status, content.decode())
 
 
 log_level_colors = {


### PR DESCRIPTION
* Fixed the issue with `ideascale.Client.stage_ideas` throwing 1 stage not found exception for each download task worker (now it throws only 1)