### PR TITLE
chore: Necessary fixes to earthly book building | NPG-000

### DIFF
--- a/containers/book/Earthfile
+++ b/containers/book/Earthfile
@@ -4,6 +4,7 @@ FROM debian:stable-slim
 
 builder:
     FROM ghcr.io/input-output-hk/catalyst-gh-tools:v1.4.3
+    RUN rustup component add rustfmt
 
     COPY --dir ../..+rust-source/src .
     COPY --dir ../..+rust-source/tests .
@@ -20,6 +21,7 @@ rustdoc-test:
 rustdoc:
     FROM +builder
 
+    BUILD +rustdoc-test
     RUN rustup component add rustfmt --toolchain nightly-x86_64-unknown-linux-gnu
     ENV RUSTDOCFLAGS="$RUSTDOCFLAGS --enable-index-page -Zunstable-options"
     RUN cargo +nightly doc \
@@ -55,7 +57,7 @@ builder-chapter-8:
 
     RUN mkdir /db-diagrams
 
-    CMD ["./build-db-diagrams.sh"]
+    ENTRYPOINT ["./build-db-diagrams.sh"]
     
 # Need to be run with the -P flag
 build-chapter-8:
@@ -93,7 +95,9 @@ mdbook:
 
     # Add an empty '.git' folder, needed by mdbook-open-on-gh for relative path calculation
     RUN mkdir .git
-    CMD while ! mdbook build; do sleep 1; done;
+    COPY build-mdbook.sh .
+    RUN chmod ugo+x ./build-mdbook.sh
+    ENTRYPOINT ["./build-mdbook.sh"]
 
     #RUN mdbook build
     SAVE ARTIFACT book

--- a/containers/book/build-mdbook.sh
+++ b/containers/book/build-mdbook.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Enable strict mode
+set +x
+set -o errexit
+set -o pipefail
+set -o nounset
+set -o functrace
+set -o errtrace
+set -o monitor
+set -o posix
+shopt -s dotglob
+
+echo ">>> Building mdbook..."
+CMD="mdbook build"
+# will retry to build 6 times every 5 seconds
+if  ! (r=6; while ! eval "$CMD" ; do
+    ((--r))||exit
+    echo "Build failed. Retrying.";
+    sleep 5;done) ; then
+    exit 1
+fi
+
+echo ">>> Build successful.";
+exit 0


### PR DESCRIPTION
# Description

fix: add rustfmt to run rustdoc-tests.
feat: retry commands in entry scripts up to 6 times

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Running `earthly -P ./containers/book+build-docs` locally.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
