### PR TITLE
feat: Add new deleted fields for Proposal and Objective types | NPG-7499

### DIFF
--- a/book/src/07_web_api/openapi/core_backend_api.yaml
+++ b/book/src/07_web_api/openapi/core_backend_api.yaml
@@ -918,11 +918,15 @@ components:
             Long form explanation of this particular objective.\
             *May contain HTML Markup.*\
             *May contain Links to external content or assets.*
+        deleted:
+          type: boolean
+          description: Whether this Objective has been deleted or not.
       required:
         - id
         - type
         - title
         - description
+        - deleted
     ObjectiveDetails:
       title: Objective Details
       x-stoplight:
@@ -1019,10 +1023,14 @@ components:
         summary:
           type: string
           description: Brief description of the proposal.
+        deleted:
+          type: boolean
+          description: Whether this Proposal has been deleted or not.
       required:
         - id
         - title
         - summary
+        - deleted
       x-stoplight:
         id: 149678fbb6bb5
     ProposerDetails:

--- a/src/cat-data-service/src/service/v1/event/objective/mod.rs
+++ b/src/cat-data-service/src/service/v1/event/objective/mod.rs
@@ -173,6 +173,7 @@ mod tests {
                         },
                         "title": "title 1",
                         "description": "description 1",
+                        "deleted": false,
                         "groups": [
                             {
                                 "group": "direct",
@@ -201,6 +202,7 @@ mod tests {
                         },
                         "title": "title 2",
                         "description": "description 2",
+                        "deleted": false,
                         "groups": [],
                     }
                 ]
@@ -225,6 +227,7 @@ mod tests {
                         },
                         "title": "title 1",
                         "description": "description 1",
+                        "deleted": false,
                         "groups": [
                             {
                                 "group": "direct",
@@ -267,6 +270,7 @@ mod tests {
                         },
                         "title": "title 2",
                         "description": "description 2",
+                        "deleted": false,
                         "groups": [],
                     }
                 ]

--- a/src/cat-data-service/src/service/v1/event/objective/proposal/mod.rs
+++ b/src/cat-data-service/src/service/v1/event/objective/proposal/mod.rs
@@ -137,6 +137,7 @@ mod tests {
                     "id": 10,
                     "title": "title 1",
                     "summary": "summary 1",
+                    "deleted": false,
                     "funds": 100,
                     "url": "url.xyz",
                     "files": "files.xyz",
@@ -186,16 +187,19 @@ mod tests {
                     "id": 10,
                     "title": "title 1",
                     "summary": "summary 1",
+                    "deleted": false
                 },
                 {
                     "id": 20,
                     "title": "title 2",
                     "summary": "summary 2",
+                    "deleted": false
                 },
                 {
                     "id": 30,
                     "title": "title 3",
                     "summary": "summary 3",
+                    "deleted": false
                 }
             ])
         ));
@@ -216,11 +220,13 @@ mod tests {
                     "id": 10,
                     "title": "title 1",
                     "summary": "summary 1",
+                    "deleted": false
                 },
                 {
                     "id": 20,
                     "title": "title 2",
                     "summary": "summary 2",
+                    "deleted": false
                 },
             ])
         ));
@@ -241,11 +247,13 @@ mod tests {
                     "id": 20,
                     "title": "title 2",
                     "summary": "summary 2",
+                    "deleted": false
                 },
                 {
                     "id": 30,
                     "title": "title 3",
                     "summary": "summary 3",
+                    "deleted": false
                 }
             ])
         ));
@@ -266,6 +274,7 @@ mod tests {
                     "id": 20,
                     "title": "title 2",
                     "summary": "summary 2",
+                    "deleted": false
                 },
             ])
         ));

--- a/src/cat-data-service/src/service/v1/search.rs
+++ b/src/cat-data-service/src/service/v1/search.rs
@@ -428,7 +428,8 @@ mod tests {
                                 "description": "A Simple choice"
                             },
                             "title": "title 1",
-                            "description": "description 1"
+                            "description": "description 1",
+                            "deleted": false,
                         },
                         {
                             "id": 2,
@@ -437,7 +438,8 @@ mod tests {
                                 "description": "??"
                             },
                             "title": "title 2",
-                            "description": "description 2"
+                            "description": "description 2",
+                            "deleted": false,
                         },
                         {
                             "id": 3,
@@ -446,7 +448,8 @@ mod tests {
                                 "description": "A Simple choice"
                             },
                             "title": "title 3",
-                            "description": "description 3"
+                            "description": "description 3",
+                            "deleted": false,
                         },
                         {
                             "id": 4,
@@ -455,7 +458,8 @@ mod tests {
                                 "description": "??"
                             },
                             "title": "title 4",
-                            "description": "description 4"
+                            "description": "description 4",
+                            "deleted": false,
                         }
                     ]
                 }
@@ -525,7 +529,8 @@ mod tests {
                                 "description": "??"
                             },
                             "title": "title 4",
-                            "description": "description 4"
+                            "description": "description 4",
+                            "deleted": false,
                         },
                         {
                             "id": 3,
@@ -534,7 +539,8 @@ mod tests {
                                 "description": "A Simple choice"
                             },
                             "title": "title 3",
-                            "description": "description 3"
+                            "description": "description 3",
+                            "deleted": false,
                         },
                         {
                             "id": 2,
@@ -543,7 +549,8 @@ mod tests {
                                 "description": "??"
                             },
                             "title": "title 2",
-                            "description": "description 2"
+                            "description": "description 2",
+                            "deleted": false,
                         },
                         {
                             "id": 1,
@@ -552,7 +559,8 @@ mod tests {
                                 "description": "A Simple choice"
                             },
                             "title": "title 1",
-                            "description": "description 1"
+                            "description": "description 1",
+                            "deleted": false,
                         }
                     ]
                 }
@@ -593,7 +601,8 @@ mod tests {
                                 "description": "??"
                             },
                             "title": "title 4",
-                            "description": "description 4"
+                            "description": "description 4",
+                            "deleted": false,
                         },
                     ]
 
@@ -635,7 +644,8 @@ mod tests {
                                 "description": "A Simple choice"
                             },
                             "title": "title 3",
-                            "description": "description 3"
+                            "description": "description 3",
+                            "deleted": false,
                         },
                         {
                             "id": 2,
@@ -644,7 +654,8 @@ mod tests {
                                 "description": "??"
                             },
                             "title": "title 2",
-                            "description": "description 2"
+                            "description": "description 2",
+                            "deleted": false,
                         },
                         {
                             "id": 1,
@@ -653,7 +664,8 @@ mod tests {
                                 "description": "A Simple choice"
                             },
                             "title": "title 1",
-                            "description": "description 1"
+                            "description": "description 1",
+                            "deleted": false,
                         }
                     ]
                 }
@@ -713,17 +725,20 @@ mod tests {
                         {
                             "id": 10,
                             "title": "title 1",
-                            "summary": "summary 1"
+                            "summary": "summary 1",
+                            "deleted": false,
                         },
                         {
                             "id": 20,
                             "title": "title 2",
-                            "summary": "summary 2"
+                            "summary": "summary 2",
+                            "deleted": false,
                         },
                         {
                             "id": 30,
                             "title": "title 3",
-                            "summary": "summary 3"
+                            "summary": "summary 3",
+                            "deleted": false,
                         }
                     ]
                 }
@@ -789,17 +804,20 @@ mod tests {
                         {
                             "id": 30,
                             "title": "title 3",
-                            "summary": "summary 3"
+                            "summary": "summary 3",
+                            "deleted": false
                         },
                         {
                             "id": 20,
                             "title": "title 2",
-                            "summary": "summary 2"
+                            "summary": "summary 2",
+                            "deleted": false
                         },
                         {
                             "id": 10,
                             "title": "title 1",
-                            "summary": "summary 1"
+                            "summary": "summary 1",
+                            "deleted": false
                         }
                     ]
                 }
@@ -836,12 +854,14 @@ mod tests {
                         {
                             "id": 30,
                             "title": "title 3",
-                            "summary": "summary 3"
+                            "summary": "summary 3",
+                            "deleted": false
                         },
                         {
                             "id": 20,
                             "title": "title 2",
-                            "summary": "summary 2"
+                            "summary": "summary 2",
+                            "deleted": false
                         }
                     ]
                 }
@@ -878,12 +898,14 @@ mod tests {
                         {
                             "id": 20,
                             "title": "title 2",
-                            "summary": "summary 2"
+                            "summary": "summary 2",
+                            "deleted": false
                         },
                         {
                             "id": 10,
                             "title": "title 1",
-                            "summary": "summary 1"
+                            "summary": "summary 1",
+                            "deleted": false
                         }
                     ]
                 }
@@ -920,7 +942,8 @@ mod tests {
                         {
                             "id": 20,
                             "title": "title 2",
-                            "summary": "summary 2"
+                            "summary": "summary 2",
+                            "deleted": false
                         }
                     ]
                 }

--- a/src/cat-data-service/src/types/objective.rs
+++ b/src/cat-data-service/src/types/objective.rs
@@ -75,12 +75,14 @@ impl Serialize for SerdeType<&ObjectiveSummary> {
             objective_type: SerdeType<&'a ObjectiveType>,
             title: &'a String,
             description: &'a String,
+            deleted: bool,
         }
         ObjectiveSummarySerde {
             id: SerdeType(&self.id),
             objective_type: SerdeType(&self.objective_type),
             title: &self.title,
             description: &self.description,
+            deleted: self.deleted,
         }
         .serialize(serializer)
     }
@@ -259,6 +261,7 @@ mod tests {
             },
             title: "objective 1".to_string(),
             description: "description 1".to_string(),
+            deleted: false,
         });
 
         let json = serde_json::to_value(&objective_summary).unwrap();
@@ -273,6 +276,7 @@ mod tests {
                     },
                     "title": "objective 1",
                     "description": "description 1",
+                    "deleted": false,
                 }
             )
         );
@@ -362,6 +366,7 @@ mod tests {
                 },
                 title: "objective 1".to_string(),
                 description: "description 1".to_string(),
+                deleted: false,
             },
             details: ObjectiveDetails {
                 groups: vec![VoterGroup {
@@ -388,6 +393,7 @@ mod tests {
                     },
                     "title": "objective 1",
                     "description": "description 1",
+                    "deleted": false,
                     "groups": [
                         {
                             "group": "group",

--- a/src/cat-data-service/src/types/proposal.rs
+++ b/src/cat-data-service/src/types/proposal.rs
@@ -42,11 +42,13 @@ impl Serialize for SerdeType<&ProposalSummary> {
             id: SerdeType<&'a ProposalId>,
             title: &'a String,
             summary: &'a String,
+            deleted: bool,
         }
         ProposalSummarySerde {
             id: SerdeType(&self.id),
             title: &self.title,
             summary: &self.summary,
+            deleted: self.deleted,
         }
         .serialize(serializer)
     }
@@ -178,6 +180,7 @@ mod tests {
             id: ProposalId(1),
             title: "title".to_string(),
             summary: "summary".to_string(),
+            deleted: false,
         });
 
         let json = serde_json::to_value(&proposal_summary).unwrap();
@@ -188,6 +191,7 @@ mod tests {
                     "id": 1,
                     "title": "title",
                     "summary": "summary",
+                    "deleted": false,
                 }
             )
         )
@@ -269,6 +273,7 @@ mod tests {
                 id: ProposalId(1),
                 title: "title".to_string(),
                 summary: "summary".to_string(),
+                deleted: false,
             },
             details: ProposalDetails {
                 funds: 1,
@@ -287,6 +292,7 @@ mod tests {
                     "id": 1,
                     "title": "title",
                     "summary": "summary",
+                    "deleted": false,
                     "funds": 1,
                     "url": "url",
                     "files": "files",

--- a/src/event-db/migrations/V3__objective_tables.sql
+++ b/src/event-db/migrations/V3__objective_tables.sql
@@ -97,6 +97,8 @@ CREATE TABLE objective
     title TEXT NOT NULL,
     description TEXT NOT NULL,
 
+    deleted BOOLEAN NOT NULL DEFAULT FALSE,
+
     rewards_currency TEXT,
     rewards_total BIGINT,
     rewards_total_lovelace BIGINT,
@@ -126,6 +128,7 @@ COMMENT ON COLUMN objective.category IS
 See the objective_category table for allowed values.';
 COMMENT ON COLUMN objective.title IS 'The  title of the objective.';
 COMMENT ON COLUMN objective.description IS 'Long form description of the objective.';
+COMMENT ON COLUMN objective.deleted IS 'Flag which defines was this objective (challenge) deleted from ideascale or not. DEPRECATED: only used for ideascale compatibility.';
 COMMENT ON COLUMN objective.rewards_currency IS 'The currency rewards values are represented as.';
 COMMENT ON COLUMN objective.rewards_total IS 'The total reward pool to pay on this objective to winning proposals. In the Objective Currency.';
 COMMENT ON COLUMN objective.rewards_total_lovelace IS 'The total reward pool to pay on this objective to winning proposals. In Lovelace.';

--- a/src/event-db/migrations/V4__proposal_tables.sql
+++ b/src/event-db/migrations/V4__proposal_tables.sql
@@ -16,6 +16,8 @@ CREATE TABLE proposal
     files_url TEXT NOT NULL,
     impact_score BIGINT NOT NULL,
 
+    deleted BOOLEAN NOT NULL DEFAULT FALSE,
+
     extra JSONB,
 
     proposer_name TEXT NOT NULL,
@@ -45,6 +47,7 @@ COMMENT ON COLUMN proposal.funds IS 'How much funds (in the currency of the fund
 COMMENT ON COLUMN proposal.url IS 'A URL with supporting information for the proposal.';
 COMMENT ON COLUMN proposal.files_url IS 'A URL link to relevant files supporting the proposal.';
 COMMENT ON COLUMN proposal.impact_score IS 'The Impact score assigned to this proposal by the Assessors.';
+COMMENT ON COLUMN proposal.deleted IS 'Flag which defines was this proposal deleted from ideascale or not. DEPRECATED: only used for ideascale compatibility.';
 COMMENT ON COLUMN proposal.proposer_name IS 'The proposers name.';
 COMMENT ON COLUMN proposal.proposer_contact IS 'Contact details for the proposer.';
 COMMENT ON COLUMN proposal.proposer_url IS 'A URL with details of the proposer.';

--- a/src/event-db/src/queries/event/objective.rs
+++ b/src/event-db/src/queries/event/objective.rs
@@ -26,7 +26,7 @@ pub trait ObjectiveQueries: Sync + Send + 'static {
 
 impl EventDB {
     const OBJECTIVES_QUERY: &'static str =
-        "SELECT objective.row_id, objective.id, objective.title, objective.description, objective.rewards_currency, objective.rewards_total, objective.extra,
+        "SELECT objective.row_id, objective.id, objective.title, objective.description, objective.deleted, objective.rewards_currency, objective.rewards_total, objective.extra,
         objective_category.name, objective_category.description as objective_category_description
         FROM objective
         INNER JOIN objective_category on objective.category = objective_category.name
@@ -67,6 +67,7 @@ impl ObjectiveQueries for EventDB {
                 },
                 title: row.try_get("title")?,
                 description: row.try_get("description")?,
+                deleted: row.try_get("deleted")?,
             };
             let currency: Option<_> = row.try_get("rewards_currency")?;
             let value: Option<_> = row.try_get("rewards_total")?;
@@ -143,6 +144,7 @@ mod tests {
                         },
                         title: "title 1".to_string(),
                         description: "description 1".to_string(),
+                        deleted: false,
                     },
                     details: ObjectiveDetails {
                         groups: vec![
@@ -177,6 +179,7 @@ mod tests {
                         },
                         title: "title 2".to_string(),
                         description: "description 2".to_string(),
+                        deleted: false,
                     },
                     details: ObjectiveDetails {
                         groups: Vec::new(),
@@ -202,6 +205,7 @@ mod tests {
                     },
                     title: "title 1".to_string(),
                     description: "description 1".to_string(),
+                    deleted: false,
                 },
                 details: ObjectiveDetails {
                     groups: vec![
@@ -244,6 +248,7 @@ mod tests {
                     },
                     title: "title 2".to_string(),
                     description: "description 2".to_string(),
+                    deleted: false,
                 },
                 details: ObjectiveDetails {
                     groups: Vec::new(),

--- a/src/event-db/src/queries/event/proposal.rs
+++ b/src/event-db/src/queries/event/proposal.rs
@@ -29,14 +29,15 @@ pub trait ProposalQueries: Sync + Send + 'static {
 }
 
 impl EventDB {
-    const PROPOSALS_QUERY: &'static str = "SELECT proposal.id, proposal.title, proposal.summary
+    const PROPOSALS_QUERY: &'static str =
+        "SELECT proposal.id, proposal.title, proposal.summary, proposal.deleted
         FROM proposal
         INNER JOIN objective on proposal.objective = objective.row_id
         WHERE objective.event = $1 AND objective.id = $2
         LIMIT $3 OFFSET $4;";
 
     const PROPOSAL_QUERY: &'static str =
-        "SELECT proposal.id, proposal.title, proposal.summary, proposal.extra,
+        "SELECT proposal.id, proposal.title, proposal.summary, proposal.deleted, proposal.extra,
     proposal.funds, proposal.url, proposal.files_url,
     proposal.proposer_name, proposal.proposer_contact, proposal.proposer_url, proposal.public_key
     FROM proposal
@@ -74,6 +75,7 @@ impl ProposalQueries for EventDB {
             id: ProposalId(row.try_get("id")?),
             title: row.try_get("title")?,
             summary: row.try_get("summary")?,
+            deleted: row.try_get("deleted")?,
         };
 
         let details = ProposalDetails {
@@ -109,6 +111,7 @@ impl ProposalQueries for EventDB {
                 id: ProposalId(row.try_get("id")?),
                 title: row.try_get("title")?,
                 summary: row.try_get("summary")?,
+                deleted: row.try_get("deleted")?,
             };
 
             proposals.push(summary);
@@ -153,7 +156,8 @@ mod tests {
                 summary: ProposalSummary {
                     id: ProposalId(10),
                     title: String::from("title 1"),
-                    summary: String::from("summary 1")
+                    summary: String::from("summary 1"),
+                    deleted: false,
                 },
                 details: ProposalDetails {
                     funds: 100,
@@ -194,17 +198,20 @@ mod tests {
                 ProposalSummary {
                     id: ProposalId(10),
                     title: String::from("title 1"),
-                    summary: String::from("summary 1")
+                    summary: String::from("summary 1"),
+                    deleted: false
                 },
                 ProposalSummary {
                     id: ProposalId(20),
                     title: String::from("title 2"),
-                    summary: String::from("summary 2")
+                    summary: String::from("summary 2"),
+                    deleted: false
                 },
                 ProposalSummary {
                     id: ProposalId(30),
                     title: String::from("title 3"),
-                    summary: String::from("summary 3")
+                    summary: String::from("summary 3"),
+                    deleted: false
                 }
             ],
             proposal_summary
@@ -220,12 +227,14 @@ mod tests {
                 ProposalSummary {
                     id: ProposalId(10),
                     title: String::from("title 1"),
-                    summary: String::from("summary 1")
+                    summary: String::from("summary 1"),
+                    deleted: false
                 },
                 ProposalSummary {
                     id: ProposalId(20),
                     title: String::from("title 2"),
-                    summary: String::from("summary 2")
+                    summary: String::from("summary 2"),
+                    deleted: false
                 },
             ],
             proposal_summary
@@ -241,12 +250,14 @@ mod tests {
                 ProposalSummary {
                     id: ProposalId(20),
                     title: String::from("title 2"),
-                    summary: String::from("summary 2")
+                    summary: String::from("summary 2"),
+                    deleted: false
                 },
                 ProposalSummary {
                     id: ProposalId(30),
                     title: String::from("title 3"),
-                    summary: String::from("summary 3")
+                    summary: String::from("summary 3"),
+                    deleted: false
                 }
             ],
             proposal_summary
@@ -261,7 +272,8 @@ mod tests {
             vec![ProposalSummary {
                 id: ProposalId(20),
                 title: String::from("title 2"),
-                summary: String::from("summary 2")
+                summary: String::from("summary 2"),
+                deleted: false
             },],
             proposal_summary
         );

--- a/src/event-db/src/queries/search.rs
+++ b/src/event-db/src/queries/search.rs
@@ -33,12 +33,12 @@ impl EventDB {
         LEFT JOIN snapshot ON event.row_id = snapshot.event";
 
     const SEARCH_OBJECTIVES_QUERY: &'static str =
-        "SELECT objective.id, objective.title, objective.description, objective_category.name, objective_category.description as objective_category_description
+        "SELECT objective.id, objective.title, objective.description, objective.deleted, objective_category.name, objective_category.description as objective_category_description
         FROM objective
         INNER JOIN objective_category on objective.category = objective_category.name";
 
     const SEARCH_PROPOSALS_QUERY: &'static str =
-        "SELECT DISTINCT proposal.id, proposal.title, proposal.summary
+        "SELECT DISTINCT proposal.id, proposal.title, proposal.summary, proposal.deleted
         FROM proposal";
 
     fn build_where_clause(table: &str, filter: &[SearchConstraint]) -> String {
@@ -207,6 +207,7 @@ impl SearchQueries for EventDB {
                             },
                             title: row.try_get("title")?,
                             description: row.try_get("description")?,
+                            deleted: row.try_get("deleted")?,
                         };
                         objectives.push(objective);
                     }
@@ -231,6 +232,7 @@ impl SearchQueries for EventDB {
                             id: ProposalId(row.try_get("id")?),
                             title: row.try_get("title")?,
                             summary: row.try_get("summary")?,
+                            deleted: row.try_get("deleted")?,
                         };
 
                         proposals.push(summary);
@@ -741,6 +743,7 @@ mod tests {
                     },
                     title: "title 1".to_string(),
                     description: "description 1".to_string(),
+                    deleted: false,
                 },
                 ObjectiveSummary {
                     id: ObjectiveId(2),
@@ -750,6 +753,7 @@ mod tests {
                     },
                     title: "title 2".to_string(),
                     description: "description 2".to_string(),
+                    deleted: false,
                 },
                 ObjectiveSummary {
                     id: ObjectiveId(3),
@@ -759,6 +763,7 @@ mod tests {
                     },
                     title: "title 3".to_string(),
                     description: "description 3".to_string(),
+                    deleted: false,
                 },
                 ObjectiveSummary {
                     id: ObjectiveId(4),
@@ -768,6 +773,7 @@ mod tests {
                     },
                     title: "title 4".to_string(),
                     description: "description 4".to_string(),
+                    deleted: false,
                 },
             ]))
         );
@@ -806,6 +812,7 @@ mod tests {
                     },
                     title: "title 4".to_string(),
                     description: "description 4".to_string(),
+                    deleted: false,
                 },
                 ObjectiveSummary {
                     id: ObjectiveId(3),
@@ -815,6 +822,7 @@ mod tests {
                     },
                     title: "title 3".to_string(),
                     description: "description 3".to_string(),
+                    deleted: false,
                 },
                 ObjectiveSummary {
                     id: ObjectiveId(2),
@@ -824,6 +832,7 @@ mod tests {
                     },
                     title: "title 2".to_string(),
                     description: "description 2".to_string(),
+                    deleted: false,
                 },
                 ObjectiveSummary {
                     id: ObjectiveId(1),
@@ -833,6 +842,7 @@ mod tests {
                     },
                     title: "title 1".to_string(),
                     description: "description 1".to_string(),
+                    deleted: false,
                 },
             ]))
         );
@@ -852,6 +862,7 @@ mod tests {
                 },
                 title: "title 4".to_string(),
                 description: "description 4".to_string(),
+                deleted: false,
             },]))
         );
 
@@ -871,6 +882,7 @@ mod tests {
                     },
                     title: "title 3".to_string(),
                     description: "description 3".to_string(),
+                    deleted: false,
                 },
                 ObjectiveSummary {
                     id: ObjectiveId(2),
@@ -880,6 +892,7 @@ mod tests {
                     },
                     title: "title 2".to_string(),
                     description: "description 2".to_string(),
+                    deleted: false,
                 },
                 ObjectiveSummary {
                     id: ObjectiveId(1),
@@ -889,6 +902,7 @@ mod tests {
                     },
                     title: "title 1".to_string(),
                     description: "description 1".to_string(),
+                    deleted: false,
                 },
             ]))
         );
@@ -935,17 +949,20 @@ mod tests {
                 ProposalSummary {
                     id: ProposalId(10),
                     title: String::from("title 1"),
-                    summary: String::from("summary 1")
+                    summary: String::from("summary 1"),
+                    deleted: false
                 },
                 ProposalSummary {
                     id: ProposalId(20),
                     title: String::from("title 2"),
-                    summary: String::from("summary 2")
+                    summary: String::from("summary 2"),
+                    deleted: false,
                 },
                 ProposalSummary {
                     id: ProposalId(30),
                     title: String::from("title 3"),
-                    summary: String::from("summary 3")
+                    summary: String::from("summary 3"),
+                    deleted: false
                 },
             ]))
         );
@@ -979,17 +996,20 @@ mod tests {
                 ProposalSummary {
                     id: ProposalId(30),
                     title: String::from("title 3"),
-                    summary: String::from("summary 3")
+                    summary: String::from("summary 3"),
+                    deleted: false
                 },
                 ProposalSummary {
                     id: ProposalId(20),
                     title: String::from("title 2"),
-                    summary: String::from("summary 2")
+                    summary: String::from("summary 2"),
+                    deleted: false
                 },
                 ProposalSummary {
                     id: ProposalId(10),
                     title: String::from("title 1"),
-                    summary: String::from("summary 1")
+                    summary: String::from("summary 1"),
+                    deleted: false
                 },
             ]))
         );
@@ -1005,12 +1025,14 @@ mod tests {
                 ProposalSummary {
                     id: ProposalId(30),
                     title: String::from("title 3"),
-                    summary: String::from("summary 3")
+                    summary: String::from("summary 3"),
+                    deleted: false
                 },
                 ProposalSummary {
                     id: ProposalId(20),
                     title: String::from("title 2"),
-                    summary: String::from("summary 2")
+                    summary: String::from("summary 2"),
+                    deleted: false
                 },
             ]))
         );
@@ -1026,12 +1048,14 @@ mod tests {
                 ProposalSummary {
                     id: ProposalId(20),
                     title: String::from("title 2"),
-                    summary: String::from("summary 2")
+                    summary: String::from("summary 2"),
+                    deleted: false
                 },
                 ProposalSummary {
                     id: ProposalId(10),
                     title: String::from("title 1"),
-                    summary: String::from("summary 1")
+                    summary: String::from("summary 1"),
+                    deleted: false
                 },
             ]))
         );
@@ -1046,7 +1070,8 @@ mod tests {
             Some(ValueResults::Proposals(vec![ProposalSummary {
                 id: ProposalId(20),
                 title: String::from("title 2"),
-                summary: String::from("summary 2")
+                summary: String::from("summary 2"),
+                deleted: false
             },]))
         );
 

--- a/src/event-db/src/types/objective.rs
+++ b/src/event-db/src/types/objective.rs
@@ -16,6 +16,7 @@ pub struct ObjectiveSummary {
     pub objective_type: ObjectiveType,
     pub title: String,
     pub description: String,
+    pub deleted: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/event-db/src/types/proposal.rs
+++ b/src/event-db/src/types/proposal.rs
@@ -25,6 +25,7 @@ pub struct ProposalSummary {
     pub id: ProposalId,
     pub title: String,
     pub summary: String,
+    pub deleted: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]


### PR DESCRIPTION
# Description

Added new `deleted` field for `Proposal` and `Objective` types and added corresponded columns into the event-db. This new data added to handle some corner cases with importing from  ideascale service.