### PR TITLE
fix(earthly): `mv` is buggy in debian | NPG-0000

### DIFF
--- a/services/voting-node/Earthfile
+++ b/services/voting-node/Earthfile
@@ -42,7 +42,7 @@ build:
     # Build the distribution wheels and save them as artifacts
     RUN poetry export --without-hashes -f requirements.txt --output requirements.txt
     RUN poetry build --no-cache -f wheel
-    RUN mkdir -p /wheels && mv dist/*.whl /wheels && rm -rf dist
+    RUN mkdir -p /wheels && cp dist/*.whl /wheels && rm -rf dist
     SAVE ARTIFACT /src/services/voting-node src
     SAVE ARTIFACT /wheels wheels
     SAVE ARTIFACT requirements.txt

--- a/utilities/ideascale-importer/Earthfile
+++ b/utilities/ideascale-importer/Earthfile
@@ -33,7 +33,7 @@ build:
     # Build the distribution wheels and save them as artifacts
     RUN poetry export --without-hashes -f requirements.txt --output requirements.txt
     RUN poetry build --no-cache -f wheel
-    RUN mkdir -p /wheels && mv dist/*.whl /wheels && rm -rf dist
+    RUN mkdir -p /wheels && cp dist/*.whl /wheels && rm -rf dist
     SAVE ARTIFACT /src/utilities/ideascale-importer src
     SAVE ARTIFACT /wheels wheels
     SAVE ARTIFACT requirements.txt


### PR DESCRIPTION
`mv` will fail depending on the underlying filesystem of the volume used by docker for its volumes.

See: https://superuser.com/questions/1409618/renaming-a-file-with-mv-cannot-move-to-a-subdirectory-of-itself

This was failing for me,  took forever to work it out what was actually happening.

That error report would indicate this will cause cross platform issues with the build.  So lets not use `mv` in future.
