### PR TITLE
Resolve Earthfile line 0:0 target docker not found when building audi…

### DIFF
--- a/src/audit/balance/README.md
+++ b/src/audit/balance/README.md
@@ -15,7 +15,7 @@ MOUNT_PATH=/tmp/fund9-leader-1:/leader1stuff
 HISTORICAL_STATE=/leader1stuff/persist/leader-1
 BLOCK_0=/leader1stuff/artifacts/block0.bin
 
-earthly +build && earthly +docker
+earthly +build && earthly +docker-local
 docker run  --net=host -v $MOUNT_PATH --env STORAGE_PATH=$HISTORICAL_STATE --env GENESIS_PATH=$BLOCK_0 jormungandr
 ```
 


### PR DESCRIPTION
# Description

The readme to **Audit The Tally** instructs to run `earthly +build && earthly +docker` when it should be `earthly +build && earthly +docker-local`. 

Creating a pr because other core tools follows the _docker-local_ convention. 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
