### PR TITLE
fix: Make the snapshot importer compatible with the latest catalyst-toolbox output | NPG-0000

### DIFF
--- a/src/catalyst-toolbox/catalyst-toolbox/src/bin/cli/snapshot/mod.rs
+++ b/src/catalyst-toolbox/catalyst-toolbox/src/bin/cli/snapshot/mod.rs
@@ -242,7 +242,7 @@ impl SnapshotCmd {
             .voters
             .iter()
             .sorted_by_key(|v| v.hir.address.clone())
-            .filter(|v| !v.hir.underthreshold) // Summary does not have voters who don;t have enough voting power.
+            .filter(|v| !v.hir.underthreshold) // Summary does not have voters who don't have enough voting power.
             .map(|v| SnapshotSummaryVoter {
                 address: v.hir.address.to_string(),
                 value: v.hir.voting_power.as_u64() / 1000000, // Lovelace to Whole ADA conversion.

--- a/src/jormungandr/jcli/src/jcli_lib/utils/output_file.rs
+++ b/src/jormungandr/jcli/src/jcli_lib/utils/output_file.rs
@@ -43,7 +43,7 @@ impl OutputFile {
         match self.output {
             None => self,
             Some(ref path) => {
-                let mut new_path: PathBuf = PathBuf::new();
+                let mut new_path: PathBuf = path.parent().expect("Parent will exist").to_path_buf();
 
                 if let Some(path) = path.file_stem() {
                     new_path.push(path);

--- a/utilities/ideascale-importer/ideascale_importer/snapshot_importer.py
+++ b/utilities/ideascale-importer/ideascale_importer/snapshot_importer.py
@@ -40,6 +40,12 @@ class SnapshotProcessedEntry(BaseModel):
     hir: HIR
 
 
+class CatalystToolboxOutput(BaseModel):
+    """Represents the output of catalyst-toolbox."""
+
+    voters: List[SnapshotProcessedEntry]
+
+
 class Registration(BaseModel):
     """Represents a voter registration."""
 
@@ -533,10 +539,10 @@ class Importer:
             catalyst_toolbox_data_raw_json = f.read()
 
         catalyst_toolbox_data_dict = json.loads(catalyst_toolbox_data_raw_json)
-        catalyst_toolbox_data: Dict[str, List[SnapshotProcessedEntry]] = {}
-        for k, entries in catalyst_toolbox_data_dict.items():
+        catalyst_toolbox_data: Dict[str, CatalystToolboxOutput] = {}
+        for network_id, data in catalyst_toolbox_data_dict.items():
             try:
-                catalyst_toolbox_data[k] = [SnapshotProcessedEntry.model_validate(e) for e in entries]
+                catalyst_toolbox_data[network_id] = CatalystToolboxOutput.model_validate(data)
             except Exception as e:
                 logger.error(f"ERROR: {repr(e)}")
 
@@ -701,7 +707,7 @@ class Importer:
         for network_id, network_processed_snapshot in catalyst_toolbox_data.items():
             network_report = network_snapshot_reports[network_id]
 
-            for ctd in network_processed_snapshot:
+            for ctd in network_processed_snapshot.voters:
                 for snapshot_contribution in ctd.contributions:
                     network_report.processed_voting_power += snapshot_contribution.value
                     network_report.eligible_voters_count += 1


### PR DESCRIPTION
This PR makes the snapshot importer parse `catalyst-toolbox`'s output correctly.

I also fixed `catalyst-toolbox` creating the summary file in the current directory instead of in the same dir as the output file.

Closes #634.