### PR TITLE
Test/cap nonce

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -8,7 +8,7 @@ rust-toolchain:
 # Installs Cargo chef
 install-chef:
     FROM +rust-toolchain
-    RUN cargo install --debug cargo-chef
+     RUN cargo install --debug --version 0.1.59 cargo-chef --locked
 
 # Prepares the local cache
 prepare-cache:

--- a/src/voting-tools-rs/src/verification/verify.rs
+++ b/src/voting-tools-rs/src/verification/verify.rs
@@ -100,7 +100,7 @@ pub fn filter_registrations(
         };
 
         // deserialize the raw Binary CBOR.
-        let reg = match rawreg.to_signed(&cddl, network_id) {
+        let reg = match rawreg.to_signed(&cddl, network_id, SlotNo(slot as u64)) {
             Err(err) => {
                 invalids.push(InvalidRegistration {
                     spec_61284: Some(prefix_hex(&rawreg.bin_reg)),


### PR DESCRIPTION
# Description

This is a PR for testing purposes which CAPS the Nonce of CIP-15/36 registration to the Slot# the transaction is found in.
This is an attempt to work around old Yoroi wallet registrations which eclipsing newer registrations because they used a very large nonce value.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

It hasn't the PR is so that it a can be tested.

**Test Configuration**: _if applicable_

- Generate a Snapshot with the Original Rules.
- Generate a Snapshot with this test version.
- Compare them and see if the difference introduces problems, or only fixes the Yoroi Nonce issue.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
