### PR TITLE
feat: Added different logs formatting for cat-data-service | NPG-5779

### DIFF
--- a/src/cat-data-service/Cargo.toml
+++ b/src/cat-data-service/Cargo.toml
@@ -10,7 +10,7 @@ event-db = { path = "../event-db" }
 
 clap = { workspace = true }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true, features = ["fmt"]}
+tracing-subscriber = { workspace = true, features = ["fmt", "json"]}
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }

--- a/src/cat-data-service/README.md
+++ b/src/cat-data-service/README.md
@@ -18,6 +18,6 @@ To run with the specific jorm mock state cleanup timeout you can specify `JORM_C
 
 Run
 ```
-cat-data-service run --address "127.0.0.1:3030" --database-url=postgres://catalyst-event-dev:CHANGE_ME@localhost/CatalystEventDev --log-level=debug --metrics-address "127.0.0.1:3031"
+cat-data-service run --address "127.0.0.1:3030" --database-url=postgres://catalyst-event-dev:CHANGE_ME@localhost/CatalystEventDev --log-level=debug --log-format=compact --metrics-address "127.0.0.1:3031"
 ```
 

--- a/src/cat-data-service/src/cli.rs
+++ b/src/cat-data-service/src/cli.rs
@@ -20,7 +20,7 @@ impl Cli {
     pub async fn exec(self) -> Result<(), Error> {
         match self {
             Self::Run(settings) => {
-                logger::init(settings.log_level).unwrap();
+                logger::init(settings.log_format, settings.log_level).unwrap();
 
                 let state = Arc::new(State::new(Some(settings.database_url)).await?);
                 service::run(&settings.address, &settings.metrics_address, state).await?;

--- a/src/cat-data-service/src/logger.rs
+++ b/src/cat-data-service/src/logger.rs
@@ -1,9 +1,22 @@
 use clap::ValueEnum;
-use tracing::level_filters::LevelFilter;
-use tracing::subscriber::SetGlobalDefaultError;
-use tracing_subscriber::FmtSubscriber;
+use tracing::{level_filters::LevelFilter, subscriber::SetGlobalDefaultError};
+use tracing_subscriber::{
+    fmt::{
+        format::{DefaultFields, Format},
+        FormatEvent,
+    },
+    FmtSubscriber, Registry,
+};
 
+pub const LOG_FORMAT_DEFAULT: &str = "full";
 pub const LOG_LEVEL_DEFAULT: &str = "info";
+
+#[derive(ValueEnum, Clone)]
+pub enum LogFormat {
+    Full,
+    Compact,
+    Json,
+}
 
 #[derive(ValueEnum, Clone)]
 pub enum LogLevel {
@@ -24,9 +37,22 @@ impl From<LogLevel> for tracing::Level {
     }
 }
 
-pub fn init(log_level: LogLevel) -> Result<(), SetGlobalDefaultError> {
+fn init_impl<T>(format: T, log_level: LogLevel) -> Result<(), SetGlobalDefaultError>
+where
+    T: FormatEvent<Registry, DefaultFields> + Send + Sync + 'static,
+{
     let subscriber = FmtSubscriber::builder()
+        .event_format(format)
         .with_max_level(LevelFilter::from_level(log_level.into()))
         .finish();
+
     tracing::subscriber::set_global_default(subscriber)
+}
+
+pub fn init(log_format: LogFormat, log_level: LogLevel) -> Result<(), SetGlobalDefaultError> {
+    match log_format {
+        LogFormat::Full => init_impl(Format::default(), log_level),
+        LogFormat::Compact => init_impl(Format::default().compact(), log_level),
+        LogFormat::Json => init_impl(Format::default().json(), log_level),
+    }
 }

--- a/src/cat-data-service/src/settings.rs
+++ b/src/cat-data-service/src/settings.rs
@@ -1,4 +1,4 @@
-use crate::logger::{LogLevel, LOG_LEVEL_DEFAULT};
+use crate::logger::{LogFormat, LogLevel, LOG_FORMAT_DEFAULT, LOG_LEVEL_DEFAULT};
 use clap::Args;
 use std::net::SocketAddr;
 
@@ -17,6 +17,10 @@ pub struct Settings {
     /// Url to the postgres event db
     #[clap(long, env)]
     pub database_url: String,
+
+    /// Logging format
+    #[clap(long, default_value = LOG_FORMAT_DEFAULT)]
+    pub log_format: LogFormat,
 
     /// Logging level
     #[clap(long, default_value = LOG_LEVEL_DEFAULT)]


### PR DESCRIPTION
# Description

Added different logs formatting as:
- `full`, default human readable format
- `json`,  full JSON format
- `compact`, human readable less verbose output format