### PR TITLE
fix: cleans up eventdb entrypoint and adds fix for RDS | NPG-000

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -226,7 +226,7 @@ jobs:
         uses: taiki-e/install-action@nextest
 
       - name: Install cargo-make
-        run: cargo install --force cargo-make --locked
+        run: cargo install --force cargo-make --version 0.37.11 --locked
 
       - name: Install refinery
         run: cargo install refinery_cli --version 0.8.7 --locked

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -226,7 +226,7 @@ jobs:
         uses: taiki-e/install-action@nextest
 
       - name: Install cargo-make
-        run: cargo install --force cargo-make --version 0.37.11 --locked
+        run: cargo install --force cargo-make --version 0.37.10 --locked
 
       - name: Install refinery
         run: cargo install refinery_cli --version 0.8.7 --locked

--- a/src/event-db/setup/setup-db.sql
+++ b/src/event-db/setup/setup-db.sql
@@ -29,13 +29,10 @@
   \set dbUserPw `echo ${DB_USER_PW:-CHANGE_ME}`
 \endif
 
--- DISPLAY ALL VARIABLES
-\echo VARIABLES:
-\echo -> dbName ................. = :dbName
-\echo -> dbDescription .......... = :dbDescription
-\echo -> dbUser ................. = :dbUser
-\echo -> dbUserPw / $DB_USER_PW . = :dbUserPw
-
+-- The root db user of the database instance (usually postgres).
+\if :{?dbRootUser} \else
+  \set dbRootUser 'postgres'
+\endif
 
 -- Cleanup if we already ran this before.
 DROP DATABASE IF EXISTS :"dbName";
@@ -49,6 +46,9 @@ CREATE USER :"dbUser" WITH PASSWORD :'dbUserPw';
 ALTER DEFAULT privileges REVOKE EXECUTE ON functions FROM public;
 
 ALTER DEFAULT privileges IN SCHEMA public REVOKE EXECUTE ON functions FROM :"dbUser";
+
+-- This is necessary for RDS to work.
+GRANT :"dbUser" TO :"dbRootUser";
 
 -- Create the database.
 CREATE DATABASE :"dbName" WITH OWNER :"dbUser";

--- a/src/event-db/stage_data/dev/00002_fund100_params.sql
+++ b/src/event-db/stage_data/dev/00002_fund100_params.sql
@@ -1,6 +1,6 @@
 -- Define F100 IdeaScale parameters.
 INSERT INTO config (id, id2, id3, value) VALUES (
-    'ideascale,
+    'ideascale',
     '100',
     '',
     '{


### PR DESCRIPTION
This PR addresses the following issues:

1. We no longer have a dependency on graphql, so it removes all init code related to that in the eventdb entrypoint
1. The entrypoint was trying to connect to a database that didn't exist
   a. It was changed to connect to the "root" database on initialization (a new input was added for this) 
1. For initialization to work with RDS, the root role must be assigned the role the database is being created with
   a. This is a weird RDS requirement where the root role isn't really "super"
1. The debug print statements in the init script were printing out the raw database password every single run
   a. Even though our logs are private, this is still a serious issue
   b. The debug statements were moved to the entrypoint instead so they could be conditionally controlled
1. The ideascale SQL for the dev environment had a syntax error in it