### PR TITLE
chore: Correct event-db schema version | NPG-7769

### DIFF
--- a/src/event-db/src/lib.rs
+++ b/src/event-db/src/lib.rs
@@ -19,7 +19,7 @@ const DATABASE_URL_ENVVAR: &str = "EVENT_DB_URL";
 
 /// Database version this crate matches.
 /// Must equal the last Migrations Version Number.
-pub const DATABASE_SCHEMA_VERSION: i32 = 10;
+pub const DATABASE_SCHEMA_VERSION: i32 = 9;
 
 #[allow(unused)]
 /// Connection to the Election Database


### PR DESCRIPTION
# Description

Change event-db schema version to 9 so it works after the removal of the vit-ss compatibility tables.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)