### PR TITLE
fix: Fix SNAPSHOT_TOOL_SSH envvar logic and db update SQL function

### DIFF
--- a/utilities/ideascale-importer/ideascale_importer/cli/snapshot.py
+++ b/utilities/ideascale-importer/ideascale_importer/cli/snapshot.py
@@ -68,7 +68,7 @@ def import_snapshot(
         envvar="SSH_SNAPSHOT_TOOL_OUTPUT_DIR",
         help="Output directoy for storing the snapshot_tool output on the remote machine",
     ),
-    snapshot_tool_ssh: Optional[str] = typer.Option(
+    snapshot_tool_ssh: bool = typer.Option(
         default=False,
         envvar="SNAPSHOT_TOOL_SSH",
         help="If set, snapshot tool will be executed through SSH",

--- a/utilities/ideascale-importer/ideascale_importer/db/__init__.py
+++ b/utilities/ideascale-importer/ideascale_importer/db/__init__.py
@@ -77,7 +77,7 @@ async def select(conn: asyncpg.Connection, model: Model, cond: Dict[str, str] = 
         SELECT {cols_str}
         FROM {model.table()}
         {f' WHERE {cond_str}' if cond_str else ' '}
-    """.strip()  
+    """.strip()
 
     result = await conn.fetch(stmt_template)
 
@@ -123,7 +123,7 @@ async def upsert_many(
     pre_update_set_str = ",".join([f"{col} = {val}" for col, val in pre_update_cols.items()])
     pre_update_cond_str = ",".join([f"{col} {cond}" for col, cond in pre_update_cond.items()])
     stmt_template = f"""
-        WITH updated AS ({ f"UPDATE {models[0].table()} SET {pre_update_set_str} {f' WHERE {pre_update_cond_str}' if pre_update_cond_str else ' '}" if pre_update_set_str else " " })
+        {f"WITH updated AS (UPDATE {models[0].table()} SET {pre_update_set_str} {f' WHERE {pre_update_cond_str}' if pre_update_cond_str else ' '}" if pre_update_set_str else ' '}
 
         INSERT INTO {models[0].table()} ({insert_cols_str}) VALUES {val_nums_str}
         ON CONFLICT ({conflict_cols_str})


### PR DESCRIPTION
# Description

This PR fixes:
1. Snapshot importer would fail to execute even if `SNAPSHOT_TOOL_SSH` was not set
2. DB code would fail to upsert rows if `pre_update_cols` was empty

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I took a testnet snapshot on my machine.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings