### PR TITLE
fix: Fix IdeaScale importer bugs | NPG-7381

### DIFF
--- a/utilities/ideascale-importer/ideascale_importer/cli/ideascale.py
+++ b/utilities/ideascale-importer/ideascale_importer/cli/ideascale.py
@@ -75,8 +75,4 @@ def import_all(
         await importer.run()
         await importer.close()
 
-    try:
-        asyncio.run(inner(event_id, campaign_group_id, stage_id, proposals_scores_csv, ideascale_api_url))
-    except Exception as e:
-        logger.error(e)
-        raise typer.Exit(1)
+    asyncio.run(inner(event_id, campaign_group_id, stage_id, proposals_scores_csv, ideascale_api_url))

--- a/utilities/ideascale-importer/ideascale_importer/ideascale/client.py
+++ b/utilities/ideascale-importer/ideascale_importer/ideascale/client.py
@@ -58,8 +58,8 @@ class Idea:
     text: str
     author_info: IdeaAuthorInfo
     contributors: List[IdeaAuthorInfo]
-    custom_fields_by_key: Mapping[str, str]
     url: str
+    custom_fields_by_key: Mapping[str, str] = pydantic.Field(default={})
 
     def contributors_name(self) -> List[str]:
         """Get the names of all contributors."""

--- a/utilities/ideascale-importer/ideascale_importer/ideascale/client.py
+++ b/utilities/ideascale-importer/ideascale_importer/ideascale/client.py
@@ -187,7 +187,7 @@ class Client:
 
     async def funnel(self, funnel_id: int) -> Funnel:
         """Get the funnel with the given id."""
-        res = await self._get(f"/v1/funnels/{funnel_id}")
+        res = await self._get(f"/a/rest/v1/funnels/{funnel_id}")
         return pydantic.tools.parse_obj_as(Funnel, res)
 
     async def _get(self, path: str) -> Mapping[str, Any] | Iterable[Mapping[str, Any]]:

--- a/utilities/ideascale-importer/ideascale_importer/ideascale/importer.py
+++ b/utilities/ideascale-importer/ideascale_importer/ideascale/importer.py
@@ -270,8 +270,7 @@ class Importer:
 
         client = Client(self.api_token, self.ideascale_api_url)
 
-        groups = [g for g in await client.campaign_groups() if g.name.lower().startswith("fund")]
-
+        groups = await client.campaign_groups()
         if len(groups) == 0:
             logger.warning("No funds found")
             return

--- a/utilities/ideascale-importer/ideascale_importer/ideascale/importer.py
+++ b/utilities/ideascale-importer/ideascale_importer/ideascale/importer.py
@@ -299,10 +299,12 @@ class Importer:
             inserted_objectives_ix = {o.id: o for o in inserted_objectives}
 
             proposals_with_campaign_id = [(a.campaign_id, mapper.map_proposal(a, self.proposals_impact_scores)) for a in ideas]
+            proposals = []
             for objective_id, p in proposals_with_campaign_id:
-                p.objective = inserted_objectives_ix[objective_id].row_id
+                if objective_id in inserted_objectives_ix:
+                    p.objective = inserted_objectives_ix[objective_id].row_id
+                    proposals.append(p)
 
-            proposals = [p for (_, p) in proposals_with_campaign_id]
             proposal_count = len(proposals)
             await ideascale_importer.db.upsert_many(self.conn, proposals, conflict_cols=["id", "objective"])
 


### PR DESCRIPTION
# Description

- Fixed proposals not being filtered by campaign id when writing them to the DB which was causing an exception
- Fixed campaigns not being found caused by a filter on the campaign name
- Some other minor fixes

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

#### 1. API call to get ideas from a stage that is not part of a funnel of the campaigns in the campaign group:

```
poetry run ideascale-importer ideascale import-all --api-token API_KEY --database-url DBURL --ideascale-api-url https://temp-cardano-sandbox.ideascale.com  --event-id 1 --campaign-group-id 87 --stage-id 1
```

Imported 0 proposals as expected.

#### 2. API call to get ideas from a stage that is part of a funnel of the campaigns in the campaign group:
```
poetry run ideascale-importer ideascale import-all --api-token API_KEY --database-url DBURL --ideascale-api-url https://temp-cardano-sandbox.ideascale.com  --event-id 1 --campaign-group-id 87 --stage-id 4573
```

Imported 2 proposals as expected.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
