### PR TITLE
fix: crs hex::decode  | NPG-000

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2546,6 +2546,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3246,6 +3261,19 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -4621,6 +4649,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "neli"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4902,6 +4948,50 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "openssl"
+version = "0.10.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9dfc0783362704e97ef3bd24261995a699468440099ef95d869b4d9732f829a"
+dependencies = [
+ "bitflags 2.4.0",
+ "cfg-if 1.0.0",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f55da20b29f956fb01f0add8683eb26ee13ebe3ebd935e49898717c6b4b2830"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "opentelemetry"
@@ -6162,10 +6252,12 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -6176,6 +6268,7 @@ dependencies = [
  "serde_urlencoded",
  "system-configuration",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls 0.24.1",
  "tower-service",
  "url",
@@ -6403,6 +6496,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "scheduled-thread-pool"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6517,6 +6619,29 @@ checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
 dependencies = [
  "serde",
  "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -6776,6 +6901,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_core 0.5.1",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -7516,6 +7642,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.37",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]

--- a/src/sign/Cargo.toml
+++ b/src/sign/Cargo.toml
@@ -32,9 +32,6 @@ serde_json = "1.0"
 serde_yaml = "0.8.17"
 rand = "0.8.3"
 bech32 = "0.8"
-
-
 rand_core = { version = "0.5.1", default-features = false }
-
-
 ed25519-dalek = "1.0.1"
+reqwest = { version = "*", features = ["blocking","json"] }

--- a/src/sign/README.md
+++ b/src/sign/README.md
@@ -1,4 +1,5 @@
 # Fragment generator and signer:
+Generates vote fragments and signs them accordingly
 
 ## Specifications
  [*see here for format.abnf*](../chain-libs/chain-impl-mockchain/doc/format.abnf)

--- a/src/sign/README.md
+++ b/src/sign/README.md
@@ -1,4 +1,4 @@
-# Fragment generator and signer:
+# **Vote** Fragment generator and signer:
 Generates vote fragments and signs them accordingly
 
 ## Specifications
@@ -6,7 +6,7 @@ Generates vote fragments and signs them accordingly
 
  [*see here for format.md*](../chain-libs/chain-impl-mockchain/doc/format.md)
 
-## Ingredients for generating a fragment
+## Ingredients for generating a **vote** fragment
 
 - Election public key
 - Alice public key
@@ -22,7 +22,7 @@ Generates vote fragments and signs them accordingly
 cargo build --release -p sign
 ```  
 
-*Generate raw fragment in byte representation*
+*Generate raw vote fragment in byte representation*
 
 ```bash
 

--- a/src/sign/src/fragment.rs
+++ b/src/sign/src/fragment.rs
@@ -206,7 +206,7 @@ mod tests {
         // vote
         let vote = chain_vote::Vote::new(2, 1 as usize).unwrap();
 
-        let crs = chain_vote::Crs::from_hash(vote_plan_id.as_bytes());
+        let crs = chain_vote::Crs::from_hash(&hex::decode(vote_plan_id.as_bytes()).unwrap());
 
         let (ciphertexts, proof) = ek.encrypt_and_prove_vote(&mut rng, &crs, vote);
         let (proof, encrypted_vote) =

--- a/src/sign/src/fragment.rs
+++ b/src/sign/src/fragment.rs
@@ -181,7 +181,7 @@ mod tests {
     use jormungandr_lib::interfaces::AccountIdentifier;
 
     #[test]
-    fn test_fragment_generation() {
+    fn fragment_generation() {
         let mut csprng = OsRng;
 
         // User key for signing witness
@@ -289,7 +289,7 @@ mod tests {
     }
 
     #[test]
-    fn test_encrypted_vote_generation() {
+    fn encrypted_vote_generation() {
         let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
 
         // vote plan id

--- a/src/sign/src/main.rs
+++ b/src/sign/src/main.rs
@@ -16,6 +16,7 @@ use std::error::Error;
 use crate::fragment::{compose_encrypted_vote_part, generate_vote_fragment};
 
 mod fragment;
+mod network;
 
 ///
 /// Args defines and declares CLI behaviour within the context of clap

--- a/src/sign/src/main.rs
+++ b/src/sign/src/main.rs
@@ -15,8 +15,8 @@ use std::error::Error;
 
 use crate::fragment::{compose_encrypted_vote_part, generate_vote_fragment};
 
-mod fragment;
-mod network;
+pub mod fragment;
+pub mod network;
 
 ///
 /// Args defines and declares CLI behaviour within the context of clap

--- a/src/sign/src/main.rs
+++ b/src/sign/src/main.rs
@@ -68,7 +68,9 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // vote
     let vote = chain_vote::Vote::new(2, 1_usize)?;
-    let crs = chain_vote::Crs::from_hash(args.vote_plan_id.clone().as_bytes());
+    
+    // common reference string
+    let crs = chain_vote::Crs::from_hash(&hex::decode(args.vote_plan_id.clone())?);
 
     // parse ek key
     let ek = ElectionPublicKey::from_bytes(&election_pk)

--- a/src/sign/src/main.rs
+++ b/src/sign/src/main.rs
@@ -65,10 +65,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     // join sk+pk together, api requirement
     sk.extend(pk.clone());
     let keypair: Keypair = Keypair::from_bytes(&sk)?;
-
-    // vote
     let vote = chain_vote::Vote::new(2, 1_usize)?;
-    
     // common reference string
     let crs = chain_vote::Crs::from_hash(&hex::decode(args.vote_plan_id.clone())?);
 

--- a/src/sign/src/network.rs
+++ b/src/sign/src/network.rs
@@ -64,7 +64,7 @@ impl Network {
     }
 
     /// construct headers for octet-stream
-    fn construct_headers(&self) -> HeaderMap {
+    pub fn construct_headers(&self) -> HeaderMap {
         let mut headers = HeaderMap::new();
         headers.insert(
             CONTENT_TYPE,
@@ -74,6 +74,7 @@ impl Network {
     }
 }
 
+#[cfg(test)]
 mod tests {
     use crate::network::{Network, NodeResponse};
     use ed25519_dalek::Keypair;

--- a/src/sign/src/network.rs
+++ b/src/sign/src/network.rs
@@ -114,7 +114,7 @@ mod tests {
         // vote
         let vote = chain_vote::Vote::new(2, 1_usize).unwrap();
 
-        let crs = chain_vote::Crs::from_hash(vote_plan_id.as_bytes());
+        let crs = chain_vote::Crs::from_hash(&hex::decode(vote_plan_id.as_bytes()).unwrap());
 
         let (ciphertexts, proof) = ek.encrypt_and_prove_vote(&mut rng, &crs, vote);
         let (proof, encrypted_vote) =

--- a/src/sign/src/network.rs
+++ b/src/sign/src/network.rs
@@ -1,0 +1,141 @@
+//!
+//! Test code
+//! Example code on how to send a raw vote fragment
+//!
+
+use color_eyre::Result;
+
+use reqwest::blocking::Client;
+use reqwest::header::HeaderMap;
+
+use reqwest::Url;
+use serde::Deserialize as Deser;
+use serde::Serialize as Ser;
+
+use reqwest::header::{HeaderValue, CONTENT_TYPE};
+
+/// Node responds with yay or nay and associated metadata such as fragment id hash
+#[derive(Ser, Deser, Debug)]
+pub struct NodeResponse {
+    pub accepted: Vec<String>,
+    pub rejected: Vec<Rejected>,
+}
+
+/// Vote fragment rejected
+#[derive(Ser, Deser, Debug)]
+pub struct Rejected {
+    pub id: String,
+    pub reason: String,
+}
+
+/// Vote fragment accepted
+#[derive(Ser, Deser, Debug)]
+pub struct Accepted {
+    pub id: String,
+}
+
+/// Simple toy network network client for sending vote fragments
+pub struct Network {
+    pub client: Client,
+    /// URL for posting a signed vote fragment
+    /// e.g https://core.projectcatalyst.io/api/v0/message
+    pub fragment_url: String,
+}
+
+impl Network {
+    pub fn new(fragment_url: String) -> Self {
+        Self {
+            client: Client::new(),
+            fragment_url,
+        }
+    }
+
+    // Send single vote fragment to node
+    pub fn send_fragment(
+        &self,
+        fragment: Vec<u8>,
+    ) -> Result<reqwest::blocking::Response, Box<dyn std::error::Error>> {
+        Ok(self
+            .client
+            .post(Url::parse(&self.fragment_url)?)
+            .headers(self.construct_headers())
+            .body(fragment)
+            .send()?)
+    }
+
+    /// construct headers for octet-stream
+    fn construct_headers(&self) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            CONTENT_TYPE,
+            HeaderValue::from_static("application/octet-stream"),
+        );
+        headers
+    }
+}
+
+mod tests {
+    use crate::network::{Network, NodeResponse};
+    use ed25519_dalek::Keypair;
+    use rand_chacha::{rand_core::SeedableRng, ChaCha20Rng};
+    use rand_core::OsRng;
+
+    use crate::fragment::{compose_encrypted_vote_part, generate_vote_fragment};
+    use chain_vote::{Crs, ElectionPublicKey, MemberCommunicationKey, MemberState};
+
+    fn create_election_pub_key(shared_string: String, mut rng: ChaCha20Rng) -> ElectionPublicKey {
+        let h = Crs::from_hash(shared_string.as_bytes());
+        let mc1 = MemberCommunicationKey::new(&mut rng);
+        let mc = [mc1.to_public()];
+        let threshold = 1;
+        let m1 = MemberState::new(&mut rng, threshold, &h, &mc, 0);
+        let participants = vec![m1.public_key()];
+        ElectionPublicKey::from_participants(&participants)
+    }
+
+    #[test]
+    fn send_raw_fragment() {
+        let client = Network::new("https://core.dev.projectcatalyst.io/api/v0/message".to_string());
+
+        let mut csprng = OsRng;
+
+        // User key for signing witness
+        let keypair = Keypair::generate(&mut csprng);
+
+        let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
+
+        // vote plan id
+        let vote_plan_id =
+            "36ad42885189a0ac3438cdb57bc8ac7f6542e05a59d1f2e4d1d38194c9d4ac7b".to_owned();
+
+        // election public key
+        let ek = create_election_pub_key(vote_plan_id.clone(), rng.clone());
+
+        // vote
+        let vote = chain_vote::Vote::new(2, 1_usize).unwrap();
+
+        let crs = chain_vote::Crs::from_hash(vote_plan_id.as_bytes());
+
+        let (ciphertexts, proof) = ek.encrypt_and_prove_vote(&mut rng, &crs, vote);
+        let (proof, encrypted_vote) =
+            compose_encrypted_vote_part(ciphertexts.clone(), proof).unwrap();
+
+        // generate fragment
+        let fragment_bytes = generate_vote_fragment(
+            keypair,
+            encrypted_vote,
+            proof,
+            5,
+            &hex::decode(vote_plan_id.clone()).unwrap(),
+            560,
+            120,
+        )
+        .unwrap();
+
+        let response = client.send_fragment(fragment_bytes).unwrap();
+
+        let resp_json = response.json::<NodeResponse>().unwrap();
+
+        println!("{:?}", resp_json);
+    }
+}


### PR DESCRIPTION
In proof systems, provers and the verifiers rely on a common set of parameters, sometimes referred to as the common reference string (CRS).

we are using the the DigestOf<Blake2b256, VotePlan>; as the CRS

align with on the fly load tester updates
