### PR TITLE
fix: Use zlib1g-dev instead of lib32z-dev | NPG-0000

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -3,7 +3,7 @@ VERSION 0.7
 FROM debian:stable-slim
 
 rust-toolchain:
-    FROM rust:1.71.0-slim-bullseye
+    FROM rust:1.71.0-slim-bookworm
 
 # Installs Cargo chef
 install-chef:

--- a/Earthfile
+++ b/Earthfile
@@ -3,7 +3,7 @@ VERSION 0.7
 FROM debian:stable-slim
 
 rust-toolchain:
-    FROM rust:1.71.0-slim-bookworm
+    FROM rust:1.71.0-slim-bullseye
 
 # Installs Cargo chef
 install-chef:

--- a/services/voting-node/Earthfile
+++ b/services/voting-node/Earthfile
@@ -46,7 +46,7 @@ docker:
 
     # Install voting-node system dependencies
     RUN apt-get update && \
-        apt-get install -y --no-install-recommends libpq5 openssh-client
+        apt-get install -y --no-install-recommends libpq5 openssh-client build-essential libxml2-dev libxslt-dev zlib1g-dev python3-lxml
 
     ## apt cleanup
     RUN apt-get clean && \

--- a/utilities/ideascale-importer/Earthfile
+++ b/utilities/ideascale-importer/Earthfile
@@ -44,7 +44,7 @@ docker:
 
     # Install system dependencies
     RUN apt-get update && \
-        apt-get install -y --no-install-recommends libpq5
+        apt-get install -y --no-install-recommends libpq5 build-essential libxml2-dev libxslt-dev zlib1g-dev python3-lxml
 
     ## apt cleanup
     RUN apt-get clean && \

--- a/utilities/ideascale-importer/Earthfile
+++ b/utilities/ideascale-importer/Earthfile
@@ -12,7 +12,7 @@ build:
 
     # Install system dependencies
     RUN apt-get update && \
-        apt-get install -y --no-install-recommends curl build-essential libxml2-dev libxslt-dev lib32z1-dev python3-lxml
+        apt-get install -y --no-install-recommends curl build-essential libxml2-dev libxslt-dev zlib1g-dev python3-lxml
 
     # Install Poetry
     RUN curl -sSL https://install.python-poetry.org | python3 -


### PR DESCRIPTION

# Description

fix: use debian stable (currently bookworm) slim image for rust toolchain

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)