### PR TITLE
feat: Update `sign` tool v2 using new `catalyst-voting` crate | NPG-000

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1077,6 +1077,7 @@ dependencies = [
 [[package]]
 name = "catalyst-voting"
 version = "0.0.1"
+source = "git+https://github.com/input-output-hk/catalyst-libs.git?rev=d0b5784208abb7c4f2eddf8237099368e070620a#d0b5784208abb7c4f2eddf8237099368e070620a"
 dependencies = [
  "anyhow",
  "blake2b_simd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,6 +740,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2b_simd"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23285ad32269793932e830392f2fe2f83e26488fd3ec778883a93c8323735780"
+dependencies = [
+ "arrayref",
+ "arrayvec 0.7.4",
+ "constant_time_eq 0.3.1",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1064,6 +1075,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "catalyst-voting"
+version = "0.0.1"
+dependencies = [
+ "anyhow",
+ "blake2b_simd",
+ "curve25519-dalek 4.1.3",
+ "ed25519-dalek 2.1.1",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "cbor_event"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1185,7 +1208,7 @@ dependencies = [
  "curve25519-dalek-ng",
  "eccoxide 0.3.1",
  "ed25519-bip32 0.4.1",
- "ed25519-dalek",
+ "ed25519-dalek 1.0.1",
  "generic-array",
  "hex",
  "proptest",
@@ -1297,7 +1320,7 @@ name = "chain-vote"
 version = "0.1.0"
 dependencies = [
  "base64 0.21.5",
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "chain-core",
  "chain-crypto",
  "const_format",
@@ -1632,6 +1655,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "const_format"
 version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1656,6 +1685,12 @@ name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "core-foundation"
@@ -1905,6 +1940,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto",
+ "rand_core 0.6.4",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
 name = "curve25519-dalek-ng"
 version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2043,6 +2106,16 @@ checksum = "73770f8e1fe7d64df17ca66ad28994a0a623ea497fa69486e14984e715c5d174"
 dependencies = [
  "adler32",
  "byteorder",
+]
+
+[[package]]
+name = "der"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
+dependencies = [
+ "const-oid",
+ "zeroize",
 ]
 
 [[package]]
@@ -2256,7 +2329,17 @@ version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
 dependencies = [
- "signature",
+ "signature 1.6.4",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature 2.2.0",
 ]
 
 [[package]]
@@ -2283,11 +2366,26 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
- "curve25519-dalek",
- "ed25519",
+ "curve25519-dalek 3.2.0",
+ "ed25519 1.5.3",
  "rand 0.7.3",
  "serde",
  "sha2 0.9.9",
+ "zeroize",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
+dependencies = [
+ "curve25519-dalek 4.1.3",
+ "ed25519 2.2.3",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2 0.10.8",
+ "subtle",
  "zeroize",
 ]
 
@@ -2467,6 +2565,12 @@ name = "fastrand"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filedescriptor"
@@ -5257,6 +5361,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6794,6 +6908,7 @@ name = "sign"
 version = "0.1.0"
 dependencies = [
  "bech32 0.8.1",
+ "catalyst-voting",
  "chain-addr",
  "chain-core",
  "chain-crypto",
@@ -6806,7 +6921,7 @@ dependencies = [
  "color-eyre",
  "cryptoxide 0.4.4",
  "csv",
- "ed25519-dalek",
+ "ed25519-dalek 1.0.1",
  "hex",
  "jormungandr-lib",
  "rand 0.8.5",
@@ -6862,6 +6977,15 @@ name = "signature"
 version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core 0.6.4",
+]
 
 [[package]]
 name = "simdutf8"
@@ -7055,6 +7179,16 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
 
 [[package]]
 name = "sscanf"
@@ -9472,7 +9606,7 @@ dependencies = [
  "aes 0.8.3",
  "byteorder",
  "bzip2",
- "constant_time_eq",
+ "constant_time_eq 0.1.5",
  "crc32fast",
  "crossbeam-utils",
  "flate2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,9 +241,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.75"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
 
 [[package]]
 name = "arc-swap"

--- a/src/sign/Cargo.toml
+++ b/src/sign/Cargo.toml
@@ -15,6 +15,9 @@ chain-impl-mockchain = { path = "../chain-libs/chain-impl-mockchain" ,features= 
 chain-ser = { path = "../chain-libs/chain-ser" }
 chain-storage = { path = "../chain-libs/chain-storage" }
 
+# catalyst-voting = { git = "https://github.com/input-output-hk/catalyst-libs.git" }
+catalyst-voting = { path = "/Users/alexeypoghilenkov/Work/catalyst-libs/rust/catalyst-voting" }
+
 
 hex = "0.4"
 cryptoxide = "0.4.2"

--- a/src/sign/Cargo.toml
+++ b/src/sign/Cargo.toml
@@ -15,8 +15,7 @@ chain-impl-mockchain = { path = "../chain-libs/chain-impl-mockchain" ,features= 
 chain-ser = { path = "../chain-libs/chain-ser" }
 chain-storage = { path = "../chain-libs/chain-storage" }
 
-# catalyst-voting = { git = "https://github.com/input-output-hk/catalyst-libs.git" }
-catalyst-voting = { path = "/Users/alexeypoghilenkov/Work/catalyst-libs/rust/catalyst-voting" }
+catalyst-voting = { git = "https://github.com/input-output-hk/catalyst-libs.git", rev = "d0b5784208abb7c4f2eddf8237099368e070620a" }
 
 
 hex = "0.4"

--- a/src/sign/Cargo.toml
+++ b/src/sign/Cargo.toml
@@ -35,6 +35,6 @@ serde_json = "1.0"
 serde_yaml = "0.8.17"
 rand = "0.8.3"
 bech32 = "0.8"
-rand_core = { version = "0.5.1", default-features = false }
+rand_core = { version = "0.5.1", default-features = false, features = ["getrandom"] }
 ed25519-dalek = "1.0.1"
 reqwest = { version = "*", default_features = false, features = [ "blocking","json", "rustls-tls" ] }

--- a/src/sign/README.md
+++ b/src/sign/README.md
@@ -39,7 +39,7 @@ CHOICE=1
 
 ```
 
-*Generate raw vote fragment in byte representation using original `catalyst-voting` crate*
+*Generate raw vote fragment in byte representation using `catalyst-voting` crate*
 
 ```bash
 

--- a/src/sign/README.md
+++ b/src/sign/README.md
@@ -35,6 +35,6 @@ EPOCH=0
 SLOT=0
 CHOICE=1
 
-./target/release/sign --election-pub-key $ELECTION_PUB_KEY --private-key $ALICE_SK --public-key $ALICE_PK --proposal $PROPOSAL --vote-plan-id $VOTE_PLAN_ID --epoch $EPOCH --slot $SLOT --choice $CHOICE
+./target/release/sign v1 --election-pub-key $ELECTION_PUB_KEY --private-key $ALICE_SK --public-key $ALICE_PK --proposal $PROPOSAL --vote-plan-id $VOTE_PLAN_ID --epoch $EPOCH --slot $SLOT --choice $CHOICE
 
 ```

--- a/src/sign/README.md
+++ b/src/sign/README.md
@@ -22,7 +22,7 @@ Generates vote fragments and signs them accordingly
 cargo build --release -p sign
 ```  
 
-*Generate raw vote fragment in byte representation*
+*Generate raw vote fragment in byte representation using original jorm implementation*
 
 ```bash
 
@@ -36,5 +36,22 @@ SLOT=0
 CHOICE=1
 
 ./target/release/sign v1 --election-pub-key $ELECTION_PUB_KEY --private-key $ALICE_SK --public-key $ALICE_PK --proposal $PROPOSAL --vote-plan-id $VOTE_PLAN_ID --epoch $EPOCH --slot $SLOT --choice $CHOICE
+
+```
+
+*Generate raw vote fragment in byte representation using original `catalyst-voting` crate*
+
+```bash
+
+ELECTION_PUB_KEY=ristretto255_votepk1ppxnuxrqa4728evnp2ues000uvwvwtxmtf77ejc29lknjuqqu44s4cfmja
+ALICE_SK=56e367979579e2ce27fbd305892b0706b7dede999a534a864a7430a5c6aefd3c
+ALICE_PK=ea084d2d80ed0ab681333d934efc56df3868d13d46a2de3b7f27f40b62e5344d
+PROPOSAL=5
+VOTE_PLAN_ID=36ad42885189a0ac3438cdb57bc8ac7f6542e05a59d1f2e4d1d38194c9d4ac7b
+EPOCH=0
+SLOT=0
+CHOICE=1
+
+./target/release/sign v2 --election-pub-key $ELECTION_PUB_KEY --private-key $ALICE_SK --public-key $ALICE_PK --proposal $PROPOSAL --vote-plan-id $VOTE_PLAN_ID --epoch $EPOCH --slot $SLOT --choice $CHOICE
 
 ```

--- a/src/sign/src/main.rs
+++ b/src/sign/src/main.rs
@@ -10,7 +10,6 @@ use clap::Parser;
 use color_eyre::Result;
 use rand::SeedableRng;
 use rand_chacha::ChaCha20Rng;
-use std::convert::TryInto;
 
 use ed25519_dalek::*;
 use std::error::Error;

--- a/src/sign/src/main.rs
+++ b/src/sign/src/main.rs
@@ -5,10 +5,16 @@
 use bech32::Error as Bech32Error;
 use bech32::FromBase32;
 use chain_vote::ElectionPublicKey;
+use clap::Args;
 use clap::Parser;
 use color_eyre::Result;
 use rand::SeedableRng;
 use rand_chacha::ChaCha20Rng;
+use catalyst_voting::{
+     crypto::{ed25519::PrivateKey},
+     txs::v1::Tx,
+     vote_protocol::committee::ElectionSecretKey,
+};
 
 use ed25519_dalek::*;
 use std::error::Error;
@@ -18,12 +24,21 @@ use crate::fragment::{compose_encrypted_vote_part, generate_vote_fragment};
 pub mod fragment;
 pub mod network;
 
+
 ///
 /// Args defines and declares CLI behaviour within the context of clap
-///
+/// 
 #[derive(Parser, Debug, Clone)]
 #[clap(about, version, author)]
-pub struct Args {
+pub enum Cli {
+    /// Original jormungandr transaction generation
+    V1(CliArgs),
+    /// `catalyst-voting` transaction generation
+    V2(CliArgs),
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct CliArgs {
     /// Election public key issued by Trent
     #[clap(short, long)]
     pub election_pub_key: String,
@@ -50,10 +65,19 @@ pub struct Args {
     choice: u8,
 }
 
+
 fn main() -> Result<(), Box<dyn Error>> {
     color_eyre::install()?;
 
-    let args = Args::parse();
+    let cli = Cli::parse();
+
+    match cli {
+        Cli::V1(args) => v1_exec(args),
+        Cli::V2(args) => v2_exec(args),
+    }
+}
+
+fn v1_exec(args: CliArgs) -> Result<(), Box<dyn Error>>  {
     let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
 
     let pk = hex::decode(args.public_key)?;
@@ -65,6 +89,54 @@ fn main() -> Result<(), Box<dyn Error>> {
         bech32::decode(&args.election_pub_key).map_err(Bech32Error::from)?;
 
     let election_pk = Vec::<u8>::from_base32(&data).map_err(Bech32Error::from)?;
+
+    // join sk+pk together, api requirement
+    sk.extend(pk.clone());
+    let keypair: Keypair = Keypair::from_bytes(&sk)?;
+
+    let choice = args.choice;
+
+    let vote = chain_vote::Vote::new(2, choice.into())?;
+    // common reference string
+    let crs = chain_vote::Crs::from_hash(&hex::decode(args.vote_plan_id.clone())?);
+
+    // parse ek key
+    let ek = ElectionPublicKey::from_bytes(&election_pk)
+        .ok_or("unable to parse election pub key".to_string())?;
+
+    let (ciphertexts, proof) = ek.encrypt_and_prove_vote(&mut rng, &crs, vote);
+    let (proof, encrypted_vote) = compose_encrypted_vote_part(ciphertexts.clone(), proof)?;
+
+    let fragment_bytes = generate_vote_fragment(
+        keypair,
+        encrypted_vote,
+        proof,
+        args.proposal,
+        &hex::decode(args.vote_plan_id)?,
+        args.epoch,
+        args.slot,
+    )?;
+
+    // fragment in hex: output consumed as input to another program
+    println!("{:?}", hex::encode(fragment_bytes.clone()));
+
+    Ok(())
+}
+
+fn v2_exec(args: CliArgs) -> Result<(), Box<dyn Error>>  {
+    let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
+
+    // let pk = hex::decode(args.public_key)?;
+    let mut sk = hex::decode(args.private_key)?;
+
+    // Election pub key published as a Bech32_encoded address
+    // which consists of 3 parts: A Human-Readable Part (HRP) + Separator + Data:
+    let (_hrp, data, _variant) =
+        bech32::decode(&args.election_pub_key).map_err(Bech32Error::from)?;
+
+    let election_pk = Vec::<u8>::from_base32(&data).map_err(Bech32Error::from)?;
+
+
 
     // join sk+pk together, api requirement
     sk.extend(pk.clone());

--- a/src/sign/src/main.rs
+++ b/src/sign/src/main.rs
@@ -10,11 +10,7 @@ use clap::Parser;
 use color_eyre::Result;
 use rand::SeedableRng;
 use rand_chacha::ChaCha20Rng;
-use catalyst_voting::{
-     crypto::{ed25519::PrivateKey},
-     txs::v1::Tx,
-     vote_protocol::committee::ElectionSecretKey,
-};
+use std::convert::TryInto;
 
 use ed25519_dalek::*;
 use std::error::Error;
@@ -24,10 +20,9 @@ use crate::fragment::{compose_encrypted_vote_part, generate_vote_fragment};
 pub mod fragment;
 pub mod network;
 
-
 ///
 /// Args defines and declares CLI behaviour within the context of clap
-/// 
+///
 #[derive(Parser, Debug, Clone)]
 #[clap(about, version, author)]
 pub enum Cli {
@@ -65,21 +60,22 @@ pub struct CliArgs {
     choice: u8,
 }
 
-
 fn main() -> Result<(), Box<dyn Error>> {
     color_eyre::install()?;
 
     let cli = Cli::parse();
 
+    let mut rng = ChaCha20Rng::from_entropy();
     match cli {
-        Cli::V1(args) => v1_exec(args),
-        Cli::V2(args) => v2_exec(args),
+        Cli::V1(args) => v1_exec(args, &mut rng),
+        Cli::V2(args) => v2_exec(args, &mut rng),
     }
 }
 
-fn v1_exec(args: CliArgs) -> Result<(), Box<dyn Error>>  {
-    let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
+/// Number of voting options
+const VOTING_OPTIONS: u8 = 2;
 
+fn v1_exec(args: CliArgs, rng: &mut ChaCha20Rng) -> Result<(), Box<dyn Error>> {
     let pk = hex::decode(args.public_key)?;
     let mut sk = hex::decode(args.private_key)?;
 
@@ -96,7 +92,7 @@ fn v1_exec(args: CliArgs) -> Result<(), Box<dyn Error>>  {
 
     let choice = args.choice;
 
-    let vote = chain_vote::Vote::new(2, choice.into())?;
+    let vote = chain_vote::Vote::new(VOTING_OPTIONS.into(), choice.into())?;
     // common reference string
     let crs = chain_vote::Crs::from_hash(&hex::decode(args.vote_plan_id.clone())?);
 
@@ -104,7 +100,7 @@ fn v1_exec(args: CliArgs) -> Result<(), Box<dyn Error>>  {
     let ek = ElectionPublicKey::from_bytes(&election_pk)
         .ok_or("unable to parse election pub key".to_string())?;
 
-    let (ciphertexts, proof) = ek.encrypt_and_prove_vote(&mut rng, &crs, vote);
+    let (ciphertexts, proof) = ek.encrypt_and_prove_vote(rng, &crs, vote);
     let (proof, encrypted_vote) = compose_encrypted_vote_part(ciphertexts.clone(), proof)?;
 
     let fragment_bytes = generate_vote_fragment(
@@ -123,50 +119,46 @@ fn v1_exec(args: CliArgs) -> Result<(), Box<dyn Error>>  {
     Ok(())
 }
 
-fn v2_exec(args: CliArgs) -> Result<(), Box<dyn Error>>  {
-    let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
-
-    // let pk = hex::decode(args.public_key)?;
-    let mut sk = hex::decode(args.private_key)?;
+fn v2_exec(args: CliArgs, rng: &mut ChaCha20Rng) -> Result<(), Box<dyn Error>> {
+    let sk_bytes = hex::decode(args.private_key)?;
 
     // Election pub key published as a Bech32_encoded address
     // which consists of 3 parts: A Human-Readable Part (HRP) + Separator + Data:
     let (_hrp, data, _variant) =
         bech32::decode(&args.election_pub_key).map_err(Bech32Error::from)?;
 
-    let election_pk = Vec::<u8>::from_base32(&data).map_err(Bech32Error::from)?;
+    let election_pk_bytes = Vec::<u8>::from_base32(&data).map_err(Bech32Error::from)?;
 
+    let private_key = catalyst_voting::crypto::ed25519::PrivateKey::from_bytes(
+        &sk_bytes
+            .try_into()
+            .map_err(|_| "private key invalid length")?,
+    );
+    let election_public_key =
+        catalyst_voting::vote_protocol::committee::ElectionPublicKey::from_bytes(
+            &election_pk_bytes
+                .try_into()
+                .map_err(|_| "election public key invalid length")?,
+        )?;
 
-
-    // join sk+pk together, api requirement
-    sk.extend(pk.clone());
-    let keypair: Keypair = Keypair::from_bytes(&sk)?;
-
+    let vote_plan_id = hex::decode(args.vote_plan_id.clone())?
+        .try_into()
+        .map_err(|_| "vote plan id invalid length")?;
+    let proposal_index = args.proposal;
     let choice = args.choice;
 
-    let vote = chain_vote::Vote::new(2, choice.into())?;
-    // common reference string
-    let crs = chain_vote::Crs::from_hash(&hex::decode(args.vote_plan_id.clone())?);
-
-    // parse ek key
-    let ek = ElectionPublicKey::from_bytes(&election_pk)
-        .ok_or("unable to parse election pub key".to_string())?;
-
-    let (ciphertexts, proof) = ek.encrypt_and_prove_vote(&mut rng, &crs, vote);
-    let (proof, encrypted_vote) = compose_encrypted_vote_part(ciphertexts.clone(), proof)?;
-
-    let fragment_bytes = generate_vote_fragment(
-        keypair,
-        encrypted_vote,
-        proof,
-        args.proposal,
-        &hex::decode(args.vote_plan_id)?,
-        args.epoch,
-        args.slot,
+    let tx = catalyst_voting::txs::v1::Tx::new_private(
+        vote_plan_id,
+        proposal_index,
+        VOTING_OPTIONS,
+        choice,
+        &election_public_key,
+        &private_key,
+        rng,
     )?;
 
     // fragment in hex: output consumed as input to another program
-    println!("{:?}", hex::encode(fragment_bytes.clone()));
+    println!("{:?}", hex::encode(tx.to_bytes()));
 
     Ok(())
 }


### PR DESCRIPTION
# Description

Updated `sign` tool with the new cli command `v2` which generates the `VoteCast` jorm fragment using the new `catalyst-voting` crate https://github.com/input-output-hk/catalyst-libs/tree/main/rust/catalyst-voting.

This PR updates the interface of the `sign` cli tool to have a few command options:
- `sign v1 ...` original jorm implementation.
- `sign v2 ...` using new `catalyst-voting` crate.

The rest of the passing arguments remains the same

Closes #717 