### PR TITLE
fix: Add `Access-Control-Allow-Headers` cors header | NPG-0000

### DIFF
--- a/src/cat-data-service/src/service/mod.rs
+++ b/src/cat-data-service/src/service/mod.rs
@@ -46,6 +46,7 @@ fn cors_layer() -> CorsLayer {
     CorsLayer::new()
         .allow_methods([Method::GET, Method::POST])
         .allow_origin(Any)
+        .allow_headers(Any)
 }
 
 async fn run_service(app: Router, addr: &SocketAddr, name: &str) -> Result<(), Error> {


### PR DESCRIPTION
# Description

Seting `Access-Control-Allow-Headers` to the cors heder responses, needed for requests with `Access-Control-Request-Headers` value.