### PR TITLE
fix: Earthly integration tests use 'earthly/dind' container

### DIFF
--- a/src/cat-data-service/Earthfile
+++ b/src/cat-data-service/Earthfile
@@ -24,15 +24,20 @@ docker:
 
 # Need to be run with the -P flag
 test:
-    FROM ../../+builder
+    FROM earthly/dind:alpine
 
     COPY ../../src/event-db+docker-compose/docker-compose.yml docker-compose.yml
     WITH DOCKER \
         --compose docker-compose.yml \
         --pull postgres:14 \
         --load migrations:latest=(../../containers/event-db-migrations+docker --data=test) \
+        --load test:latest=(../../+builder) \
         --service migrations \
         --allow-privileged
-        RUN EVENT_DB_URL="postgres://catalyst-event-dev:CHANGE_ME@localhost/CatalystEventDev" cargo test -p cat-data-service --all-features
+        RUN docker run \
+            --network default_default \
+            -e EVENT_DB_URL="postgres://catalyst-event-dev:CHANGE_ME@postgres/CatalystEventDev" \
+            test:latest \
+                cargo test -p cat-data-service --all-features
     END
 

--- a/src/event-db/Earthfile
+++ b/src/event-db/Earthfile
@@ -38,14 +38,19 @@ docker-compose:
 
 # Need to be run with the -P flag
 test:
-    FROM ../../+builder
+    FROM earthly/dind:alpine
 
     COPY +docker-compose/docker-compose.yml .
     WITH DOCKER \
         --compose docker-compose.yml \
         --pull postgres:14 \
         --load migrations:latest=(../../containers/event-db-migrations+docker --data=test) \
+        --load test:latest=(../../+builder) \
         --service migrations \
         --allow-privileged
-        RUN EVENT_DB_URL="postgres://catalyst-event-dev:CHANGE_ME@localhost/CatalystEventDev" cargo test -p event-db
+        RUN docker run \
+            --network default_default \
+            -e EVENT_DB_URL="postgres://catalyst-event-dev:CHANGE_ME@postgres/CatalystEventDev" \
+            test:latest \
+                cargo test -p event-db
     END


### PR DESCRIPTION
# Description

CI tests are breaking because Earthly tries to install docker in containers that don't have it, causing unexpected timeouts. As recommended by Earthly Docs, https://docs.earthly.dev/best-practices#use-earthly-dind , this PR updates integration tests to address this problem.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration

- [x] Local execution of `earthly -P +test`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
