### PR TITLE
feat: Handle DB connection timeouts | NPG-000

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2445,6 +2445,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-postgres",
+ "tracing",
 ]
 
 [[package]]

--- a/src/cat-data-service/Earthfile
+++ b/src/cat-data-service/Earthfile
@@ -24,15 +24,20 @@ docker:
 
 # Need to be run with the -P flag
 test:
-    FROM ../../+builder
+    FROM earthly/dind:alpine
 
     COPY ../../src/event-db+docker-compose/docker-compose.yml docker-compose.yml
     WITH DOCKER \
         --compose docker-compose.yml \
         --pull postgres:14 \
         --load migrations:latest=(../../containers/event-db-migrations+docker --data=test) \
+        --load test:latest=(../../+builder) \
         --service migrations \
         --allow-privileged
-        RUN EVENT_DB_URL="postgres://catalyst-event-dev:CHANGE_ME@localhost/CatalystEventDev" cargo test -p cat-data-service --all-features
+        RUN docker run \
+            --network default_default \
+            -e EVENT_DB_URL="postgres://catalyst-event-dev:CHANGE_ME@postgres/CatalystEventDev" \
+            test:latest \
+                cargo test -p cat-data-service --all-features
     END
 

--- a/src/cat-data-service/src/cli.rs
+++ b/src/cat-data-service/src/cli.rs
@@ -27,7 +27,8 @@ impl Cli {
                 logger::init(settings.log_level).unwrap();
 
                 let state = Arc::new(
-                    State::new(Some(settings.database_url), settings.delay_seconds).await?,
+                    State::new_with_delay(Some(settings.database_url), settings.delay_seconds)
+                        .await?,
                 );
                 set_var(
                     RETRY_AFTER_DELAY_SECONDS_ENVVAR,

--- a/src/cat-data-service/src/cli.rs
+++ b/src/cat-data-service/src/cli.rs
@@ -27,8 +27,7 @@ impl Cli {
                 logger::init(settings.log_level).unwrap();
 
                 let state = Arc::new(
-                    State::new_with_delay(Some(settings.database_url), settings.delay_seconds)
-                        .await?,
+                    State::new(Some(settings.database_url), Some(settings.delay_seconds)).await?,
                 );
 
                 // Check the schema version, if connection to DB timesout, log as warning and

--- a/src/cat-data-service/src/cli.rs
+++ b/src/cat-data-service/src/cli.rs
@@ -31,8 +31,8 @@ impl Cli {
                         .await?,
                 );
 
-                // Check the schema version, if connection to DB timesout, log as warning,
-                // otherwise, return Error.
+                // Check the schema version, if connection to DB timesout, log as warning and
+                // continue, otherwise, return Error.
                 match state.event_db.schema_version_check().await {
                     Ok(current_ver) => {
                         tracing::info!(schema_version = current_ver, "verified schema version")

--- a/src/cat-data-service/src/cli.rs
+++ b/src/cat-data-service/src/cli.rs
@@ -1,10 +1,10 @@
 use crate::{
     logger, service,
-    settings::{Settings, RETRY_AFTER_DELAY_SECONDS_ENVVAR},
+    settings::{RetryAfterParams, Settings},
     state::State,
 };
 use clap::Parser;
-use std::{env::set_var, sync::Arc};
+use std::sync::Arc;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -30,10 +30,26 @@ impl Cli {
                     State::new_with_delay(Some(settings.database_url), settings.delay_seconds)
                         .await?,
                 );
-                set_var(
-                    RETRY_AFTER_DELAY_SECONDS_ENVVAR,
-                    settings.delay_seconds.to_string(),
-                );
+
+                // Check the schema version, if connection to DB timesout, log as warning,
+                // otherwise, return Error.
+                match state.event_db.schema_version_check().await {
+                    Ok(current_ver) => {
+                        tracing::info!(schema_version = current_ver, "verified schema version")
+                    }
+                    Err(e) => {
+                        tracing::warn!(error = e.to_string(), "could not verify schema version");
+                        // Only return error if it is not a connection timeout
+                        if e != event_db::error::Error::ConnectionTimeout {
+                            return Err(e.into());
+                        }
+                    }
+                };
+
+                // Initialize the `RETRY_AFTER_DELAY_SECONDS` env var with the
+                // initial value stored in settings.
+                RetryAfterParams::delay_seconds_set_var(settings.delay_seconds);
+
                 service::run(&settings.address, &settings.metrics_address, state).await?;
                 Ok(())
             }

--- a/src/cat-data-service/src/legacy_service/health.rs
+++ b/src/cat-data-service/src/legacy_service/health.rs
@@ -129,7 +129,7 @@ mod tests {
 
     #[tokio::test]
     async fn health_ready_test() {
-        let state = Arc::new(State::new(None).await.unwrap());
+        let state = Arc::new(State::new(None, None).await.unwrap());
         let app = app(state);
 
         let request = Request::builder()
@@ -148,7 +148,7 @@ mod tests {
 
     #[tokio::test]
     async fn health_live_test() {
-        let state = Arc::new(State::new(None).await.unwrap());
+        let state = Arc::new(State::new(None, None).await.unwrap());
         let app = app(state);
 
         let request = Request::builder()
@@ -170,11 +170,7 @@ mod tests {
         use crate::settings::RETRY_AFTER_DELAY_SECONDS_ENVVAR;
         const INITIAL_DELAY_SECONDS: u64 = 200;
 
-        let state = Arc::new(
-            State::new_with_delay(None, INITIAL_DELAY_SECONDS)
-                .await
-                .unwrap(),
-        );
+        let state = Arc::new(State::new(None, Some(INITIAL_DELAY_SECONDS)).await.unwrap());
         let app = app(state);
 
         // Request without query parameters resets env vars.
@@ -200,7 +196,7 @@ mod tests {
         // Request with `http_date` query parameter sets `RETRY_AFTER_HTTP_DATE` env var,
         // and resets `RETRY_AFTER_DELAY_SECONDS` to initial state value.
         let request = Request::builder()
-            .uri("/health/retry-after?http_date=2040-01-01T00:00:00Z".to_string())
+            .uri("/health/retry-after?http-date=2040-01-01T00:00:00Z".to_string())
             .method("PUT")
             .body(Body::empty())
             .unwrap();
@@ -219,7 +215,7 @@ mod tests {
         // Request with `delay_seconds` query parameter sets `RETRY_AFTER_DELAY_SECONDS` env var,
         // and resets `RETRY_AFTER_HTTP_DATE` to the default value.
         let request = Request::builder()
-            .uri("/health/retry-after?delay_seconds=900".to_string())
+            .uri("/health/retry-after?delay-seconds=900".to_string())
             .method("PUT")
             .body(Body::empty())
             .unwrap();

--- a/src/cat-data-service/src/legacy_service/health.rs
+++ b/src/cat-data-service/src/legacy_service/health.rs
@@ -1,13 +1,14 @@
-use crate::service::Error;
+use crate::{service::Error, state::State};
 use axum::{routing::get, Router};
+use std::sync::Arc;
 
 use super::handle_result;
 
-pub fn health() -> Router {
+pub fn health(state: Arc<State>) -> Router {
     Router::new()
         .route(
             "/health/ready",
-            get(|| async { handle_result(ready_exec().await) }),
+            get(|| async { handle_result(ready_exec(state).await) }),
         )
         .route(
             "/health/live",
@@ -15,9 +16,10 @@ pub fn health() -> Router {
         )
 }
 
-async fn ready_exec() -> Result<bool, Error> {
+async fn ready_exec(state: Arc<State>) -> Result<bool, Error> {
     tracing::debug!("health ready exec");
 
+    state.event_db.schema_version_check().await?;
     Ok(true)
 }
 

--- a/src/cat-data-service/src/legacy_service/mod.rs
+++ b/src/cat-data-service/src/legacy_service/mod.rs
@@ -37,7 +37,7 @@ fn metrics_app() -> Router {
 
 fn cors_layer() -> CorsLayer {
     CorsLayer::new()
-        .allow_methods([Method::GET, Method::POST])
+        .allow_methods([Method::GET, Method::POST, Method::PUT])
         .allow_origin(Any)
         .allow_headers(Any)
 }

--- a/src/cat-data-service/src/legacy_service/mod.rs
+++ b/src/cat-data-service/src/legacy_service/mod.rs
@@ -25,8 +25,8 @@ mod v1;
 pub fn app(state: Arc<State>) -> Router {
     // build our application with a route
     let v0 = v0::v0(state.clone());
-    let v1 = v1::v1(state);
-    let health = health::health();
+    let v1 = v1::v1(state.clone());
+    let health = health::health(state);
     Router::new().nest("/api", v1.merge(v0)).merge(health)
 }
 

--- a/src/cat-data-service/src/legacy_service/v0/fund.rs
+++ b/src/cat-data-service/src/legacy_service/v0/fund.rs
@@ -48,7 +48,7 @@ mod tests {
 
     #[tokio::test]
     async fn fund_test() {
-        let state = Arc::new(State::new(None).await.unwrap());
+        let state = Arc::new(State::new(None, None).await.unwrap());
         let app = app(state);
 
         let request = Request::builder()

--- a/src/cat-data-service/src/legacy_service/v1/event/ballots.rs
+++ b/src/cat-data-service/src/legacy_service/v1/event/ballots.rs
@@ -57,7 +57,7 @@ mod tests {
 
     #[tokio::test]
     async fn ballots_test() {
-        let state = Arc::new(State::new(None).await.unwrap());
+        let state = Arc::new(State::new(None, None).await.unwrap());
         let app = app(state);
 
         let request = Request::builder()

--- a/src/cat-data-service/src/legacy_service/v1/event/mod.rs
+++ b/src/cat-data-service/src/legacy_service/v1/event/mod.rs
@@ -96,7 +96,7 @@ mod tests {
 
     #[tokio::test]
     async fn event_test() {
-        let state = Arc::new(State::new(None).await.unwrap());
+        let state = Arc::new(State::new(None, None).await.unwrap());
         let app = app(state);
 
         let request = Request::builder()
@@ -167,7 +167,7 @@ mod tests {
 
     #[tokio::test]
     async fn events_test() {
-        let state = Arc::new(State::new(None).await.unwrap());
+        let state = Arc::new(State::new(None, None).await.unwrap());
         let app = app(state);
 
         let request = Request::builder()

--- a/src/cat-data-service/src/legacy_service/v1/event/objective/ballots.rs
+++ b/src/cat-data-service/src/legacy_service/v1/event/objective/ballots.rs
@@ -64,7 +64,7 @@ mod tests {
 
     #[tokio::test]
     async fn ballots_test() {
-        let state = Arc::new(State::new(None).await.unwrap());
+        let state = Arc::new(State::new(None, None).await.unwrap());
         let app = app(state);
 
         let request = Request::builder()

--- a/src/cat-data-service/src/legacy_service/v1/event/objective/mod.rs
+++ b/src/cat-data-service/src/legacy_service/v1/event/objective/mod.rs
@@ -152,7 +152,7 @@ mod tests {
 
     #[tokio::test]
     async fn objectives_test() {
-        let state = Arc::new(State::new(None).await.unwrap());
+        let state = Arc::new(State::new(None, None).await.unwrap());
         let app = app(state);
 
         let request = Request::builder()
@@ -293,7 +293,7 @@ mod tests {
 
     #[tokio::test]
     async fn objectives_voting_status_test() {
-        let state = Arc::new(State::new(None).await.unwrap());
+        let state = Arc::new(State::new(None, None).await.unwrap());
         let app = app(state);
 
         let data = mocked_voting_status_data();

--- a/src/cat-data-service/src/legacy_service/v1/event/objective/proposal/ballot.rs
+++ b/src/cat-data-service/src/legacy_service/v1/event/objective/proposal/ballot.rs
@@ -66,7 +66,7 @@ mod tests {
 
     #[tokio::test]
     async fn ballot_test() {
-        let state = Arc::new(State::new(None).await.unwrap());
+        let state = Arc::new(State::new(None, None).await.unwrap());
         let app = app(state);
 
         let request = Request::builder()

--- a/src/cat-data-service/src/legacy_service/v1/event/objective/proposal/mod.rs
+++ b/src/cat-data-service/src/legacy_service/v1/event/objective/proposal/mod.rs
@@ -118,7 +118,7 @@ mod tests {
 
     #[tokio::test]
     async fn proposal_test() {
-        let state = Arc::new(State::new(None).await.unwrap());
+        let state = Arc::new(State::new(None, None).await.unwrap());
         let app = app(state);
 
         let request = Request::builder()
@@ -171,7 +171,7 @@ mod tests {
 
     #[tokio::test]
     async fn proposals_test() {
-        let state = Arc::new(State::new(None).await.unwrap());
+        let state = Arc::new(State::new(None, None).await.unwrap());
         let app = app(state);
 
         let request = Request::builder()

--- a/src/cat-data-service/src/legacy_service/v1/event/objective/proposal/review.rs
+++ b/src/cat-data-service/src/legacy_service/v1/event/objective/proposal/review.rs
@@ -73,7 +73,7 @@ mod tests {
 
     #[tokio::test]
     async fn reviews_test() {
-        let state = Arc::new(State::new(None).await.unwrap());
+        let state = Arc::new(State::new(None, None).await.unwrap());
         let app = app(state);
 
         let request = Request::builder()

--- a/src/cat-data-service/src/legacy_service/v1/event/objective/review_type.rs
+++ b/src/cat-data-service/src/legacy_service/v1/event/objective/review_type.rs
@@ -71,7 +71,7 @@ mod tests {
 
     #[tokio::test]
     async fn review_types_test() {
-        let state = Arc::new(State::new(None).await.unwrap());
+        let state = Arc::new(State::new(None, None).await.unwrap());
         let app = app(state);
 
         let request = Request::builder()

--- a/src/cat-data-service/src/legacy_service/v1/registration.rs
+++ b/src/cat-data-service/src/legacy_service/v1/registration.rs
@@ -117,7 +117,7 @@ mod tests {
 
     #[tokio::test]
     async fn voter_test() {
-        let state = Arc::new(State::new(None).await.unwrap());
+        let state = Arc::new(State::new(None, None).await.unwrap());
         let app = app(state);
 
         let request = Request::builder()
@@ -247,7 +247,7 @@ mod tests {
 
     #[tokio::test]
     async fn delegations_test() {
-        let state = Arc::new(State::new(None).await.unwrap());
+        let state = Arc::new(State::new(None, None).await.unwrap());
         let app = app(state);
 
         let request = Request::builder()

--- a/src/cat-data-service/src/legacy_service/v1/search.rs
+++ b/src/cat-data-service/src/legacy_service/v1/search.rs
@@ -71,7 +71,7 @@ mod tests {
 
     #[tokio::test]
     async fn search_events_test() {
-        let state = Arc::new(State::new(None).await.unwrap());
+        let state = Arc::new(State::new(None, None).await.unwrap());
         let app = app(state);
 
         let request = Request::builder()
@@ -413,7 +413,7 @@ mod tests {
 
     #[tokio::test]
     async fn search_objectives_test() {
-        let state = Arc::new(State::new(None).await.unwrap());
+        let state = Arc::new(State::new(None, None).await.unwrap());
         let app = app(state);
 
         let request = Request::builder()
@@ -714,7 +714,7 @@ mod tests {
 
     #[tokio::test]
     async fn search_proposals_test() {
-        let state = Arc::new(State::new(None).await.unwrap());
+        let state = Arc::new(State::new(None, None).await.unwrap());
         let app = app(state);
 
         let request = Request::builder()

--- a/src/cat-data-service/src/service/api/health/mod.rs
+++ b/src/cat-data-service/src/service/api/health/mod.rs
@@ -1,5 +1,10 @@
-use crate::service::common::tags::ApiTags;
+use crate::{service::common::tags::ApiTags, settings::RetryAfterParams, state::State};
+use poem::{
+    web::{Data, Query},
+    Result,
+};
 use poem_openapi::OpenApi;
+use std::sync::Arc;
 
 mod live_get;
 mod ready_get;
@@ -45,8 +50,8 @@ impl HealthApi {
     /// * 500 Server Error - If anything within this function fails unexpectedly.
     /// * 503 Service Unavailable - Service is not ready, requests to other
     /// endpoints should not be sent until the service becomes ready.
-    async fn ready_get(&self) -> ready_get::AllResponses {
-        ready_get::endpoint().await
+    async fn ready_get(&self, state: Data<&Arc<State>>) -> ready_get::AllResponses {
+        ready_get::endpoint(state).await
     }
 
     #[oai(path = "/live", method = "get", operation_id = "healthLive")]

--- a/src/cat-data-service/src/service/api/health/mod.rs
+++ b/src/cat-data-service/src/service/api/health/mod.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 
 mod live_get;
 mod ready_get;
+mod retry_after_put;
 mod started_get;
 
 pub(crate) struct HealthApi;
@@ -72,6 +73,34 @@ impl HealthApi {
     async fn live_get(&self) -> live_get::AllResponses {
         live_get::endpoint().await
     }
+
+    #[oai(
+        path = "/retry-after",
+        method = "put",
+        operation_id = "healthRetryAfter"
+    )]
+    /// Service Ready
+    ///
+    /// This endpoint is used to determine if the service is ready and able to serve requests.
+    ///
+    /// ## Note
+    ///
+    /// *This endpoint is for internal use of the service deployment infrastructure.
+    /// It may not be exposed publicly.*
+    ///
+    /// ## Responses
+    ///
+    /// * 204 No Content - Service is Ready and can serve requests.
+    /// * 500 Server Error - If anything within this function fails unexpectedly.
+    /// * 503 Service Unavailable - Service is not ready, requests to other
+    /// endpoints should not be sent until the service becomes ready.
+    async fn retry_after(
+        &self,
+        params: Result<Query<RetryAfterParams>>,
+        state: Data<&Arc<State>>,
+    ) -> retry_after_put::AllResponses {
+        retry_after_put::endpoint(params, state).await
+    }
 }
 
 /// Need to setup and run a test event db instance
@@ -103,10 +132,25 @@ mod tests {
         let resp = app.get("/api/health/started").send().await;
         resp.assert_status(StatusCode::NO_CONTENT);
 
-        let resp = app.get("/api/health/ready").send().await;
-        resp.assert_status(StatusCode::NO_CONTENT);
+        //let resp = app.get("/api/health/ready").send().await;
+        //resp.assert_status(StatusCode::NO_CONTENT);
 
         let resp = app.get("/api/health/live").send().await;
+        resp.assert_status(StatusCode::NO_CONTENT);
+
+        let resp = app.put("/api/health/retry-after").send().await;
+        resp.assert_status(StatusCode::NO_CONTENT);
+
+        let resp = app
+            .put("/api/health/retry-after?delay-seconds=1")
+            .send()
+            .await;
+        resp.assert_status(StatusCode::NO_CONTENT);
+
+        let resp = app
+            .put("/api/health/retry-after?http-date=2099-01-01T00:00:00Z")
+            .send()
+            .await;
         resp.assert_status(StatusCode::NO_CONTENT);
     }
 }

--- a/src/cat-data-service/src/service/api/health/mod.rs
+++ b/src/cat-data-service/src/service/api/health/mod.rs
@@ -126,7 +126,7 @@ mod tests {
 
     #[tokio::test]
     async fn health_test() {
-        let state = Arc::new(State::new(None).await.unwrap());
+        let state = Arc::new(State::new(None, None).await.unwrap());
         let app = mk_test_app(state);
 
         let resp = app.get("/api/health/started").send().await;

--- a/src/cat-data-service/src/service/api/health/mod.rs
+++ b/src/cat-data-service/src/service/api/health/mod.rs
@@ -132,8 +132,8 @@ mod tests {
         let resp = app.get("/api/health/started").send().await;
         resp.assert_status(StatusCode::NO_CONTENT);
 
-        //let resp = app.get("/api/health/ready").send().await;
-        //resp.assert_status(StatusCode::NO_CONTENT);
+        let resp = app.get("/api/health/ready").send().await;
+        resp.assert_status(StatusCode::NO_CONTENT);
 
         let resp = app.get("/api/health/live").send().await;
         resp.assert_status(StatusCode::NO_CONTENT);

--- a/src/cat-data-service/src/service/api/health/ready_get.rs
+++ b/src/cat-data-service/src/service/api/health/ready_get.rs
@@ -39,7 +39,6 @@ pub(crate) type AllResponses = response! {
 /// * 204 No Content - Service is Ready to serve requests.
 /// * 500 Server Error - If anything within this function fails unexpectedly. (Possible but unlikely)
 /// * 503 Service Unavailable - Service is not ready, do not send other requests.
-#[allow(clippy::unused_async)]
 pub(crate) async fn endpoint(state: Data<&Arc<State>>) -> AllResponses {
     // otherwise everything seems to be A-OK
     match state.event_db.schema_version_check().await {

--- a/src/cat-data-service/src/service/api/health/retry_after_put.rs
+++ b/src/cat-data-service/src/service/api/health/retry_after_put.rs
@@ -1,0 +1,120 @@
+//! Implementation of the PUT /health/retry-after endpoint
+
+use std::sync::Arc;
+
+use crate::settings::RetryAfterParams;
+use crate::state::State;
+use crate::{
+    service::common::responses::{
+        resp_2xx::NoContent,
+        resp_4xx::ApiValidationError,
+        resp_5xx::{server_error, ServerError},
+    },
+    settings::RETRY_AFTER_HTTP_DATE_DEFAULT,
+};
+use poem::error::ParseQueryError;
+use poem::{
+    web::{Data, Query},
+    Result,
+};
+use poem_extensions::response;
+use poem_extensions::UniResponse::{T204, T400, T500};
+use poem_openapi::payload::PlainText;
+
+pub(crate) type AllResponses = response! {
+    204: NoContent,
+    400: ApiValidationError,
+    500: ServerError,
+};
+
+/// # PUT /health/retry-after
+///
+/// Configuration of the "retry-after" for 503 responses endpoint.
+///
+/// During the service runtime, when disconnects to the database happen,
+/// the appropriate response status code is 503, which includes a string
+/// that is either `<delay-secods>` or `<http-date>`.
+///
+/// This endpoint accepts two optional query parameters:
+///
+/// * `http-date` is the UTC Datetime string, which if set, will be returned in all 503 responses.
+///   Example:  `PUT /health/retry-after?http-date=2099-01-31T00:00:00Z`
+/// * `delay-seconds` is number of seconds as a positive integer, which if set, will be returned in
+///   all 503 response.
+///   Example:  `PUT /health/retry-after?delay-seconds=120`
+///
+/// If none of the query parameters is present, then the header value will be reset
+/// to the service's original settings.
+///   Example:  `PUT /health/retry-after`
+///
+/// If no problems occur, this endpoint will always just return 204.
+///
+/// If query parameters are invalid, for example an invalid datetime strinn
+/// In theory it can also return 500 if for some reason a temporary circumstance
+/// is preventing this service from properly serving request.
+///
+/// An example could be the service has started a long and cpu intensive task
+/// and is not able to properly service requests while it is occurring.
+/// This would let the load balancer shift traffic to other instances of this
+/// service that are ready.
+///
+/// ## Responses
+///
+/// * 204 No Content - Service is Ready to serve requests.
+/// * 400 API Validation Error - If anything within this function fails unexpectedly. (Possible but unlikely)
+/// * 500 Service  - Service is not ready, do not send other requests.
+#[allow(clippy::unused_async)]
+pub(crate) async fn endpoint(
+    params: Result<Query<RetryAfterParams>>,
+    state: Data<&Arc<State>>,
+) -> AllResponses {
+    match params {
+        Ok(Query(params)) => {
+            match params {
+                // Request without query parameters resets env vars.
+                // Sets `RETRY_AFTER_HTTP_DATE` to the default value.
+                // Sets `RETRY_AFTER_DELAY_SECONDS` to initial state value.
+                RetryAfterParams {
+                    http_date: None,
+                    delay_seconds: None,
+                } => {
+                    tracing::debug!("RETRY_AFTER parameters RESET");
+
+                    let date_str = RETRY_AFTER_HTTP_DATE_DEFAULT;
+                    RetryAfterParams::http_date_set_var(date_str);
+
+                    let delay_secs = state.delay_seconds;
+                    RetryAfterParams::delay_seconds_set_var(delay_secs);
+                }
+                // Request with `http_date` query parameter sets `RETRY_AFTER_HTTP_DATE` env var,
+                // and resets `RETRY_AFTER_DELAY_SECONDS` to initial state value.
+                RetryAfterParams {
+                    http_date: Some(http_date),
+                    delay_seconds: _,
+                } => {
+                    let date_str = http_date.to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+                    RetryAfterParams::http_date_set_var(&date_str);
+
+                    let delay_secs = state.delay_seconds;
+                    RetryAfterParams::delay_seconds_set_var(delay_secs);
+                }
+                // Request with `delay_seconds` query parameter sets `RETRY_AFTER_DELAY_SECONDS` env var,
+                // and resets `RETRY_AFTER_HTTP_DATE` to the default value.
+                RetryAfterParams {
+                    http_date: None,
+                    delay_seconds: Some(delay_seconds),
+                } => {
+                    let date_str = RETRY_AFTER_HTTP_DATE_DEFAULT;
+                    RetryAfterParams::http_date_set_var(date_str);
+
+                    RetryAfterParams::delay_seconds_set_var(delay_seconds);
+                }
+            };
+            T204(NoContent)
+        }
+        Err(err) if err.is::<ParseQueryError>() => {
+            T400(ApiValidationError(PlainText(err.to_string())))
+        }
+        Err(err) => T500(server_error!("{}", err.to_string())),
+    }
+}

--- a/src/cat-data-service/src/service/api/registration/mod.rs
+++ b/src/cat-data-service/src/service/api/registration/mod.rs
@@ -102,7 +102,7 @@ mod tests {
 
     #[tokio::test]
     async fn voter_test() {
-        let state = Arc::new(State::new(None).await.unwrap());
+        let state = Arc::new(State::new(None, None).await.unwrap());
         let app = mk_test_app(state);
 
         let resp = app

--- a/src/cat-data-service/src/service/api/test_endpoints/test_get.rs
+++ b/src/cat-data-service/src/service/api/test_endpoints/test_get.rs
@@ -58,7 +58,7 @@ pub(crate) async fn endpoint(
         }
         15 => {
             error!("id: {id:?}, action: {action:?}");
-            T503(ServiceUnavailable)
+            T503(ServiceUnavailable("120".to_string()))
         }
         20 => {
             panic!("id: {id:?}, action: {action:?}");

--- a/src/cat-data-service/src/service/common/responses/resp_4xx.rs
+++ b/src/cat-data-service/src/service/common/responses/resp_4xx.rs
@@ -13,7 +13,7 @@ pub(crate) struct BadRequest<T: IntoResponse + Payload>(T);
 #[oai(status = 400)]
 /// This error means that the request was malformed.
 /// It has failed to pass validation, as specified by the OpenAPI schema.
-pub(crate) struct ApiValidationError(PlainText<String>);
+pub(crate) struct ApiValidationError(pub(crate) PlainText<String>);
 
 #[derive(OneResponse)]
 #[oai(status = 401)]

--- a/src/cat-data-service/src/service/common/responses/resp_5xx.rs
+++ b/src/cat-data-service/src/service/common/responses/resp_5xx.rs
@@ -93,4 +93,21 @@ impl ResponseError for ServerError {
 /// or has become unavailable.*
 ///
 /// #### NO DATA BODY IS RETURNED FOR THIS RESPONSE
-pub(crate) struct ServiceUnavailable;
+pub(crate) struct ServiceUnavailable(#[oai(header = "retry-after")] pub(crate) String);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderValue;
+    use poem::IntoResponse;
+
+    #[tokio::test]
+    async fn into_response() {
+        let response = ServiceUnavailable("120".to_string()).into_response();
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(
+            response.headers().get("RETRY-AFTER"),
+            Some(&HeaderValue::from_static("120"))
+        );
+    }
+}

--- a/src/cat-data-service/src/settings.rs
+++ b/src/cat-data-service/src/settings.rs
@@ -1,9 +1,11 @@
 //! Command line and environment variable settings for the service
 //!
 use crate::logger::{LogLevel, LOG_LEVEL_DEFAULT};
+use chrono::prelude::*;
 use clap::Args;
 use dotenvy::dotenv;
 use lazy_static::lazy_static;
+use serde::Deserialize;
 use std::env;
 use std::net::{IpAddr, SocketAddr};
 use tracing::log::error;
@@ -101,6 +103,21 @@ impl StringEnvVar {
     /// * &str - the value
     pub(crate) fn as_str(&self) -> &str {
         &self.0
+    }
+}
+
+#[derive(Deserialize, Debug)]
+pub(crate) struct RetryAfterParams {
+    pub(crate) http_date: Option<DateTime<Utc>>,
+    pub(crate) delay_seconds: Option<u64>,
+}
+
+impl Default for RetryAfterParams {
+    fn default() -> Self {
+        RetryAfterParams {
+            http_date: Some("1970-01-01T00:00:00Z".parse::<DateTime<Utc>>().unwrap()), //Some(Utc.timestamp_opt(0, 0).unwrap()),
+            delay_seconds: Some(RETRY_AFTER_DELAY_SECONDS_DEFAULT),
+        }
     }
 }
 

--- a/src/cat-data-service/src/settings.rs
+++ b/src/cat-data-service/src/settings.rs
@@ -38,6 +38,13 @@ const API_HOSTNAMES_DEFAULT: &str = "https://api.prod.projectcatalyst.io";
 /// Default API_URL_PREFIX used in development.
 const API_URL_PREFIX_DEFAULT: &str = "/api";
 
+/// The name of the env var that specifies the delay-seconds in the 'Retry-After' header of 503
+/// responses.
+pub(crate) const RETRY_AFTER_HTTP_DATE_ENVVAR: &str = "RETRY_AFTER_HTTP_DATE";
+
+/// The default http-date in the 'Retry-After' header of 503 responses.
+pub(crate) const RETRY_AFTER_HTTP_DATE_DEFAULT: &str = "1970-01-01T00:00:00Z";
+
 /// The default delay-seconds in the 'Retry-After' header of 503 responses.
 pub(crate) const RETRY_AFTER_DELAY_SECONDS_DEFAULT: u64 = 120;
 /// The name of the env var that specifies the delay-seconds in the 'Retry-After' header of 503
@@ -115,7 +122,7 @@ pub(crate) struct RetryAfterParams {
 impl Default for RetryAfterParams {
     fn default() -> Self {
         RetryAfterParams {
-            http_date: Some("1970-01-01T00:00:00Z".parse::<DateTime<Utc>>().unwrap()), //Some(Utc.timestamp_opt(0, 0).unwrap()),
+            http_date: Some(RETRY_AFTER_HTTP_DATE_DEFAULT.parse().unwrap()),
             delay_seconds: Some(RETRY_AFTER_DELAY_SECONDS_DEFAULT),
         }
     }

--- a/src/cat-data-service/src/settings.rs
+++ b/src/cat-data-service/src/settings.rs
@@ -68,6 +68,9 @@ pub struct Settings {
     /// Logging level
     #[clap(long, default_value = LOG_LEVEL_DEFAULT)]
     pub log_level: LogLevel,
+
+    #[clap(long, env, default_value = "120")]
+    pub delay_seconds: u64,
 }
 
 /// An environment variable read as a string.

--- a/src/cat-data-service/src/settings.rs
+++ b/src/cat-data-service/src/settings.rs
@@ -36,6 +36,9 @@ const API_HOSTNAMES_DEFAULT: &str = "https://api.prod.projectcatalyst.io";
 /// Default API_URL_PREFIX used in development.
 const API_URL_PREFIX_DEFAULT: &str = "/api";
 
+/// Default RETRY_AFTER_DELAY_SECONDS used in development.
+pub(crate) const RETRY_AFTER_DELAY_SECONDS_DEFAULT: &str = "120";
+
 #[derive(Args, Clone)]
 pub struct Settings {
     /// Server binding address

--- a/src/cat-data-service/src/settings.rs
+++ b/src/cat-data-service/src/settings.rs
@@ -1,7 +1,7 @@
 //! Command line and environment variable settings for the service
 //!
 use crate::logger::{LogLevel, LOG_LEVEL_DEFAULT};
-use chrono::prelude::*;
+use chrono::{DateTime, Utc};
 use clap::Args;
 use dotenvy::dotenv;
 use lazy_static::lazy_static;
@@ -118,7 +118,9 @@ impl StringEnvVar {
 
 #[derive(Deserialize, Debug)]
 pub(crate) struct RetryAfterParams {
+    #[serde(rename = "http-date")]
     pub(crate) http_date: Option<DateTime<Utc>>,
+    #[serde(rename = "delay-seconds")]
     pub(crate) delay_seconds: Option<u64>,
 }
 

--- a/src/cat-data-service/src/settings.rs
+++ b/src/cat-data-service/src/settings.rs
@@ -36,8 +36,11 @@ const API_HOSTNAMES_DEFAULT: &str = "https://api.prod.projectcatalyst.io";
 /// Default API_URL_PREFIX used in development.
 const API_URL_PREFIX_DEFAULT: &str = "/api";
 
-/// Default RETRY_AFTER_DELAY_SECONDS used in development.
-pub(crate) const RETRY_AFTER_DELAY_SECONDS_DEFAULT: &str = "120";
+/// The default delay-seconds in the 'Retry-After' header of 503 responses.
+pub(crate) const RETRY_AFTER_DELAY_SECONDS_DEFAULT: u64 = 120;
+/// The name of the env var that specifies the delay-seconds in the 'Retry-After' header of 503
+/// responses.
+pub(crate) const RETRY_AFTER_DELAY_SECONDS_ENVVAR: &str = "RETRY_AFTER_DELAY_SECONDS";
 
 #[derive(Args, Clone)]
 pub struct Settings {

--- a/src/cat-data-service/src/settings.rs
+++ b/src/cat-data-service/src/settings.rs
@@ -131,6 +131,27 @@ impl Default for RetryAfterParams {
     }
 }
 
+impl RetryAfterParams {
+    /// Set `RETRY_AFTER_HTTP_DATE` env var.
+    pub fn delay_seconds_set_var(delay_secs: u64) {
+        let delay_secs = delay_secs.to_string();
+        std::env::set_var(RETRY_AFTER_DELAY_SECONDS_ENVVAR, &delay_secs);
+        tracing::debug!(
+            delay_seconds = delay_secs,
+            "{RETRY_AFTER_DELAY_SECONDS_ENVVAR:} ENV set"
+        );
+    }
+    /// Set `RETRY_AFTER_HTTP_DATE` env var.
+    pub fn http_date_set_var(date_str: &str) {
+        let date_str = date_str.to_string();
+        std::env::set_var(RETRY_AFTER_HTTP_DATE_ENVVAR, &date_str);
+        tracing::debug!(
+            http_date = date_str,
+            "{RETRY_AFTER_HTTP_DATE_ENVVAR:} ENV set"
+        );
+    }
+}
+
 // Lazy intialization of all env vars which are not command line parameters.
 // All env vars used by the application should be listed here and all should have a default.
 // The default for all NON Secret values should be suitable for Production, and NOT development.

--- a/src/cat-data-service/src/state/mod.rs
+++ b/src/cat-data-service/src/state/mod.rs
@@ -1,6 +1,6 @@
 //! Shared state used by all endpoints.
 //!
-use crate::cli::Error;
+use crate::{cli::Error, settings::RETRY_AFTER_DELAY_SECONDS_DEFAULT};
 use event_db::queries::EventDbQueries;
 use std::sync::Arc;
 
@@ -21,7 +21,16 @@ pub struct State {
 }
 
 impl State {
-    pub async fn new(database_url: Option<String>, delay_seconds: u64) -> Result<Self, Error> {
+    #[allow(dead_code)]
+    pub async fn new(database_url: Option<String>) -> Result<Self, Error> {
+        let delay_seconds: u64 = RETRY_AFTER_DELAY_SECONDS_DEFAULT;
+        Self::new_with_delay(database_url, delay_seconds).await
+    }
+
+    pub async fn new_with_delay(
+        database_url: Option<String>,
+        delay_seconds: u64,
+    ) -> Result<Self, Error> {
         // Get a connection to the Database.
         let event_db = match database_url.clone() {
             Some(url) => Arc::new(event_db::establish_connection(Some(url.as_str())).await?),

--- a/src/cat-data-service/src/state/mod.rs
+++ b/src/cat-data-service/src/state/mod.rs
@@ -15,12 +15,13 @@ pub struct State {
     /// This is Private, it needs to be accessed with a function.
     //event_db_handle: Arc<ArcSwap<Option<dyn EventDbQueries>>>, // Private need to get it with a function.
     pub event_db: Arc<dyn EventDbQueries>, // This needs to be obsoleted, we want the DB to be able to be down.
+    pub delay_seconds: u64,
     #[cfg(feature = "jorm-mock")]
     pub jorm: std::sync::Mutex<jorm_mock::JormState>,
 }
 
 impl State {
-    pub async fn new(database_url: Option<String>) -> Result<Self, Error> {
+    pub async fn new(database_url: Option<String>, delay_seconds: u64) -> Result<Self, Error> {
         // Get a connection to the Database.
         let event_db = match database_url.clone() {
             Some(url) => Arc::new(event_db::establish_connection(Some(url.as_str())).await?),
@@ -34,6 +35,7 @@ impl State {
             //db_url: database_url,
             //event_db_handle: Arc::new(RwLock::new(None)),
             event_db,
+            delay_seconds,
             #[cfg(feature = "jorm-mock")]
             jorm: std::sync::Mutex::new(jorm),
         };

--- a/src/cat-data-service/src/state/mod.rs
+++ b/src/cat-data-service/src/state/mod.rs
@@ -33,8 +33,8 @@ impl State {
     ) -> Result<Self, Error> {
         // Get a connection to the Database.
         let event_db = match database_url.clone() {
-            Some(url) => Arc::new(event_db::establish_connection(Some(url.as_str())).await?),
-            None => Arc::new(event_db::establish_connection(None).await?),
+            Some(url) => Arc::new(event_db::EventDB::new(Some(url.as_str())).await?),
+            None => Arc::new(event_db::EventDB::new(None).await?),
         };
 
         #[cfg(feature = "jorm-mock")]

--- a/src/cat-data-service/src/state/mod.rs
+++ b/src/cat-data-service/src/state/mod.rs
@@ -21,7 +21,6 @@ pub struct State {
 }
 
 impl State {
-    #[allow(dead_code)]
     pub async fn new(
         database_url: Option<String>,
         delay_seconds: Option<u64>,

--- a/src/event-db/Cargo.toml
+++ b/src/event-db/Cargo.toml
@@ -24,3 +24,5 @@ tokio = { version = "1", features = ["full"] }
 chrono = { workspace = true }
 
 rust_decimal = {  workspace = true, features = ["serde-with-float", "db-tokio-postgres"] }
+
+tracing = { workspace = true }

--- a/src/event-db/src/error.rs
+++ b/src/event-db/src/error.rs
@@ -5,8 +5,12 @@ use bb8::RunError;
 /// Event database errors
 #[derive(thiserror::Error, Debug, PartialEq, Eq)]
 pub enum Error {
+    #[error("DB connection timed out")]
+    ConnectionTimeout,
     #[error(" Schema in database does not match schema supported by the Crate. The current schema version: {was}, the schema version we expected: {expected}")]
     MismatchedSchema { was: i32, expected: i32 },
+    #[error("DB URL is undefined")]
+    NoDatabaseUrl,
     #[error("Cannot find this item, error: {0}")]
     NotFound(String),
     #[error("error: {0}")]
@@ -17,7 +21,10 @@ pub enum Error {
 
 impl From<RunError<tokio_postgres::Error>> for Error {
     fn from(val: RunError<tokio_postgres::Error>) -> Self {
-        Self::Unknown(val.to_string())
+        match val {
+            RunError::TimedOut => Self::ConnectionTimeout,
+            _ => Self::Unknown(val.to_string()),
+        }
     }
 }
 

--- a/src/event-db/src/lib.rs
+++ b/src/event-db/src/lib.rs
@@ -21,6 +21,8 @@ const DATABASE_URL_ENVVAR: &str = "EVENT_DB_URL";
 /// Must equal the last Migrations Version Number.
 pub const DATABASE_SCHEMA_VERSION: i32 = 9;
 
+pub const RETRY_AFTER_DELAY_SECONDS_DEFAULT: u64 = 120;
+pub const RETRY_AFTER_DELAY_SECONDS_ENVVAR: &str = "RETRY_AFTER_DELAY_SECONDS";
 #[allow(unused)]
 /// Connection to the Election Database
 pub struct EventDB {

--- a/src/event-db/src/lib.rs
+++ b/src/event-db/src/lib.rs
@@ -6,6 +6,7 @@ use error::Error;
 use schema_check::SchemaVersion;
 use std::str::FromStr;
 use tokio_postgres::NoTls;
+use tracing;
 
 mod config_table;
 pub mod error;

--- a/src/event-db/src/lib.rs
+++ b/src/event-db/src/lib.rs
@@ -3,7 +3,6 @@ use bb8::Pool;
 use bb8_postgres::PostgresConnectionManager;
 use dotenvy::dotenv;
 use error::Error;
-use schema_check::SchemaVersion;
 use std::str::FromStr;
 use tokio_postgres::NoTls;
 
@@ -70,19 +69,6 @@ pub async fn establish_connection(url: Option<&str>) -> Result<EventDB, Error> {
     let pool = Pool::builder().build(pg_mgr).await?;
 
     let db = EventDB { pool };
-
-    match db.schema_version_check().await {
-        Ok(current_ver) => {
-            tracing::info!(schema_version = current_ver, "verified schema version")
-        }
-        Err(e) => {
-            tracing::warn!(error = e.to_string(), "could not verify schema version");
-            // Only return error if it is not a connection timeout
-            if e != Error::ConnectionTimeout {
-                return Err(e);
-            }
-        }
-    };
 
     Ok(db)
 }

--- a/src/event-db/src/lib.rs
+++ b/src/event-db/src/lib.rs
@@ -43,7 +43,9 @@ pub struct EventDB {
 ///
 /// This function will return an error if:
 /// * `url` is None and the environment variable "`DATABASE_URL`" isn't set.
-/// * There is any error communicating the the database to check its schema.
+/// * There is any error communicating the the database to check its schema, EXCEPT
+///   if the connection to the DB times out. If connection timeout happens, the
+///   schmea version won't be checked, and it will logged as a warning.
 /// * The database schema in the DB does not 100% match the schema supported by
 ///   this library.
 ///

--- a/src/event-db/src/lib.rs
+++ b/src/event-db/src/lib.rs
@@ -21,8 +21,6 @@ const DATABASE_URL_ENVVAR: &str = "EVENT_DB_URL";
 /// Must equal the last Migrations Version Number.
 pub const DATABASE_SCHEMA_VERSION: i32 = 9;
 
-pub const RETRY_AFTER_DELAY_SECONDS_DEFAULT: u64 = 120;
-pub const RETRY_AFTER_DELAY_SECONDS_ENVVAR: &str = "RETRY_AFTER_DELAY_SECONDS";
 #[allow(unused)]
 /// Connection to the Election Database
 pub struct EventDB {

--- a/src/event-db/src/lib.rs
+++ b/src/event-db/src/lib.rs
@@ -32,6 +32,9 @@ pub struct EventDB {
 }
 
 impl EventDB {
+    /// Return a configured EventDB connection pool.
+    /// Accepts an optional database url, if None is set, it defaults to the
+    /// env var `EVENT_DB_URL`, otherwise it returns an Error.
     pub async fn new(url: Option<&str>) -> Result<EventDB, Error> {
         let database_url = match url {
             Some(url) => url.to_string(),

--- a/src/event-db/src/queries/mod.rs
+++ b/src/event-db/src/queries/mod.rs
@@ -6,7 +6,7 @@ use self::{
     registration::RegistrationQueries,
     search::SearchQueries,
 };
-use crate::EventDB;
+use crate::{schema_check::SchemaVersion, EventDB};
 
 pub mod event;
 pub mod registration;
@@ -23,6 +23,7 @@ pub trait EventDbQueries:
     + SearchQueries
     + BallotQueries
     + vit_ss::fund::VitSSFundQueries
+    + SchemaVersion
 {
 }
 


### PR DESCRIPTION
# Description

Allow `cat-data-service` to run without connection to DB, logging errors and having a configurable Retry-After header of a 503 response code.

All endpoints attempt to get a connection if none is available.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**: _if applicable_

- Firmware version:
- Hardware:
- Toolchain:
- SDK:

**List of new dependencies**: _if applicable_

Provide a list of newly added dependencies in this PR, with the description of what are they doing and why do we need them.

- Crate A: description
- Crate B: description

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
