### PR TITLE
chore: Enable prometheus metrics in jormungandr by default | NPG-000

### DIFF
--- a/src/jormungandr/jormungandr/Cargo.toml
+++ b/src/jormungandr/jormungandr/Cargo.toml
@@ -94,7 +94,7 @@ libc = "0.2.124"
 nix = "0.25"
 
 [features]
-default = ["codegen-rustfmt"]
+default = ["codegen-rustfmt", "prometheus-metrics"]
 with-bench = []
 codegen-rustfmt = ["chain-network/codegen-rustfmt"]
 integration-test = []


### PR DESCRIPTION
# Description

Add the `prometheus-metrics` feature to the set of defaults in jormungandr.
