### PR TITLE
feat: Update snapshot-tool readme | NPG-000

### DIFF
--- a/src/voting-tools-rs/README.md
+++ b/src/voting-tools-rs/README.md
@@ -4,8 +4,14 @@ This tool generates voting power info from a `cardano-db-sync` instance.
 
 Example usage:
 
-```
+```sh
 snapshot-tool --db postgres --db-user postgres --db-host localhost --out-file output.json
+```
+
+To get a full list of available arguments run:
+
+```sh
+snapshot-tool --help
 ```
 
 ## Building

--- a/src/voting-tools-rs/README.md
+++ b/src/voting-tools-rs/README.md
@@ -1,6 +1,6 @@
 # Voting Tools (Rust)
 
-This tool generates voting power info from a db-sync instance.
+This tool generates voting power info from a `cardano-db-sync` instance.
 
 Example usage:
 
@@ -10,31 +10,14 @@ snapshot-tool --db postgres --db-user postgres --db-host localhost --out-file ou
 
 ## Building
 
-Building with nix should be straightforward, simply enter a dev environment with `nix develop`, then run `cargo build` to build.
+Building with nix should be straightforward, simply enter a dev environment with `nix develop`, then run `cargo build -p voting_tools_rs` to build.
 
 ## Testing
 
-To run tests, run `cargo test`. Note, these tests include database tests, which require a running postgres instance to connect to. If you want to run only non-database tests, run `cargo test --no-default-features`
+To run tests, run `cargo test -p voting_tools_rs`.
 
-### Database tests
+## Spin up cardano-db-sync
 
-Database tests perform predefined queries against a test database. If the results don't match the snapshots, the test fails. This requires having the correct data in your database. The current test data can be found [here](https://updates-cardano-testnet.s3.amazonaws.com/cardano-db-sync/index.html#13/).
+To sucessufully run the `snapshot-tool` it is needed to have a running [`cardano-db-sync`](https://github.com/IntersectMBO/cardano-db-sync) instance.
 
-There are also "reference database tests", which populate a mock database with fake data, run queries against them, and check the results. These do not require the preset test data, as the correct data is created in the test.
-
-Once you have this database set up, create a file at `<project_root>/test_db.json`, which contains credentials to connect to this database, for example:
-
-```json
-{
-  "host": "localhost",
-  "name": "database_name",
-  "user": "username",
-  "password": "password"
-}
-```
-
-(Note, password is optional).
-
-From there, running `cargo test` will run database tests as well as regular tests. If tests pass, great!
-
-If not, you need to review the changes. It's possible that you intended to change the result of a query. Use `cargo insta review` to go through all failed tests and mark them as "intended" or not.
+[Here](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/building-running.md) you can found a guide how to build and run `cardano-db-sync`.


### PR DESCRIPTION
# Description

Updating a stale `snapshot-tool` Readme.
Providing a guides how to build and run `snapshot-tool` itself and referencing to the `cardano-db-sync` docs for spin upping local instance of the database.