### PR TITLE
fix: Fixed catalyt-toolbox RewardAddress formating | NPG-7784

### DIFF
--- a/src/catalyst-toolbox/catalyst-toolbox/src/bin/cli/rewards/dreps.rs
+++ b/src/catalyst-toolbox/catalyst-toolbox/src/bin/cli/rewards/dreps.rs
@@ -7,7 +7,6 @@ use color_eyre::Report;
 use jormungandr_lib::{crypto::account::Identifier, interfaces::AccountVotes};
 use serde::Serialize;
 use snapshot_lib::registration::RewardAddress;
-use snapshot_lib::NetworkType;
 use snapshot_lib::SnapshotInfo;
 use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
@@ -48,10 +47,6 @@ pub struct DrepsRewards {
     /// Can be obtained from /api/v0/proposals.
     #[clap(long)]
     proposals: PathBuf,
-
-    /// Specify network type of the, could be "mainnet" or "testnet"
-    #[clap(long, default_value = "mainnet")]
-    net_type: NetworkType,
 }
 
 fn write_rewards_results(
@@ -77,7 +72,7 @@ fn write_rewards_results(
 }
 
 impl DrepsRewards {
-    fn exec_impl(self) -> Result<(), Report> {
+    pub fn exec(self) -> Result<(), Report> {
         let DrepsRewards {
             output,
             total_rewards,
@@ -126,12 +121,5 @@ impl DrepsRewards {
 
         write_rewards_results(&output, results)?;
         Ok(())
-    }
-
-    pub fn exec(self) -> Result<(), Report> {
-        match self.net_type {
-            NetworkType::Mainnet => self.exec_impl(),
-            NetworkType::Testnet => self.exec_impl(),
-        }
     }
 }

--- a/src/catalyst-toolbox/catalyst-toolbox/src/bin/cli/rewards/dreps.rs
+++ b/src/catalyst-toolbox/catalyst-toolbox/src/bin/cli/rewards/dreps.rs
@@ -6,11 +6,9 @@ use clap::Parser;
 use color_eyre::Report;
 use jormungandr_lib::{crypto::account::Identifier, interfaces::AccountVotes};
 use serde::Serialize;
+use snapshot_lib::registration::RewardAddress;
 use snapshot_lib::NetworkType;
-use snapshot_lib::{
-    registration::{MainnetRewardAddress, RewardAddressTrait, TestnetRewardAddress},
-    SnapshotInfo,
-};
+use snapshot_lib::SnapshotInfo;
 use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
 
@@ -56,14 +54,14 @@ pub struct DrepsRewards {
     net_type: NetworkType,
 }
 
-fn write_rewards_results<RewardAddressType: RewardAddressTrait>(
+fn write_rewards_results(
     output: &Option<PathBuf>,
-    rewards: BTreeMap<RewardAddressType, Rewards>,
+    rewards: BTreeMap<RewardAddress, Rewards>,
 ) -> Result<(), Report> {
     #[derive(Serialize, Debug)]
-    struct Entry<RewardAddressType> {
+    struct Entry {
         #[serde(rename = "Address")]
-        address: RewardAddressType,
+        address: RewardAddress,
         #[serde(rename = "Reward for the voter (lovelace)")]
         reward: Rewards,
     }
@@ -79,7 +77,7 @@ fn write_rewards_results<RewardAddressType: RewardAddressTrait>(
 }
 
 impl DrepsRewards {
-    fn exec_impl<RewardAddressType: RewardAddressTrait>(self) -> Result<(), Report> {
+    fn exec_impl(self) -> Result<(), Report> {
         let DrepsRewards {
             output,
             total_rewards,
@@ -102,7 +100,7 @@ impl DrepsRewards {
             )?,
         )?;
 
-        let snapshot: Vec<SnapshotInfo<RewardAddressType>> = serde_json::from_reader(
+        let snapshot: Vec<SnapshotInfo> = serde_json::from_reader(
             jcli_lib::utils::io::open_file_read(&Some(snapshot_info_path))?,
         )?;
 
@@ -132,8 +130,8 @@ impl DrepsRewards {
 
     pub fn exec(self) -> Result<(), Report> {
         match self.net_type {
-            NetworkType::Mainnet => self.exec_impl::<MainnetRewardAddress>(),
-            NetworkType::Testnet => self.exec_impl::<TestnetRewardAddress>(),
+            NetworkType::Mainnet => self.exec_impl(),
+            NetworkType::Testnet => self.exec_impl(),
         }
     }
 }

--- a/src/catalyst-toolbox/catalyst-toolbox/src/bin/cli/rewards/full/mod.rs
+++ b/src/catalyst-toolbox/catalyst-toolbox/src/bin/cli/rewards/full/mod.rs
@@ -4,13 +4,12 @@ use catalyst_toolbox::{
 };
 use color_eyre::Result;
 use config::*;
-use snapshot_lib::registration::RewardAddressTrait;
 use std::path::Path;
 use tracing::info;
 
 mod config;
 
-pub(super) fn full_rewards<RewardAddressType: RewardAddressTrait>(path: &Path) -> Result<()> {
+pub(super) fn full_rewards(path: &Path) -> Result<()> {
     let config = json_from_file(path)?;
     let Config {
         inputs:
@@ -45,7 +44,7 @@ pub(super) fn full_rewards<RewardAddressType: RewardAddressTrait>(path: &Path) -
     } = config;
 
     info!("calculating voter rewards");
-    super::voters::voter_rewards::<RewardAddressType>(
+    super::voters::voter_rewards(
         &Some(voter_rewards_output),
         &vote_count_path,
         &snapshot_path,

--- a/src/catalyst-toolbox/catalyst-toolbox/src/bin/cli/rewards/mod.rs
+++ b/src/catalyst-toolbox/catalyst-toolbox/src/bin/cli/rewards/mod.rs
@@ -13,7 +13,6 @@ use jormungandr_lib::{
     crypto::{account::Identifier, hash::Hash},
     interfaces::AccountVotes,
 };
-use snapshot_lib::registration::{MainnetRewardAddress, TestnetRewardAddress};
 use snapshot_lib::NetworkType;
 use std::{collections::HashMap, path::PathBuf};
 
@@ -52,8 +51,8 @@ impl Rewards {
             Rewards::Veterans(cmd) => cmd.exec(),
             Rewards::Dreps(cmd) => cmd.exec(),
             Rewards::Full { path, net_type } => match net_type {
-                NetworkType::Mainnet => full::full_rewards::<MainnetRewardAddress>(&path),
-                NetworkType::Testnet => full::full_rewards::<TestnetRewardAddress>(&path),
+                NetworkType::Mainnet => full::full_rewards(&path),
+                NetworkType::Testnet => full::full_rewards(&path),
             },
             Rewards::Proposers(proposers) => proposers::rewards(&proposers),
         }

--- a/src/catalyst-toolbox/catalyst-toolbox/src/bin/cli/rewards/mod.rs
+++ b/src/catalyst-toolbox/catalyst-toolbox/src/bin/cli/rewards/mod.rs
@@ -13,7 +13,6 @@ use jormungandr_lib::{
     crypto::{account::Identifier, hash::Hash},
     interfaces::AccountVotes,
 };
-use snapshot_lib::NetworkType;
 use std::{collections::HashMap, path::PathBuf};
 
 #[derive(Parser)]
@@ -32,12 +31,7 @@ pub enum Rewards {
     Veterans(veterans::VeteransRewards),
 
     /// Calculate full rewards based on a config file
-    Full {
-        path: PathBuf,
-        /// Specify network type of the, could be "mainnet" or "testnet"
-        #[clap(default_value = "mainnet")]
-        net_type: NetworkType,
-    },
+    Full { path: PathBuf },
 
     /// Calculate rewards for propsers
     Proposers(proposers_lib::ProposerRewards),
@@ -50,10 +44,7 @@ impl Rewards {
             Rewards::CommunityAdvisors(cmd) => cmd.exec(),
             Rewards::Veterans(cmd) => cmd.exec(),
             Rewards::Dreps(cmd) => cmd.exec(),
-            Rewards::Full { path, net_type } => match net_type {
-                NetworkType::Mainnet => full::full_rewards(&path),
-                NetworkType::Testnet => full::full_rewards(&path),
-            },
+            Rewards::Full { path } => full::full_rewards(&path),
             Rewards::Proposers(proposers) => proposers::rewards(&proposers),
         }
     }

--- a/src/catalyst-toolbox/catalyst-toolbox/src/bin/cli/rewards/voters.rs
+++ b/src/catalyst-toolbox/catalyst-toolbox/src/bin/cli/rewards/voters.rs
@@ -5,8 +5,8 @@ use catalyst_toolbox::utils::{assert_are_close, json_from_file};
 use clap::Parser;
 use color_eyre::{Report, Result};
 use serde::Serialize;
-use snapshot_lib::registration::{MainnetRewardAddress, RewardAddressTrait, TestnetRewardAddress};
-use snapshot_lib::{NetworkType, SnapshotInfo};
+use snapshot_lib::registration::RewardAddress;
+use snapshot_lib::{NetworkType};
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
@@ -42,14 +42,14 @@ pub struct VotersRewards {
     net_type: NetworkType,
 }
 
-fn write_rewards_results<RewardAddressType: RewardAddressTrait>(
+fn write_rewards_results(
     output: &Option<PathBuf>,
-    rewards: BTreeMap<RewardAddressType, Rewards>,
+    rewards: BTreeMap<RewardAddress, Rewards>,
 ) -> Result<(), Report> {
     #[derive(Serialize, Debug)]
-    struct Entry<RewardAddressType> {
+    struct Entry {
         #[serde(rename = "Address")]
-        address: RewardAddressType,
+        address: RewardAddress,
         #[serde(rename = "Reward for the voter (lovelace)")]
         reward: Rewards,
     }
@@ -76,14 +76,14 @@ impl VotersRewards {
         } = self;
 
         match net_type {
-            NetworkType::Mainnet => voter_rewards::<MainnetRewardAddress>(
+            NetworkType::Mainnet => voter_rewards(
                 &output,
                 &votes_count_path,
                 &snapshot_info_path,
                 vote_threshold,
                 total_rewards,
             ),
-            NetworkType::Testnet => voter_rewards::<TestnetRewardAddress>(
+            NetworkType::Testnet => voter_rewards(
                 &output,
                 &votes_count_path,
                 &snapshot_info_path,
@@ -94,7 +94,7 @@ impl VotersRewards {
     }
 }
 
-pub fn voter_rewards<RewardAddressType: RewardAddressTrait>(
+pub fn voter_rewards(
     output: &Option<PathBuf>,
     votes_count_path: &Path,
     snapshot_path: &Path,
@@ -102,7 +102,7 @@ pub fn voter_rewards<RewardAddressType: RewardAddressTrait>(
     total_rewards: u64,
 ) -> Result<()> {
     let vote_count = json_from_file(votes_count_path)?;
-    let snapshot: Vec<SnapshotInfo<RewardAddressType>> = json_from_file(snapshot_path)?;
+    let snapshot = json_from_file(snapshot_path)?;
 
     let results = calc_voter_rewards(
         vote_count,

--- a/src/catalyst-toolbox/catalyst-toolbox/src/bin/cli/rewards/voters.rs
+++ b/src/catalyst-toolbox/catalyst-toolbox/src/bin/cli/rewards/voters.rs
@@ -6,7 +6,6 @@ use clap::Parser;
 use color_eyre::{Report, Result};
 use serde::Serialize;
 use snapshot_lib::registration::RewardAddress;
-use snapshot_lib::{NetworkType};
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
@@ -36,10 +35,6 @@ pub struct VotersRewards {
     /// Number of global votes required to be able to receive voter rewards
     #[clap(long, default_value = "0")]
     vote_threshold: u64,
-
-    /// Specify network type of the, could be "mainnet" or "testnet"
-    #[clap(long, default_value = "mainnet")]
-    net_type: NetworkType,
 }
 
 fn write_rewards_results(
@@ -72,25 +67,15 @@ impl VotersRewards {
             snapshot_info_path,
             votes_count_path,
             vote_threshold,
-            net_type,
         } = self;
 
-        match net_type {
-            NetworkType::Mainnet => voter_rewards(
-                &output,
-                &votes_count_path,
-                &snapshot_info_path,
-                vote_threshold,
-                total_rewards,
-            ),
-            NetworkType::Testnet => voter_rewards(
-                &output,
-                &votes_count_path,
-                &snapshot_info_path,
-                vote_threshold,
-                total_rewards,
-            ),
-        }
+        voter_rewards(
+            &output,
+            &votes_count_path,
+            &snapshot_info_path,
+            vote_threshold,
+            total_rewards,
+        )
     }
 }
 

--- a/src/catalyst-toolbox/catalyst-toolbox/src/bin/cli/snapshot/mod.rs
+++ b/src/catalyst-toolbox/catalyst-toolbox/src/bin/cli/snapshot/mod.rs
@@ -4,7 +4,7 @@ use jcli_lib::utils::{output_file::OutputFile, output_format::OutputFormat};
 use jormungandr_lib::interfaces::Value;
 use snapshot_lib::{
     voting_group::{RepsVotersAssigner, DEFAULT_DIRECT_VOTER_GROUP, DEFAULT_REPRESENTATIVE_GROUP},
-    NetworkType, Snapshot,
+    Snapshot,
 };
 use snapshot_lib::{Dreps, Fraction};
 use std::fs::File;
@@ -45,14 +45,10 @@ pub struct SnapshotCmd {
 
     #[clap(flatten)]
     output_format: OutputFormat,
-
-    /// Specify network type of the, could be "mainnet" or "testnet"
-    #[clap(long, default_value = "mainnet")]
-    net_type: NetworkType,
 }
 
 impl SnapshotCmd {
-    pub fn exec_impl(self) -> Result<(), Report> {
+    pub fn exec(self) -> Result<(), Report> {
         let raw_snapshot = serde_json::from_reader(File::open(&self.snapshot)?)?;
         let dreps = if let Some(dreps) = &self.dreps {
             serde_json::from_reader(File::open(dreps)?)?
@@ -79,12 +75,5 @@ impl SnapshotCmd {
             .format_json(serde_json::to_value(initials)?)?;
         out_writer.write_all(content.as_bytes())?;
         Ok(())
-    }
-
-    pub fn exec(self) -> Result<(), Report> {
-        match self.net_type {
-            NetworkType::Mainnet => self.exec_impl(),
-            NetworkType::Testnet => self.exec_impl(),
-        }
     }
 }

--- a/src/catalyst-toolbox/catalyst-toolbox/src/bin/cli/snapshot/mod.rs
+++ b/src/catalyst-toolbox/catalyst-toolbox/src/bin/cli/snapshot/mod.rs
@@ -3,9 +3,8 @@ use color_eyre::Report;
 use jcli_lib::utils::{output_file::OutputFile, output_format::OutputFormat};
 use jormungandr_lib::interfaces::Value;
 use snapshot_lib::{
-    registration::{MainnetRewardAddress, RewardAddressTrait, TestnetRewardAddress},
     voting_group::{RepsVotersAssigner, DEFAULT_DIRECT_VOTER_GROUP, DEFAULT_REPRESENTATIVE_GROUP},
-    NetworkType, RawSnapshot, Snapshot,
+    NetworkType, Snapshot,
 };
 use snapshot_lib::{Dreps, Fraction};
 use std::fs::File;
@@ -53,9 +52,8 @@ pub struct SnapshotCmd {
 }
 
 impl SnapshotCmd {
-    pub fn exec_impl<RewardAddressType: RewardAddressTrait>(self) -> Result<(), Report> {
-        let raw_snapshot: RawSnapshot<RewardAddressType> =
-            serde_json::from_reader(File::open(&self.snapshot)?)?;
+    pub fn exec_impl(self) -> Result<(), Report> {
+        let raw_snapshot = serde_json::from_reader(File::open(&self.snapshot)?)?;
         let dreps = if let Some(dreps) = &self.dreps {
             serde_json::from_reader(File::open(dreps)?)?
         } else {
@@ -85,8 +83,8 @@ impl SnapshotCmd {
 
     pub fn exec(self) -> Result<(), Report> {
         match self.net_type {
-            NetworkType::Mainnet => self.exec_impl::<MainnetRewardAddress>(),
-            NetworkType::Testnet => self.exec_impl::<TestnetRewardAddress>(),
+            NetworkType::Mainnet => self.exec_impl(),
+            NetworkType::Testnet => self.exec_impl(),
         }
     }
 }

--- a/src/catalyst-toolbox/catalyst-toolbox/src/rewards/dreps.rs
+++ b/src/catalyst-toolbox/catalyst-toolbox/src/rewards/dreps.rs
@@ -14,12 +14,12 @@ pub enum Error {
     MultipleEntries,
 }
 
-fn filter_requirements<RewardAddressType>(
-    mut dreps: Vec<SnapshotInfo<RewardAddressType>>,
+fn filter_requirements(
+    mut dreps: Vec<SnapshotInfo>,
     votes: VoteCount,
     top_dreps_to_reward: usize,
     votes_threshold: Threshold,
-) -> Vec<SnapshotInfo<RewardAddressType>> {
+) -> Vec<SnapshotInfo> {
     // only the top `top_dreps_to_reward` representatives get rewards
     dreps.sort_by_key(|v| v.hir.voting_power);
     dreps.reverse();
@@ -33,8 +33,8 @@ fn filter_requirements<RewardAddressType>(
         .collect()
 }
 
-pub fn calc_dreps_rewards<RewardAddressType>(
-    snapshot: Vec<SnapshotInfo<RewardAddressType>>,
+pub fn calc_dreps_rewards(
+    snapshot: Vec<SnapshotInfo>,
     votes: VoteCount,
     drep_voting_group: VotingGroup,
     top_dreps_to_reward: usize,
@@ -91,12 +91,12 @@ mod tests {
     use super::*;
     use jormungandr_lib::crypto::hash::Hash;
     use proptest::prop_assert_eq;
-    use snapshot_lib::{registration::TestnetRewardAddress, *};
+    use snapshot_lib::*;
     use std::collections::HashMap;
     use test_strategy::proptest;
 
     #[proptest]
-    fn test_small(snapshot: Snapshot<TestnetRewardAddress>) {
+    fn test_small(snapshot: Snapshot) {
         let voting_keys = snapshot.voting_keys().collect::<Vec<_>>();
 
         let votes_count = voting_keys
@@ -145,7 +145,7 @@ mod tests {
     }
 
     #[proptest]
-    fn test_threshold(snapshot: Snapshot<TestnetRewardAddress>) {
+    fn test_threshold(snapshot: Snapshot) {
         let voters = snapshot.to_full_snapshot_info();
 
         let rewards = calc_dreps_rewards(
@@ -161,7 +161,7 @@ mod tests {
     }
 
     #[proptest]
-    fn test_per_category_threshold(snapshot: Snapshot<TestnetRewardAddress>) {
+    fn test_per_category_threshold(snapshot: Snapshot) {
         use vit_servicing_station_tests::common::data::ArbitrarySnapshotGenerator;
 
         let voters = snapshot.to_full_snapshot_info();

--- a/src/catalyst-toolbox/snapshot-lib/src/influence_cap.rs
+++ b/src/catalyst-toolbox/snapshot-lib/src/influence_cap.rs
@@ -45,10 +45,10 @@ fn calc_vp_to_remove(x: u64, tot: u64, threshold: Fraction) -> u64 {
 ///       It's easy to see we need to repeat step 2.1 at most min(ceil(1/T), N) times.
 ///
 /// Complexity: O(NlogN + min(ceil(1/T), N))
-pub fn cap_voting_influence<RewardAddressType>(
-    mut voters: Vec<SnapshotInfo<RewardAddressType>>,
+pub fn cap_voting_influence(
+    mut voters: Vec<SnapshotInfo>,
     threshold: Fraction,
-) -> Result<Vec<SnapshotInfo<RewardAddressType>>, Error> {
+) -> Result<Vec<SnapshotInfo>, Error> {
     voters.retain(|v| v.hir.voting_power > 0.into());
 
     if voters.is_empty() {
@@ -109,7 +109,7 @@ pub fn cap_voting_influence<RewardAddressType>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{registration::TestnetRewardAddress, voter_hir::tests::VpRange, VoterHIR};
+    use crate::{voter_hir::tests::VpRange, VoterHIR};
     use proptest::{collection::vec, prelude::*};
     use test_strategy::proptest;
 
@@ -117,9 +117,7 @@ mod tests {
 
     #[proptest]
     fn test_insufficient_voters(
-        #[strategy(vec(any::<SnapshotInfo<TestnetRewardAddress>>(), 1..100))] voters: Vec<
-            SnapshotInfo<TestnetRewardAddress>,
-        >,
+        #[strategy(vec(any::<SnapshotInfo>(), 1..100))] voters: Vec<SnapshotInfo>,
     ) {
         let cap = Fraction::new(1u64, voters.len() as u64 + 1);
         assert!(cap_voting_influence(voters, cap).is_err());
@@ -127,8 +125,8 @@ mod tests {
 
     #[proptest]
     fn test_exact_voters(
-        #[strategy(vec(any_with::<SnapshotInfo<TestnetRewardAddress>>((Default::default(), DEFAULT_VP_STRATEGY)), 1..100))]
-        voters: Vec<SnapshotInfo<TestnetRewardAddress>>,
+        #[strategy(vec(any_with::<SnapshotInfo>((Default::default(), DEFAULT_VP_STRATEGY)), 1..100))]
+        voters: Vec<SnapshotInfo>,
     ) {
         let cap = Fraction::new(1u64, voters.len() as u64);
         let min = voters.iter().map(|v| v.hir.voting_power).min().unwrap();
@@ -141,8 +139,8 @@ mod tests {
 
     #[proptest]
     fn test_exact_voters_fixed_at_threshold(
-        #[strategy(vec(any_with::<SnapshotInfo<TestnetRewardAddress>>((Default::default(), DEFAULT_VP_STRATEGY)), 101..=101))]
-        voters: Vec<SnapshotInfo<TestnetRewardAddress>>,
+        #[strategy(vec(any_with::<SnapshotInfo>((Default::default(), DEFAULT_VP_STRATEGY)), 101..=101))]
+        voters: Vec<SnapshotInfo>,
     ) {
         let cap = Fraction::new(999u64, 100000u64);
         let res = cap_voting_influence(voters, cap).unwrap();
@@ -158,8 +156,8 @@ mod tests {
 
     #[proptest]
     fn test_exact_voters_fixed_below_threshold(
-        #[strategy(vec(any_with::<SnapshotInfo<TestnetRewardAddress>>((Default::default(), DEFAULT_VP_STRATEGY)), 100..=100))]
-        voters: Vec<SnapshotInfo<TestnetRewardAddress>>,
+        #[strategy(vec(any_with::<SnapshotInfo>((Default::default(), DEFAULT_VP_STRATEGY)), 100..=100))]
+        voters: Vec<SnapshotInfo>,
     ) {
         let cap = Fraction::new(9u64, 1000u64);
         assert!(cap_voting_influence(voters, cap).is_err());
@@ -167,8 +165,8 @@ mod tests {
 
     #[proptest]
     fn test_below_threshold(
-        #[strategy(vec(any_with::<SnapshotInfo<TestnetRewardAddress>>((Default::default(), DEFAULT_VP_STRATEGY)), 100..300))]
-        voters: Vec<SnapshotInfo<TestnetRewardAddress>>,
+        #[strategy(vec(any_with::<SnapshotInfo>((Default::default(), DEFAULT_VP_STRATEGY)), 100..300))]
+        voters: Vec<SnapshotInfo>,
     ) {
         let cap = Fraction::new(1u64, 100u64);
         let res = cap_voting_influence(voters, cap).unwrap();
@@ -182,7 +180,7 @@ mod tests {
         }
     }
 
-    impl Arbitrary for SnapshotInfo<TestnetRewardAddress> {
+    impl Arbitrary for SnapshotInfo {
         type Parameters = (String, VpRange);
         type Strategy = BoxedStrategy<Self>;
 

--- a/src/catalyst-toolbox/snapshot-lib/src/lib.rs
+++ b/src/catalyst-toolbox/snapshot-lib/src/lib.rs
@@ -9,7 +9,6 @@ use std::{
     collections::{BTreeMap, HashSet},
     iter::Iterator,
     num::NonZeroU64,
-    str::FromStr,
 };
 use thiserror::Error;
 pub use voter_hir::VoterHIR;
@@ -23,23 +22,6 @@ mod voter_hir;
 pub mod voting_group;
 
 pub const CATALYST_VOTING_PURPOSE_TAG: u64 = 0;
-
-#[derive(Clone, Debug)]
-pub enum NetworkType {
-    Mainnet = 0,
-    Testnet = 1,
-}
-
-impl FromStr for NetworkType {
-    type Err = String;
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "mainnet" => Ok(Self::Mainnet),
-            "testnet" => Ok(Self::Testnet),
-            _ => Err("unknown network type".to_string()),
-        }
-    }
-}
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct RawSnapshot(Vec<VotingRegistration>);

--- a/src/catalyst-toolbox/snapshot-lib/src/lib.rs
+++ b/src/catalyst-toolbox/snapshot-lib/src/lib.rs
@@ -1,6 +1,8 @@
 pub use fraction::Fraction;
 use jormungandr_lib::{crypto::account::Identifier, interfaces::Value};
-use registration::{serde_impl::IdentifierDef, Delegations, StakeAddress, VotingRegistration};
+use registration::{
+    serde_impl::IdentifierDef, Delegations, RewardAddress, StakeAddress, VotingRegistration,
+};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::{
     borrow::Borrow,
@@ -24,8 +26,8 @@ pub const CATALYST_VOTING_PURPOSE_TAG: u64 = 0;
 
 #[derive(Clone, Debug)]
 pub enum NetworkType {
-    Mainnet,
-    Testnet,
+    Mainnet = 0,
+    Testnet = 1,
 }
 
 impl FromStr for NetworkType {
@@ -40,12 +42,10 @@ impl FromStr for NetworkType {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct RawSnapshot<RewardAddressType>(Vec<VotingRegistration<RewardAddressType>>);
+pub struct RawSnapshot(Vec<VotingRegistration>);
 
-impl<RewardAddressType> From<Vec<VotingRegistration<RewardAddressType>>>
-    for RawSnapshot<RewardAddressType>
-{
-    fn from(from: Vec<VotingRegistration<RewardAddressType>>) -> Self {
+impl From<Vec<VotingRegistration>> for RawSnapshot {
+    fn from(from: Vec<VotingRegistration>) -> Self {
         Self(from)
     }
 }
@@ -95,33 +95,33 @@ pub enum Error {
 
 /// Contribution to a voting key for some registration
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct KeyContribution<RewardAddressType> {
+pub struct KeyContribution {
     pub stake_public_key: StakeAddress,
-    pub reward_address: RewardAddressType,
+    pub reward_address: RewardAddress,
     pub value: u64,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct SnapshotInfo<RewardAddressType> {
+pub struct SnapshotInfo {
     /// The values in the contributions are the original values in the registration transactions and
     /// thus retain the original proportions.
     /// However, it's possible that the sum of those values is greater than the voting power assigned in the
     /// VoterHIR, due to voting power caps or additional transformations.
-    pub contributions: Vec<KeyContribution<RewardAddressType>>,
+    pub contributions: Vec<KeyContribution>,
     pub hir: VoterHIR,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct Snapshot<RewardAddressType> {
+pub struct Snapshot {
     // a raw public key is preferred so that we don't have to worry about discrimination when deserializing from
     // a CIP-36 compatible encoding
-    inner: BTreeMap<Identifier, SnapshotInfo<RewardAddressType>>,
+    inner: BTreeMap<Identifier, SnapshotInfo>,
     stake_threshold: Value,
 }
 
-impl<RewardAddressType: Clone> Snapshot<RewardAddressType> {
+impl Snapshot {
     pub fn from_raw_snapshot(
-        raw_snapshot: RawSnapshot<RewardAddressType>,
+        raw_snapshot: RawSnapshot,
         stake_threshold: Value,
         cap: Fraction,
         voting_group_assigner: &impl VotingGroupAssigner,
@@ -204,9 +204,9 @@ impl<RewardAddressType: Clone> Snapshot<RewardAddressType> {
     }
 
     fn apply_voting_power_cap(
-        voters: Vec<SnapshotInfo<RewardAddressType>>,
+        voters: Vec<SnapshotInfo>,
         cap: Fraction,
-    ) -> Result<Vec<SnapshotInfo<RewardAddressType>>, Error> {
+    ) -> Result<Vec<SnapshotInfo>, Error> {
         Ok(influence_cap::cap_voting_influence(voters, cap)?
             .into_iter()
             .collect())
@@ -223,7 +223,7 @@ impl<RewardAddressType: Clone> Snapshot<RewardAddressType> {
             .collect::<Vec<_>>()
     }
 
-    pub fn to_full_snapshot_info(&self) -> Vec<SnapshotInfo<RewardAddressType>> {
+    pub fn to_full_snapshot_info(&self) -> Vec<SnapshotInfo> {
         self.inner.values().cloned().collect()
     }
 
@@ -234,7 +234,7 @@ impl<RewardAddressType: Clone> Snapshot<RewardAddressType> {
     pub fn contributions_for_voting_key<I: Borrow<Identifier>>(
         &self,
         voting_public_key: I,
-    ) -> Vec<KeyContribution<RewardAddressType>> {
+    ) -> Vec<KeyContribution> {
         self.inner
             .get(voting_public_key.borrow())
             .cloned()
@@ -245,8 +245,6 @@ impl<RewardAddressType: Clone> Snapshot<RewardAddressType> {
 
 #[cfg(any(test, feature = "proptest"))]
 pub mod tests {
-    use crate::registration::TestnetRewardAddress;
-
     use super::*;
     use chain_addr::{Discrimination, Kind};
     use jormungandr_lib::interfaces::{Address, InitialUTxO};
@@ -261,7 +259,7 @@ pub mod tests {
         }
     }
 
-    impl<RewardAddressType> Snapshot<RewardAddressType> {
+    impl Snapshot {
         pub fn to_block0_initials(&self, discrimination: Discrimination) -> Vec<InitialUTxO> {
             self.inner
                 .iter()
@@ -276,22 +274,20 @@ pub mod tests {
         }
     }
 
-    impl Arbitrary for RawSnapshot<TestnetRewardAddress> {
+    impl Arbitrary for RawSnapshot {
         type Parameters = ();
-        type Strategy = BoxedStrategy<RawSnapshot<TestnetRewardAddress>>;
+        type Strategy = BoxedStrategy<RawSnapshot>;
 
         fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
-            any::<Vec<VotingRegistration<TestnetRewardAddress>>>()
-                .prop_map(Self)
-                .boxed()
+            any::<Vec<VotingRegistration>>().prop_map(Self).boxed()
         }
     }
 
     #[proptest]
     fn test_threshold(
-        _raw: RawSnapshot<TestnetRewardAddress>,
+        _raw: RawSnapshot,
         _stake_threshold: u64,
-        _additional_reg: VotingRegistration<TestnetRewardAddress>,
+        _additional_reg: VotingRegistration,
     ) {
         let mut add = _raw.clone();
         add.0.push(_additional_reg.clone());
@@ -314,12 +310,12 @@ pub mod tests {
         );
     }
 
-    impl Arbitrary for Snapshot<TestnetRewardAddress> {
+    impl Arbitrary for Snapshot {
         type Parameters = ();
-        type Strategy = BoxedStrategy<Snapshot<TestnetRewardAddress>>;
+        type Strategy = BoxedStrategy<Snapshot>;
 
         fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
-            (any::<RawSnapshot<TestnetRewardAddress>>(), 1..u64::MAX)
+            (any::<RawSnapshot>(), 1..u64::MAX)
                 .prop_map(|(raw_snapshot, threshold)| {
                     Self::from_raw_snapshot(
                         raw_snapshot,
@@ -335,7 +331,7 @@ pub mod tests {
 
     // Test all voting power is distributed among delegated keys
     #[proptest]
-    fn test_voting_power_all_distributed(_reg: VotingRegistration<TestnetRewardAddress>) {
+    fn test_voting_power_all_distributed(_reg: VotingRegistration) {
         let snapshot = Snapshot::from_raw_snapshot(
             vec![_reg.clone()].into(),
             0.into(),
@@ -352,7 +348,7 @@ pub mod tests {
     }
 
     #[proptest]
-    fn test_non_catalyst_regs_are_ignored(mut _reg: VotingRegistration<TestnetRewardAddress>) {
+    fn test_non_catalyst_regs_are_ignored(mut _reg: VotingRegistration) {
         _reg.voting_purpose = 1;
         assert_eq!(
             Snapshot::from_raw_snapshot(
@@ -387,7 +383,7 @@ pub mod tests {
             raw_snapshot.push(VotingRegistration {
                 stake_public_key: StakeAddress(String::new()),
                 voting_power: i.into(),
-                reward_address: TestnetRewardAddress(String::new()),
+                reward_address: RewardAddress(String::new()),
                 delegations,
                 voting_purpose: 0,
                 nonce: 0,
@@ -417,7 +413,7 @@ pub mod tests {
 
     #[test]
     fn test_raw_snapshot_parsing() {
-        let raw: RawSnapshot<TestnetRewardAddress> = serde_json::from_str(
+        let raw: RawSnapshot = serde_json::from_str(
             r#"[
             {
                 "rewards_address": "0xe1ffff2912572257b59dca84c965e4638a09f1524af7a15787eb0d8a46",

--- a/src/catalyst-toolbox/snapshot-lib/src/registration.rs
+++ b/src/catalyst-toolbox/snapshot-lib/src/registration.rs
@@ -351,6 +351,40 @@ mod tests {
 
     #[cfg(test)]
     #[test]
+    fn reward_address_serde_test() {
+        assert_eq!(
+            serde_json::to_value(&RewardAddress(
+                "0x01cd3be59b212a45b99f2d26bd179c7119e2851c3b7ada415eff504683c7a5c447ebee137a684b65750e8ab5227ffb3199017bdaf069464c11".to_string()
+            )).unwrap(),
+            serde_json::json!("addr1q8xnhevmyy4ytwvl95nt69uuwyv79pgu8dad5s27lagydq785hzy06lwzdaxsjm9w58g4dfz0lanrxgp00d0q62xfsgsh7dfml")
+        );
+
+        assert_eq!(
+            serde_json::to_value(&RewardAddress(
+                "0xe1b8d7b8e56a3ed89ee21bc062d284d537f843b50b68b905618b130297".to_string()
+            ))
+            .unwrap(),
+            serde_json::json!("stake1uxud0w89dgld38hzr0qx955y65mlssa4pd5tjptp3vfs99cj39wag")
+        );
+
+        assert_eq!(
+            serde_json::to_value(&RewardAddress(
+                "0x00cd3be59b212a45b99f2d26bd179c7119e2851c3b7ada415eff504683c7a5c447ebee137a684b65750e8ab5227ffb3199017bdaf069464c11".to_string()
+            )).unwrap(),
+            serde_json::json!("addr_test1qrxnhevmyy4ytwvl95nt69uuwyv79pgu8dad5s27lagydq785hzy06lwzdaxsjm9w58g4dfz0lanrxgp00d0q62xfsgs5gsfhq")
+        );
+
+        assert_eq!(
+            serde_json::to_value(&RewardAddress(
+                "0xe0b8d7b8e56a3ed89ee21bc062d284d537f843b50b68b905618b130297".to_string()
+            ))
+            .unwrap(),
+            serde_json::json!("stake_test1uzud0w89dgld38hzr0qx955y65mlssa4pd5tjptp3vfs99c4m0ve4")
+        );
+    }
+
+    #[cfg(test)]
+    #[test]
     fn parse_example() {
         assert_de_tokens(
             &Delegations::New(vec![

--- a/src/catalyst-toolbox/snapshot-lib/src/registration.rs
+++ b/src/catalyst-toolbox/snapshot-lib/src/registration.rs
@@ -3,55 +3,22 @@ use jormungandr_lib::interfaces::Value;
 use serde::{de::Error as _, ser::Error as _, Deserialize, Serialize};
 use std::ops::{Deref, DerefMut};
 
-const MAINNET_PREFIX: &str = "addr";
-const TESTNET_PREFIX: &str = "addr_test";
-#[allow(dead_code)]
-const STAKE_PREFIX: &str = "stake";
+const MAINNET_PAYMENT_PREFIX: &str = "addr";
+const TESTNET_PAYMENT_PREFIX: &str = "addr_test";
+const MAINNET_STAKE_PREFIX: &str = "stake";
+const TESTNET_STAKE_PREFIX: &str = "stake_test";
 
-pub trait RewardAddressTrait:
-    for<'a> Deserialize<'a>
-    + Serialize
-    + Clone
-    + Default
-    + PartialEq
-    + Eq
-    + PartialOrd
-    + Ord
-    + std::fmt::Debug
-{
-}
+#[derive(Deserialize, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct RewardAddress(pub String);
 
-#[derive(Deserialize, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct MainnetRewardAddress(pub String);
-
-impl RewardAddressTrait for MainnetRewardAddress {}
-
-impl Deref for MainnetRewardAddress {
+impl Deref for RewardAddress {
     type Target = String;
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl DerefMut for MainnetRewardAddress {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
-#[derive(Deserialize, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct TestnetRewardAddress(pub String);
-
-impl RewardAddressTrait for TestnetRewardAddress {}
-
-impl Deref for TestnetRewardAddress {
-    type Target = String;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl DerefMut for TestnetRewardAddress {
+impl DerefMut for RewardAddress {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }
@@ -79,12 +46,12 @@ impl DerefMut for StakeAddress {
 /// to tag the purpose of the vote.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 #[allow(clippy::module_name_repetitions)]
-pub struct VotingRegistration<RewardAddressType> {
+pub struct VotingRegistration {
     pub stake_public_key: StakeAddress,
     pub voting_power: Value,
     /// Shelley address discriminated for the same network this transaction is submitted to.
     #[serde(rename = "rewards_address")]
-    pub reward_address: RewardAddressType,
+    pub reward_address: RewardAddress,
     pub delegations: Delegations,
     /// 0 = Catalyst, assumed 0 for old legacy registrations
     #[serde(default)]
@@ -94,7 +61,7 @@ pub struct VotingRegistration<RewardAddressType> {
     pub nonce: u64,
 }
 
-impl<RewardAddressType> VotingRegistration<RewardAddressType> {
+impl VotingRegistration {
     #[must_use]
     pub fn is_legacy(&self) -> bool {
         matches!(self.delegations, Delegations::Legacy(_))
@@ -240,31 +207,70 @@ pub mod serde_impl {
         }
     }
 
-    impl Serialize for MainnetRewardAddress {
+    impl Serialize for RewardAddress {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where
             S: Serializer,
         {
+            enum AddrType {
+                Shelley,
+                Stake,
+            }
+            enum NetType {
+                Mainnet,
+                Testnet,
+            }
+            // Following cip-0019 specification https://github.com/cardano-foundation/CIPs/blob/master/CIP-0019/README.md of the addresses formats
             use bech32::ToBase32;
             let bytes = hex::decode(self.trim_start_matches("0x"))
                 .map_err(|e| S::Error::custom(format!("invalid hex string: {}", e)))?;
 
-            bech32::encode(MAINNET_PREFIX, bytes.to_base32(), bech32::Variant::Bech32)
-                .map_err(|e| S::Error::custom(format!("bech32 encoding failed: {}", e)))?
-                .serialize(serializer)
-        }
-    }
+            let addr_prefix = bytes
+                .get(0)
+                .ok_or_else(|| S::Error::custom("invalid address format"))?;
 
-    impl Serialize for TestnetRewardAddress {
-        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where
-            S: Serializer,
-        {
-            use bech32::ToBase32;
-            let bytes = hex::decode(self.trim_start_matches("0x"))
-                .map_err(|e| S::Error::custom(format!("invalid hex string: {}", e)))?;
+            // Shelley addrs: 0x0?, 0x1?, 0x2?, 0x3?, 0x4?, 0x5?, 0x6?, 0x7?
+            // Stake addrs: 0xE?, 0xF?
+            let addr_type = addr_prefix >> 4 & 0xf;
+            // 0 or 1 are valid addrs in the following cases:
+            // type = 0x0 -  Testnet network
+            // type = 0x1 -  Mainnet network
+            let addr_net = addr_prefix & 0xf;
 
-            bech32::encode(TESTNET_PREFIX, bytes.to_base32(), bech32::Variant::Bech32)
+            let addr_type = match addr_type {
+                // Shelley
+                0x0 | 0x1 | 0x2 | 0x3 | 0x4 | 0x5 | 0x6 | 0x7 => AddrType::Shelley,
+                // Stake
+                0xf | 0xe => AddrType::Stake,
+                _ => {
+                    return Err(S::Error::custom(format!(
+                        "invalid address format, incorrect addr type: {}",
+                        addr_type
+                    )))
+                }
+            };
+
+            let addr_net = match addr_net {
+                // Mainnet
+                0x1 => NetType::Mainnet,
+                // Testnet
+                0x0 => NetType::Testnet,
+                _ => {
+                    return Err(S::Error::custom(format!(
+                        "invalid address format, incorrect network tag: {}",
+                        addr_net
+                    )))
+                }
+            };
+
+            let prefix = match (addr_type, addr_net) {
+                (AddrType::Shelley, NetType::Mainnet) => MAINNET_PAYMENT_PREFIX,
+                (AddrType::Stake, NetType::Mainnet) => MAINNET_STAKE_PREFIX,
+                (AddrType::Shelley, NetType::Testnet) => TESTNET_PAYMENT_PREFIX,
+                (AddrType::Stake, NetType::Testnet) => TESTNET_STAKE_PREFIX,
+            };
+
+            bech32::encode(prefix, bytes.to_base32(), bech32::Variant::Bech32)
                 .map_err(|e| S::Error::custom(format!("bech32 encoding failed: {}", e)))?
                 .serialize(serializer)
         }
@@ -274,7 +280,6 @@ pub mod serde_impl {
 #[cfg(any(test, feature = "proptest"))]
 mod tests {
     use super::*;
-    use bech32::ToBase32;
     use chain_crypto::{Ed25519, SecretKey};
     use proptest::collection::vec;
     use proptest::prelude::*;
@@ -321,29 +326,15 @@ mod tests {
         }
     }
 
-    impl Arbitrary for VotingRegistration<TestnetRewardAddress> {
+    impl Arbitrary for VotingRegistration {
         type Parameters = ();
-        type Strategy = BoxedStrategy<VotingRegistration<TestnetRewardAddress>>;
+        type Strategy = BoxedStrategy<VotingRegistration>;
 
         fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
             (any::<([u8; 32], [u8; 32], Delegations)>(), 0..45_000_000u64)
                 .prop_map(|((stake_key, rewards_addr, delegations), vp)| {
-                    let stake_public_key = StakeAddress(
-                        bech32::encode(
-                            STAKE_PREFIX,
-                            stake_key.to_base32(),
-                            bech32::Variant::Bech32,
-                        )
-                        .unwrap(),
-                    );
-                    let reward_address = TestnetRewardAddress(
-                        bech32::encode(
-                            TESTNET_PREFIX,
-                            rewards_addr.to_base32(),
-                            bech32::Variant::Bech32,
-                        )
-                        .unwrap(),
-                    );
+                    let stake_public_key = StakeAddress(hex::encode(stake_key));
+                    let reward_address = RewardAddress(hex::encode(rewards_addr));
                     let voting_power: Value = vp.into();
                     VotingRegistration {
                         stake_public_key,

--- a/src/catalyst-toolbox/snapshot-lib/src/sve.rs
+++ b/src/catalyst-toolbox/snapshot-lib/src/sve.rs
@@ -11,15 +11,12 @@ use crate::{
     RawSnapshot,
 };
 
-pub struct Snapshot<RewardAddressType> {
-    inner: HashMap<Identifier, Vec<VotingRegistration<RewardAddressType>>>,
+pub struct Snapshot {
+    inner: HashMap<Identifier, Vec<VotingRegistration>>,
 }
 
-impl<RewardAddressType> Snapshot<RewardAddressType> {
-    pub fn new(
-        raw_snapshot: RawSnapshot<RewardAddressType>,
-        min_stake_threshold: Value,
-    ) -> (Self, usize) {
+impl Snapshot {
+    pub fn new(raw_snapshot: RawSnapshot, min_stake_threshold: Value) -> (Self, usize) {
         let mut total_rejected_registrations: usize = 0;
 
         let inner = raw_snapshot

--- a/src/event-db/docker-compose.yml
+++ b/src/event-db/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       - ADMIN_ROLE_PASSWORD=CHANGE_ME
       - ADMIN_USER_PASSWORD=CHANGE_ME
       - ANON_ROLE_PASSWORD=CHANGE_ME
+      - STAGE=dev
     depends_on:
       postgres:
         condition: service_healthy

--- a/src/vit-servicing-station/vit-servicing-station-lib/src/v0/endpoints/snapshot/handlers.rs
+++ b/src/vit-servicing-station/vit-servicing-station-lib/src/v0/endpoints/snapshot/handlers.rs
@@ -29,8 +29,8 @@ pub async fn get_delegator_info(
 
 /// Snapshot information update with timestamp.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-pub struct SnapshotInfoInput<RewardAddressType> {
-    pub snapshot: Vec<SnapshotInfo<RewardAddressType>>,
+pub struct SnapshotInfoInput {
+    pub snapshot: Vec<SnapshotInfo>,
     #[serde(deserialize_with = "crate::utils::serde::deserialize_unix_timestamp_from_rfc3339")]
     #[serde(serialize_with = "crate::utils::serde::serialize_unix_timestamp_as_rfc3339")]
     pub update_timestamp: i64,
@@ -38,8 +38,8 @@ pub struct SnapshotInfoInput<RewardAddressType> {
 
 /// Raw Snapshot information update with timestamp.
 #[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct RawSnapshotInput<RewardAddressType> {
-    pub snapshot: RawSnapshot<RewardAddressType>,
+pub struct RawSnapshotInput {
+    pub snapshot: RawSnapshot,
     #[serde(deserialize_with = "crate::utils::serde::deserialize_unix_timestamp_from_rfc3339")]
     #[serde(serialize_with = "crate::utils::serde::serialize_unix_timestamp_as_rfc3339")]
     pub update_timestamp: i64,

--- a/src/vit-servicing-station/vit-servicing-station-tests/src/common/snapshot.rs
+++ b/src/vit-servicing-station/vit-servicing-station-tests/src/common/snapshot.rs
@@ -4,7 +4,7 @@ use jormungandr_lib::crypto::account::Identifier;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 use snapshot_lib::{
-    registration::{StakeAddress, TestnetRewardAddress},
+    registration::{RewardAddress, StakeAddress},
     KeyContribution, SnapshotInfo, VoterHIR,
 };
 use time::OffsetDateTime;
@@ -13,7 +13,7 @@ use vit_servicing_station_lib::v0::endpoints::snapshot::SnapshotInfoInput;
 #[derive(Debug, Clone)]
 pub struct Snapshot {
     pub tag: String,
-    pub content: SnapshotInfoInput<TestnetRewardAddress>,
+    pub content: SnapshotInfoInput,
 }
 
 impl Default for Snapshot {
@@ -87,7 +87,7 @@ impl SnapshotBuilder {
                     Some(SnapshotInfo {
                         contributions: std::iter::from_fn(|| {
                             Some(KeyContribution {
-                                reward_address: TestnetRewardAddress(format!(
+                                reward_address: RewardAddress(format!(
                                     "address_{:?}",
                                     rng.gen_range(1u64, 1_000u64)
                                 )),
@@ -149,8 +149,8 @@ impl PartialEq for VotingPower {
 
 impl Eq for VotingPower {}
 
-impl<RewardAddressType> From<SnapshotInfo<RewardAddressType>> for VotingPower {
-    fn from(snapshot_info: SnapshotInfo<RewardAddressType>) -> Self {
+impl From<SnapshotInfo> for VotingPower {
+    fn from(snapshot_info: SnapshotInfo) -> Self {
         let delegations_power: u64 = snapshot_info
             .contributions
             .iter()
@@ -205,7 +205,7 @@ impl SnapshotUpdater {
 
     pub fn add_contributions_to_voter(
         mut self,
-        contributions: Vec<KeyContribution<TestnetRewardAddress>>,
+        contributions: Vec<KeyContribution>,
         voting_key: &Identifier,
     ) -> Self {
         let voter = self

--- a/src/vit-servicing-station/vit-servicing-station-tests/src/tests/snapshots/verifier.rs
+++ b/src/vit-servicing-station/vit-servicing-station-tests/src/tests/snapshots/verifier.rs
@@ -1,8 +1,8 @@
 use crate::common::{clients::RestClient, raw_snapshot::RawSnapshot, snapshot::VotingPower};
-use snapshot_lib::{registration::MainnetRewardAddress, SnapshotInfo};
+use snapshot_lib::SnapshotInfo;
 
 pub fn assert_raw_against_full_snapshot(
-    snapshot_entry: &SnapshotInfo<MainnetRewardAddress>,
+    snapshot_entry: &SnapshotInfo,
     raw_snapshot: &RawSnapshot,
     rest_client: &RestClient,
 ) {
@@ -24,7 +24,7 @@ pub fn assert_raw_against_full_snapshot(
 }
 
 pub fn assert_is_empty_raw_against_full_snapshot(
-    snapshot_entry: &SnapshotInfo<MainnetRewardAddress>,
+    snapshot_entry: &SnapshotInfo,
     raw_snapshot: &RawSnapshot,
     timestamp: i64,
     rest_client: &RestClient,

--- a/src/vit-testing/integration-tests/src/common/snapshot/result.rs
+++ b/src/vit-testing/integration-tests/src/common/snapshot/result.rs
@@ -3,9 +3,7 @@
 use jormungandr_lib::crypto::account::Identifier;
 use jortestkit::prelude::WaitBuilder;
 use mainnet_tools::snapshot::OutputExtension;
-use snapshot_lib::registration::{
-    Delegations as VotingDelegations, MainnetRewardAddress, VotingRegistration,
-};
+use snapshot_lib::registration::{Delegations as VotingDelegations, VotingRegistration};
 use snapshot_trigger_service::client::rest::SnapshotRestClient;
 use snapshot_trigger_service::config::JobParameters;
 use snapshot_trigger_service::ContextState;
@@ -73,9 +71,7 @@ pub fn get_snapshot_from_history_by_id<Q: Into<String>, S: Into<String>, P: Into
     })
 }
 
-pub fn read_initials<S: Into<String>>(
-    snapshot: S,
-) -> Result<Vec<VotingRegistration<MainnetRewardAddress>>, Error> {
+pub fn read_initials<S: Into<String>>(snapshot: S) -> Result<Vec<VotingRegistration>, Error> {
     let snapshot = snapshot.into();
     serde_json::from_str(&snapshot).map_err(Into::into)
 }
@@ -83,7 +79,7 @@ pub fn read_initials<S: Into<String>>(
 #[derive(Debug)]
 pub struct SnapshotResult {
     status: ContextState,
-    snapshot: Vec<VotingRegistration<MainnetRewardAddress>>,
+    snapshot: Vec<VotingRegistration>,
 }
 
 impl SnapshotResult {
@@ -95,10 +91,7 @@ impl SnapshotResult {
         Ok(Self::new(status, voting_registrations))
     }
 
-    pub fn new(
-        status: ContextState,
-        snapshot: Vec<VotingRegistration<MainnetRewardAddress>>,
-    ) -> Self {
+    pub fn new(status: ContextState, snapshot: Vec<VotingRegistration>) -> Self {
         Self { status, snapshot }
     }
 
@@ -110,14 +103,11 @@ impl SnapshotResult {
         self.status.clone()
     }
 
-    pub fn registrations(&self) -> &Vec<VotingRegistration<MainnetRewardAddress>> {
+    pub fn registrations(&self) -> &Vec<VotingRegistration> {
         &self.snapshot
     }
 
-    pub fn by_identifier(
-        &self,
-        identifier: &Identifier,
-    ) -> Option<VotingRegistration<MainnetRewardAddress>> {
+    pub fn by_identifier(&self, identifier: &Identifier) -> Option<VotingRegistration> {
         self.registrations()
             .iter()
             .cloned()
@@ -127,10 +117,7 @@ impl SnapshotResult {
             })
     }
 
-    pub fn by_delegation(
-        &self,
-        id: &Identifier,
-    ) -> Result<Option<VotingRegistration<MainnetRewardAddress>>, Error> {
+    pub fn by_delegation(&self, id: &Identifier) -> Result<Option<VotingRegistration>, Error> {
         Ok(self
             .registrations()
             .iter()

--- a/src/vit-testing/integration-tests/src/common/snapshot/voter_hirs_asserts.rs
+++ b/src/vit-testing/integration-tests/src/common/snapshot/voter_hirs_asserts.rs
@@ -1,6 +1,6 @@
 use jormungandr_lib::crypto::account::Identifier;
 use jormungandr_lib::interfaces::Value;
-use snapshot_lib::registration::{Delegations, MainnetRewardAddress, VotingRegistration};
+use snapshot_lib::registration::{Delegations, VotingRegistration};
 use snapshot_lib::VoterHIR;
 
 pub trait RegistrationAsserts {
@@ -8,7 +8,7 @@ pub trait RegistrationAsserts {
     fn assert_not_contain_voting_key(&self, identifier: &Identifier);
 }
 
-impl RegistrationAsserts for Vec<VotingRegistration<MainnetRewardAddress>> {
+impl RegistrationAsserts for Vec<VotingRegistration> {
     fn assert_contains_voting_key_and_value(&self, identifier: &Identifier, value: Value) {
         assert!(self.iter().any(|x| {
             value == x.voting_power

--- a/src/vit-testing/integration-tests/src/common/snapshot_filter.rs
+++ b/src/vit-testing/integration-tests/src/common/snapshot_filter.rs
@@ -5,7 +5,6 @@ use fraction::Fraction;
 use jormungandr_lib::crypto::account::Identifier;
 use jormungandr_lib::interfaces::InitialUTxO;
 use jormungandr_lib::interfaces::Value;
-use snapshot_lib::registration::MainnetRewardAddress;
 use snapshot_lib::registration::VotingRegistration;
 use snapshot_lib::voting_group::VotingGroupAssigner;
 use snapshot_lib::{RawSnapshot, Snapshot, VoterHIR};
@@ -37,7 +36,7 @@ impl SnapshotFilterSource for SnapshotResult {
 }
 
 pub struct SnapshotFilter {
-    snapshot: Snapshot<MainnetRewardAddress>,
+    snapshot: Snapshot,
 }
 
 impl SnapshotFilter {
@@ -70,7 +69,7 @@ impl SnapshotFilter {
     }
 
     pub fn from_voting_registrations(
-        voting_registrations: Vec<VotingRegistration<MainnetRewardAddress>>,
+        voting_registrations: Vec<VotingRegistration>,
         voting_threshold: Value,
         cap: Fraction,
         voting_group_assigner: &impl VotingGroupAssigner,
@@ -99,7 +98,7 @@ impl SnapshotFilter {
         self.snapshot.to_block0_initials(Discrimination::Production)
     }
 
-    pub fn snapshot(&self) -> Snapshot<MainnetRewardAddress> {
+    pub fn snapshot(&self) -> Snapshot {
         self.snapshot.clone()
     }
 }

--- a/src/vit-testing/integration-tests/src/e2e/local/active_voters_rewards.rs
+++ b/src/vit-testing/integration-tests/src/e2e/local/active_voters_rewards.rs
@@ -158,8 +158,9 @@ pub fn voters_with_at_least_one_vote() {
     assert_eq!(
         records
             .iter()
-            .find(|(x, _y)| **x
-                == RewardAddress(alice_wallet.reward_address().to_address().to_hex()))
+            .find(
+                |(x, _y)| **x == RewardAddress(alice_wallet.reward_address().to_address().to_hex())
+            )
             .unwrap()
             .1,
         &50u32.into()
@@ -168,8 +169,7 @@ pub fn voters_with_at_least_one_vote() {
     assert_eq!(
         records
             .iter()
-            .find(|(x, _y)| **x
-                == RewardAddress(bob_wallet.reward_address().to_address().to_hex()))
+            .find(|(x, _y)| **x == RewardAddress(bob_wallet.reward_address().to_address().to_hex()))
             .unwrap()
             .1,
         &50u32.into()

--- a/src/vit-testing/integration-tests/src/e2e/local/active_voters_rewards.rs
+++ b/src/vit-testing/integration-tests/src/e2e/local/active_voters_rewards.rs
@@ -13,7 +13,7 @@ use chain_impl_mockchain::block::BlockDate;
 use jormungandr_automation::testing::time;
 use jormungandr_lib::crypto::account::Identifier;
 use mainnet_lib::{wallet_state::MainnetWalletStateBuilder, MainnetNetworkBuilder};
-use snapshot_lib::registration::MainnetRewardAddress;
+use snapshot_lib::registration::RewardAddress;
 use snapshot_trigger_service::config::JobParameters;
 use vit_servicing_station_tests::common::data::ArbitraryValidVotingTemplateGenerator;
 use vitup::config::VoteBlockchainTime;
@@ -159,7 +159,7 @@ pub fn voters_with_at_least_one_vote() {
         records
             .iter()
             .find(|(x, _y)| **x
-                == MainnetRewardAddress(alice_wallet.reward_address().to_address().to_hex()))
+                == RewardAddress(alice_wallet.reward_address().to_address().to_hex()))
             .unwrap()
             .1,
         &50u32.into()
@@ -169,7 +169,7 @@ pub fn voters_with_at_least_one_vote() {
         records
             .iter()
             .find(|(x, _y)| **x
-                == MainnetRewardAddress(bob_wallet.reward_address().to_address().to_hex()))
+                == RewardAddress(bob_wallet.reward_address().to_address().to_hex()))
             .unwrap()
             .1,
         &50u32.into()

--- a/src/vit-testing/integration-tests/src/e2e/rewards/rewards_scenarios.rs
+++ b/src/vit-testing/integration-tests/src/e2e/rewards/rewards_scenarios.rs
@@ -14,7 +14,7 @@ use chain_impl_mockchain::block::BlockDate;
 use jormungandr_automation::testing::time;
 use jormungandr_lib::crypto::account::Identifier;
 use mainnet_lib::{wallet_state::MainnetWalletStateBuilder, MainnetNetworkBuilder};
-use snapshot_lib::registration::MainnetRewardAddress;
+use snapshot_lib::registration::RewardAddress;
 use snapshot_lib::VotingGroup;
 use snapshot_trigger_service::config::JobParameters;
 use vit_servicing_station_tests::common::data::ArbitraryValidVotingTemplateGenerator;
@@ -254,7 +254,7 @@ pub fn mixed_rewards_happy_path() {
         direct_records
             .iter()
             .find(|(x, _y)| **x
-                == MainnetRewardAddress(emma_wallet.reward_address().to_address().to_hex()))
+                == RewardAddress(emma_wallet.reward_address().to_address().to_hex()))
             .unwrap()
             .1,
         &EXPECTED_REWARD.into()
@@ -265,8 +265,7 @@ pub fn mixed_rewards_happy_path() {
     assert_eq!(
         direct_records
             .iter()
-            .find(|(x, _y)| **x
-                == MainnetRewardAddress(jim_wallet.reward_address().to_address().to_hex()))
+            .find(|(x, _y)| **x == RewardAddress(jim_wallet.reward_address().to_address().to_hex()))
             .unwrap()
             .1,
         &EXPECTED_REWARD.into()

--- a/src/vit-testing/integration-tests/src/e2e/rewards/voter_rewards.rs
+++ b/src/vit-testing/integration-tests/src/e2e/rewards/voter_rewards.rs
@@ -13,7 +13,7 @@ use chain_impl_mockchain::block::BlockDate;
 use jormungandr_automation::testing::time;
 use jormungandr_lib::crypto::account::Identifier;
 use mainnet_lib::{wallet_state::MainnetWalletStateBuilder, MainnetNetworkBuilder};
-use snapshot_lib::registration::MainnetRewardAddress;
+use snapshot_lib::registration::RewardAddress;
 use snapshot_trigger_service::config::JobParameters;
 use vit_servicing_station_tests::common::data::ArbitraryValidVotingTemplateGenerator;
 use vitup::config::VoteBlockchainTime;
@@ -170,8 +170,9 @@ pub fn voter_rewards_happy_path() {
     assert_eq!(
         records
             .iter()
-            .find(|(x, _y)| **x
-                == MainnetRewardAddress(alice_wallet.reward_address().to_address().to_hex()))
+            .find(
+                |(x, _y)| **x == RewardAddress(alice_wallet.reward_address().to_address().to_hex())
+            )
             .unwrap()
             .1,
         &EXPECTED_REWARD.into()
@@ -180,8 +181,7 @@ pub fn voter_rewards_happy_path() {
     assert_eq!(
         records
             .iter()
-            .find(|(x, _y)| **x
-                == MainnetRewardAddress(bob_wallet.reward_address().to_address().to_hex()))
+            .find(|(x, _y)| **x == RewardAddress(bob_wallet.reward_address().to_address().to_hex()))
             .unwrap()
             .1,
         &EXPECTED_REWARD.into()
@@ -189,6 +189,5 @@ pub fn voter_rewards_happy_path() {
 
     assert!(!records
         .iter()
-        .any(|(x, _y)| *x
-            == MainnetRewardAddress(clarice_wallet.reward_address().to_address().to_hex())));
+        .any(|(x, _y)| *x == RewardAddress(clarice_wallet.reward_address().to_address().to_hex())));
 }

--- a/src/vit-testing/integration-tests/src/integration/from_snapshot_to_vit_servicing_station.rs
+++ b/src/vit-testing/integration-tests/src/integration/from_snapshot_to_vit_servicing_station.rs
@@ -3,7 +3,6 @@ use crate::common::snapshot::mock;
 use crate::common::CardanoWallet;
 use assert_fs::TempDir;
 use mainnet_lib::{wallet_state::MainnetWalletStateBuilder, MainnetNetworkBuilder};
-use snapshot_lib::registration::MainnetRewardAddress;
 use snapshot_lib::SnapshotInfo;
 use snapshot_trigger_service::config::JobParameters;
 use vit_servicing_station_tests::common::data::ArbitraryValidVotingTemplateGenerator;
@@ -81,8 +80,7 @@ pub fn put_raw_snapshot() {
         "expected tags vs tags taken from REST API"
     );
 
-    let snapshot_infos: Vec<SnapshotInfo<MainnetRewardAddress>> =
-        raw_snapshot.clone().try_into().unwrap();
+    let snapshot_infos: Vec<SnapshotInfo> = raw_snapshot.clone().try_into().unwrap();
 
     for snapshot_info in snapshot_infos.iter() {
         let voting_power = VotingPower::from(snapshot_info.clone());

--- a/src/vit-testing/mainnet-tools/src/snapshot/convert.rs
+++ b/src/vit-testing/mainnet-tools/src/snapshot/convert.rs
@@ -82,7 +82,7 @@ use mainnet_lib::wallet_state::{MainnetWalletState, TemplateError};
 use mainnet_lib::{MainnetNetworkBuilder, SnapshotParameters};
 use num_traits::ToPrimitive;
 use snapshot_lib::registration::{
-    Delegations as VotingDelegations, MainnetRewardAddress, StakeAddress, VotingRegistration,
+    Delegations as VotingDelegations, RewardAddress, StakeAddress, VotingRegistration,
 };
 use vit_servicing_station_lib::v0::endpoints::snapshot::RawSnapshotInput;
 use voting_tools_rs::test_api::MockDbProvider;
@@ -95,15 +95,11 @@ pub trait OutputExtension {
     /// # Errors
     ///
     /// At any internal error while creating a voting registration from output
-    fn try_into_voting_registration(
-        self,
-    ) -> Result<VotingRegistration<MainnetRewardAddress>, Error>;
+    fn try_into_voting_registration(self) -> Result<VotingRegistration, Error>;
 }
 
 impl OutputExtension for SnapshotEntry {
-    fn try_into_voting_registration(
-        self,
-    ) -> Result<VotingRegistration<MainnetRewardAddress>, Error> {
+    fn try_into_voting_registration(self) -> Result<VotingRegistration, Error> {
         Ok(VotingRegistration {
             stake_public_key: StakeAddress(self.stake_key.to_string()),
             voting_power: self
@@ -113,7 +109,7 @@ impl OutputExtension for SnapshotEntry {
                     Error::CannotConvertFromOutput("cannot extract voting power".to_string())
                 })?
                 .into(),
-            reward_address: MainnetRewardAddress(hex::encode(&self.rewards_address.0)),
+            reward_address: RewardAddress(hex::encode(&self.rewards_address.0)),
             delegations: match self.voting_key {
                 VotingKey::Direct(legacy) => VotingDelegations::Legacy(
                     Identifier::from_hex(&legacy.to_hex())

--- a/src/voting-tools-rs/src/verification/verify.rs
+++ b/src/voting-tools-rs/src/verification/verify.rs
@@ -205,8 +205,8 @@ pub fn is_valid_rewards_address(rewards_address_prefix: &u8, network: NetworkId)
     let addr_net = rewards_address_prefix & 0xf;
 
     // 0 or 1 are valid addrs in the following cases:
-    // type = 0x0 -  network = 0
-    // type = 0x0 -  network = 1
+    // type = 0x0 -  Testnet network
+    // type = 0x1 -  Mainnet network
     match network {
         NetworkId::Mainnet => {
             if addr_net != 1 {

--- a/utilities/ideascale-importer/ideascale_importer/snapshot_importer.py
+++ b/utilities/ideascale-importer/ideascale_importer/snapshot_importer.py
@@ -465,7 +465,7 @@ class Importer:
                 "min_stake_threshold and voting_power_cap must be set either as CLI arguments or in the database"
             )
 
-        for network_id, params in self.network_params.items():
+        for params in self.network_params.values():
             catalyst_toolbox_cmd = (
                 f"{self.catalyst_toolbox_path} snapshot"
                 f" -s {params.snapshot_tool_out_file}"
@@ -473,7 +473,6 @@ class Importer:
                 f" -v {self.voting_power_cap}"
                 f" --dreps {self.dreps_out_file}"
                 f" --output-format json {params.catalyst_toolbox_out_file}"
-                f" --net-type {network_id}"
             )
 
             await run_cmd("catalyst-toolbox", catalyst_toolbox_cmd)


### PR DESCRIPTION
# Description

Fixed RewardAddress formating which was incorrect in this PR https://github.com/input-output-hk/catalyst-core/pull/497.
So now address type and network type defines from the bytes itself accoring to the https://github.com/cardano-foundation/CIPs/blob/master/CIP-0019/README.md. 