### PR TITLE
fix: Lovelace rounding and docs catalyst toolbox | NPG-000

### DIFF
--- a/src/catalyst-toolbox/catalyst-toolbox/src/bin/cli/sve_snapshot.rs
+++ b/src/catalyst-toolbox/catalyst-toolbox/src/bin/cli/sve_snapshot.rs
@@ -24,7 +24,7 @@ pub struct SveSnapshotCmd {
     #[clap(short, long)]
     file: PathBuf,
 
-    /// Registrations voting power threshold for eligibility
+    /// Registrations voting power threshold for eligibility expressed in lovelace
     #[clap(short, long)]
     min_stake_threshold: Value,
 
@@ -32,7 +32,7 @@ pub struct SveSnapshotCmd {
     #[clap(short, long)]
     discrimination: Discrimination,
 
-    /// Whether voting power is expressed in lovelace or ada
+    /// Whether voting power in the outputfile is expressed in lovelace or ada
     #[clap(short, long)]
     lovelace: bool,
 

--- a/src/catalyst-toolbox/snapshot-lib/src/sve.rs
+++ b/src/catalyst-toolbox/snapshot-lib/src/sve.rs
@@ -59,18 +59,16 @@ impl Snapshot {
         self.inner
             .iter()
             .map(|(vk, regs)| {
-                let value: Value = regs
+                let mut value: Value = regs
                     .iter()
-                    .map(|reg| {
-                        let value = u64::from(reg.voting_power);
-                        if lovelace {
-                            value / 1_000_000
-                        } else {
-                            value
-                        }
-                    })
+                    .map(|reg| u64::from(reg.voting_power))
                     .sum::<u64>()
                     .into();
+
+                //convert to ADA
+                if lovelace{
+                    value = (u64::from(value)/1_000_000).into();
+                }
 
                 let address = chain_addr::Address(
                     discrimination,

--- a/src/catalyst-toolbox/snapshot-lib/src/sve.rs
+++ b/src/catalyst-toolbox/snapshot-lib/src/sve.rs
@@ -66,8 +66,8 @@ impl Snapshot {
                     .into();
 
                 //convert to ADA
-                if !lovelace{
-                    value = (u64::from(value)/1_000_000).into();
+                if !lovelace {
+                    value = (u64::from(value) / 1_000_000).into();
                 }
 
                 let address = chain_addr::Address(

--- a/src/catalyst-toolbox/snapshot-lib/src/sve.rs
+++ b/src/catalyst-toolbox/snapshot-lib/src/sve.rs
@@ -66,7 +66,7 @@ impl Snapshot {
                     .into();
 
                 //convert to ADA
-                if lovelace{
+                if !lovelace{
                     value = (u64::from(value)/1_000_000).into();
                 }
 


### PR DESCRIPTION
# Description

Fix conversion lovelace to ADA for catalyst-toolbox sve-snapshot. Now the conversion to ada is done on the total voting power. Also fixed the docs has they were unclear on what the --lovelace option does

## Checklist

- [ ] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
