### PR TITLE
Fixed incorrect bits info

### DIFF
--- a/src/chain-wallet-libs/doc/CRYPTO.md
+++ b/src/chain-wallet-libs/doc/CRYPTO.md
@@ -33,7 +33,7 @@ Valid BIP39 Encoding defined (where CS is Checksum Size):
 | 15 words     | 165 bits     | 160 bits (20 bytes) | 5 bits |
 | 18 words     | 198 bits     | 192 bits (24 bytes) | 6 bits |
 | 21 words     | 231 bits     | 224 bits (28 bytes) | 7 bits |
-| 24 words     | 264 bits     | 254 bits (32 bytes) | 8 bits |
+| 24 words     | 264 bits     | 256 bits (32 bytes) | 8 bits |
 
 Words of the dictionary are different enough that it should
 be hard to swap by mistake one word by another close by,


### PR DESCRIPTION
# Description

Minor typo here, 32 bytes should be 256 bits of data.

## Type of change

Minor documentation updates, no code related.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
